### PR TITLE
Add Cognee knowledge graph memory bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,15 @@ A local knowledge graph engine consisting of **6 skills** that connects email, c
 *   **Wiki Generator**: Automatically builds local, hyperlinked wiki articles for every recorded entity in the project.
 *   **Mail Sync**: Ingests and links project email threads directly to related code files.
 
-### 3. Team Bundle
+### 3. Cognee Bundle
+A knowledge graph memory backend consisting of **3 skills** that upgrades project memory from flat SQLite to a graph with embeddings.
+*   **Graph + Semantic Search**: 14 search modes across all projects — from lexical matching to graph completion and RAG retrieval.
+*   **Cross-Project Entity Linking**: Graph edges span datasets, so entities discovered in one project are queryable from another.
+*   **Auto-Recall Injection**: Automatically injects relevant past decisions and context into agent sessions before reasoning.
+*   **Coexists with Brain**: Brain stays as the zero-dependency default. Cognee is opt-in for users who want semantic search and graph memory.
+> Requires a running Cognee server. See [coco-research/cognee](https://github.com/coco-research/cognee).
+
+### 4. Team Bundle
 A workspace multi-agent pipeline engine.
 *   **Development Loop**: Spawns specialized subagents (Research, Architect, QA) to execute changes, review diffs, and write unit tests.
 *   **Deterministic Gates**: Intercepts merges and commits to run lints, import audits, reference checks, and verification suites.
@@ -326,10 +334,11 @@ A workspace multi-agent pipeline engine.
 
 ### Personal Knowledge Base
 ```bash
-bash install.sh --systems brain
+bash install.sh --systems brain,cognee
 /brain-init && /brain-update
+/cognee-init && /cognee-recall
 ```
-> Builds a local, SQLite-backed entity graph of your project. Automatically indexes decisions, terms, and file relations.
+> Builds a local knowledge graph of your project — SQLite for quick lookup (Brain) or graph + embeddings for semantic search (Cognee). Use one or both.
 
 </td>
 </tr>
@@ -578,17 +587,17 @@ npx @rkz91/coco-cli update
 <table>
 <tr><td><strong>Spec Version</strong></td><td>1.0.0</td></tr>
 <tr><td><strong>License</strong></td><td><a href="https://opensource.org/license/mit">MIT</a></td></tr>
-<tr><td><strong>Total Skills Available</strong></td><td>146 with all bundles installed (63 Core + 68 GSD + 6 Brain + 9 Superintelligence)</td></tr>
+<tr><td><strong>Total Skills Available</strong></td><td>149 with all bundles installed (63 Core + 68 GSD + 6 Brain + 3 Cognee + 9 Superintelligence)</td></tr>
 <tr><td><strong>Slash Commands</strong></td><td>277 with all bundles installed — 35 Core (shipped) + 242 Superintelligence (225 per-team + 17 cross-team, generated at install of the Superintelligence bundle)</td></tr>
 <tr><td><strong>Specialized Agents</strong></td><td>34 (10 Core + 24 GSD Bundle)</td></tr>
-<tr><td><strong>System Bundles</strong></td><td>4 (GSD, Brain, Team, Superintelligence) — opt in with <code>--systems &lt;name&gt;</code></td></tr>
+<tr><td><strong>System Bundles</strong></td><td>5 (GSD, Brain, Cognee, Team, Superintelligence) — opt in with <code>--systems &lt;name&gt;</code></td></tr>
 <tr><td><strong>Cross-IDE Rules</strong></td><td>15 (.mdc files)</td></tr>
 <tr><td><strong>Workflows Defined</strong></td><td>3 (.md pipelines)</td></tr>
 <tr><td><strong>Install Time</strong></td><td>&le; 90 seconds</td></tr>
 <tr><td><strong>Telemetry / SaaS</strong></td><td>None — 100% Local Files</td></tr>
 </table>
 
-<sub>Core install ships 63 skills + 35 commands + 10 agents. The counts above reflect a full install with all four system bundles enabled (<code>bash install.sh --systems gsd,brain,team,superintelligence</code>). Superintelligence slash commands are generated locally at install time from the team registries — no command files are transmitted or stored remotely.</sub>
+<sub>Core install ships 63 skills + 35 commands + 10 agents. The counts above reflect a full install with all five system bundles enabled (<code>bash install.sh --systems gsd,brain,cognee,team,superintelligence</code>). Superintelligence slash commands are generated locally at install time from the team registries — no command files are transmitted or stored remotely.</sub>
 
 ---
 

--- a/systems/cognee/README.md
+++ b/systems/cognee/README.md
@@ -1,0 +1,83 @@
+# Cognee — Knowledge Graph Memory Backend
+
+Graph-based, embedding-powered persistent memory for Coco agents. Upgrades project memory from a flat SQLite file (Brain) to a true knowledge graph with semantic search, cross-project entity linking, and multi-turn session awareness.
+
+## What it is
+
+Cognee is an open-source AI memory platform ([coco-research/cognee](https://github.com/coco-research/cognee)) that gives agents persistent long-term memory. This bundle wires Cognee into Coco as an optional memory backend, coexisting with the default Brain bundle.
+
+## What it gives you over Brain alone
+
+| Feature | Brain (SQLite) | Cognee |
+|---------|---------------|--------|
+| Storage | Flat relational DB | Knowledge graph + embeddings |
+| Search | Keyword + relational queries | Semantic + graph traversal + lexical |
+| Cross-project | Manual aggregation | Native cross-dataset graph queries |
+| Sessions | Stateless | Multi-turn session tracking |
+| Auto-recall | Manual context query | Automatic memory injection before agent runs |
+| Entity linking | Within one project | Across all projects and datasets |
+
+## Install
+
+### Prerequisites
+
+Cognee must be running locally (or accessible via URL):
+
+```bash
+pip install cognee
+cognee server start   # starts at http://localhost:8000
+```
+
+### Wire into Coco
+
+```bash
+bash install.sh --adapter claude-code --systems cognee
+```
+
+Or with other bundles:
+
+```bash
+bash install.sh --adapter claude-code --systems brain,cognee,gsd
+```
+
+## Skills
+
+| Skill | What it does |
+|-------|-------------|
+| `/cognee` | Status, init, dataset management, backend switching |
+| `/cognee-store` | Push decisions, entities, events, context into the graph |
+| `/cognee-recall` | Semantic + graph search, inject results as agent context |
+
+## When to use Cognee vs Brain
+
+- **Brain** → You want zero-dependency, per-project knowledge that just works. Good for: tracking decisions and entities within a single project.
+- **Cognee** → You want semantic search across projects, graph-based entity relationships, and automatic context injection. Good for: multi-project work, complex entity webs, long-running agent memory.
+- **Both** → They coexist. Use Brain for quick per-project lookup, Cognee for cross-project graph queries and recall.
+
+## Data model
+
+Cognee maps Coco's concepts to its graph:
+
+| Coco Concept | Cognee Representation |
+|-------------|---------------------|
+| Entity (person, team, system, module) | Graph node with type label |
+| Relationship (member_of, owns, depends_on) | Graph edge |
+| Decision | Graph node with metadata (date, decided_by, context) |
+| Event | Graph node with temporal data |
+| Task | Graph node with status tracking |
+| Session context | Session-scoped nodes linked to agent runs |
+
+## API reference
+
+All skills use Cognee's HTTP API. Default base URL: `http://localhost:8000` (overridable via `COGNEE_BASE_URL`).
+
+Key endpoints used by this bundle:
+
+- `GET /health` — server status
+- `POST /api/v1/add` — ingest data
+- `POST /api/v1/cognify` — process and build graph
+- `POST /api/v1/search` — query with graph/semantic search
+- `POST /api/v1/recall` — semantic search with context injection
+- `POST /api/v1/remember` — add + cognify convenience
+- `GET /api/v1/datasets` — list datasets
+- `POST /api/v1/datasets` — create dataset

--- a/systems/cognee/skills/cognee-recall/SKILL.md
+++ b/systems/cognee/skills/cognee-recall/SKILL.md
@@ -1,0 +1,266 @@
+---
+name: cognee:recall
+description: "Semantic and graph search across Cognee knowledge graph. Queries project memory, finds related entities and decisions, injects results as agent context. Triggers on: 'cognee recall', 'search memory', 'what do we know about', 'find related', 'graph search', 'memory search', 'recall context'."
+---
+
+# /cognee-recall — Search & Recall from Knowledge Graph
+
+Semantic, graph-traversal, and lexical search across Cognee's knowledge graph. Finds entities, decisions, events, and their relationships — then injects relevant results as agent context for informed decision-making.
+
+## Quick Reference
+
+```bash
+COGNEE="${COGNEE_BASE_URL:-http://localhost:8000}"
+DATASET="my-project"
+
+# Semantic search (auto-selects best strategy)
+curl -s -X POST "$COGNEE/api/v1/search" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "authentication decisions", "datasets": ["my-project"], "search_type": "FEELING_LUCKY", "top_k": 10}' | jq .
+
+# Graph completion search (relationship-aware)
+curl -s -X POST "$COGNEE/api/v1/search" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "who reports to Alice", "datasets": ["my-project"], "search_type": "GRAPH_COMPLETION", "top_k": 10}' | jq .
+
+# Recall with context injection (adds system prompt)
+curl -s -X POST "$COGNEE/api/v1/recall" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "rate limiting", "datasets": ["my-project"], "top_k": 10, "only_context": true}' | jq .
+
+# Cross-project search
+curl -s -X POST "$COGNEE/api/v1/search" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "auth decisions", "datasets": ["project-a", "project-b", "project-c"], "search_type": "FEELING_LUCKY"}' | jq .
+```
+
+## Search Types
+
+Cognee supports multiple search strategies. Use `FEELING_LUCKY` for auto-selection (recommended), or specify one:
+
+| Type | Best for |
+|------|---------|
+| `FEELING_LUCKY` | Auto-selects best strategy (default, recommended) |
+| `GRAPH_COMPLETION` | Relationship-heavy queries ("who owns X", "what depends on Y") |
+| `GRAPH_COMPLETION_COT` | Complex reasoning with chain-of-thought |
+| `GRAPH_COMPLETION_CONTEXT_EXTENSION` | Expanding context around a node |
+| `GRAPH_SUMMARY_COMPLETION` | Summarization of graph neighborhood |
+| `RAG_COMPLETION` | Retrieval-augmented generation |
+| `TRIPLET_COMPLETION` | Entity-relationship-entity patterns |
+| `CHUNKS` | Raw chunk retrieval |
+| `CHUNKS_LEXICAL` | Keyword/lexical matching |
+| `SUMMARIES` | Pre-computed summaries |
+| `NATURAL_LANGUAGE` | Free-form natural language queries |
+| `TEMPORAL` | Time-based queries |
+| `CODING_RULES` | Code-specific patterns |
+
+## Sub-commands
+
+### /cognee-recall search — Run a semantic/graph search
+
+**Procedure:**
+
+1. Ask the user what they're looking for (or use the provided query).
+2. Determine the best search type based on the query:
+   - Queries about relationships → `GRAPH_COMPLETION`
+   - General "what do we know" → `FEELING_LUCKY`
+   - Time-based ("last week", "in Q2") → `TEMPORAL` if available
+   - Code-related → `CODING_RULES`
+3. Detect which datasets to search:
+   - Default: current project dataset
+   - If user mentions another project: include its dataset
+   - Use `/cognee status` to list available datasets
+4. Execute search:
+
+```bash
+COGNEE="${COGNEE_BASE_URL:-http://localhost:8000}"
+
+curl -s -X POST "$COGNEE/api/v1/search" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"query\": \"$QUERY\",
+    \"datasets\": $DATASETS_JSON,
+    \"search_type\": \"$SEARCH_TYPE\",
+    \"top_k\": $TOP_K
+  }" | jq .
+```
+
+5. Present results:
+
+```
+COGNEE RECALL — "$QUERY"
+==================================================
+Found N results across M datasets
+
+[1] DECISION: Use JWT for API auth (2026-06-30)
+    Context: Stateless, works with existing infra
+    Dataset: my-project | Score: 0.94
+
+[2] ENTITY: Auth Service — depends_on → PlatformHub
+    Description: Authentication and authorization service
+    Dataset: my-project | Score: 0.87
+
+[3] TASK: Set up JWT middleware (open, priority 1)
+    Assigned to: Alice Chen
+    Dataset: my-project | Score: 0.82
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+### /cognee-recall context — Inject results as agent context
+
+Same as search, but formats results for direct injection into the agent's context window. Use this before making architectural decisions or when context from past sessions is needed.
+
+**Procedure:**
+
+1. Run search as above.
+2. Format results as a compact context block:
+
+```
+[COGNEE CONTEXT INJECTION — {timestamp}]
+Query: "{original_query}"
+Dataset(s): {dataset_names}
+
+Relevant knowledge:
+• DECISION ({date}): {text} — {context} [relevance: {score}]
+• ENTITY: {name} ({type}) — {description} [relevance: {score}]
+• TASK: {text} ({status}) — assigned to {assignee} [relevance: {score}]
+• EVENT: {title} ({date}, {type}) — {summary} [relevance: {score}]
+
+Use this context to inform your response. Cite specific decisions and entities where relevant.
+```
+
+3. The agent then uses this context transparently in its reasoning.
+
+### /cognee-recall graph — Explore entity neighborhood
+
+Explore the graph around a specific entity to understand its relationships.
+
+```bash
+COGNEE="${COGNEE_BASE_URL:-http://localhost:8000}"
+
+# First, get the dataset ID
+DATASET_ID=$(curl -s "$COGNEE/api/v1/datasets" | jq -r '.[] | select(.name=="my-project") | .id')
+
+# Get the full graph
+curl -s "$COGNEE/api/v1/datasets/$DATASET_ID/graph" | jq .
+```
+
+Present as a relationship map:
+
+```
+ENTITY GRAPH — "Auth Service" (my-project)
+==================================================
+                      ┌──────────────────┐
+                      │   Auth Service   │
+                      │   (system)       │
+                      └───┬──────────┬───┘
+                          │          │
+              depends_on  │          │ owns
+                          │          │
+                   ┌──────▼──┐  ┌───▼──────────┐
+                   │Platform │  │ JWT Middleware│
+                   │Hub      │  │ (module)      │
+                   │(module) │  └───────────────┘
+                   └─────────┘
+
+Related decisions:
+  • Use JWT for API auth (2026-06-30) — relates to Auth Service
+
+Related tasks:
+  • Set up JWT middleware (open) — assigned to Alice Chen
+  • Update API docs (open) — assigned to unassigned
+```
+
+### /cognee-recall cross-project — Search across multiple projects
+
+Search for related knowledge across all available datasets.
+
+```bash
+COGNEE="${COGNEE_BASE_URL:-http://localhost:8000}"
+
+# Get all dataset names
+DATASETS=$(curl -s "$COGNEE/api/v1/datasets" | jq -r '[.[].name] | join(",")')
+
+# Cross-project search
+curl -s -X POST "$COGNEE/api/v1/search" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"query\": \"$QUERY\",
+    \"datasets\": [$DATASETS_JSON],
+    \"search_type\": \"FEELING_LUCKY\",
+    \"top_k\": 15
+  }" | jq .
+```
+
+Present results grouped by dataset:
+
+```
+CROSS-PROJECT RECALL — "$QUERY"
+==================================================
+Found N results across M datasets
+
+my-project (5 results):
+  [1] DECISION: Use JWT for API auth — 0.94
+  [2] ENTITY: Auth Service — 0.87
+  ...
+
+e-and-c (3 results):
+  [1] DECISION: Stakeholder role for external users — 0.91
+  [2] ENTITY: External Review System — 0.84
+  ...
+
+optimize (2 results):
+  [1] DECISION: Migration to pgvector — 0.78
+  ...
+```
+
+## Behavior Rules
+
+### Proactive recall triggers
+Automatically run `/cognee-recall search` when:
+- User asks "what do we know about X" or "what did we decide about Y"
+- User starts a new task that references past work ("continue working on auth")
+- User makes a decision that might conflict with past decisions
+- Before architectural or design discussions that would benefit from context
+
+### Relevance threshold
+Only show results with relevance score > 0.5 by default. If fewer than 3 results exceed threshold, tell the user: "Only {N} low-relevance results found. Try a broader query."
+
+### Context injection discipline
+- Inject context **before** reasoning about a decision, not after.
+- Cite specific decisions/entities from the graph in responses: "Based on the June 30 decision to use JWT for API auth [Cognee]..."
+- Never fabricate — if the graph has no relevant data, say so.
+
+### Session-aware recall
+If Cognee supports sessions, tag recalls with a session ID for better multi-turn context:
+
+```bash
+SESSION_ID="coco-$(date +%s)"
+
+curl -s -X POST "$COGNEE/api/v1/search" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"query\": \"$QUERY\",
+    \"datasets\": [\"$DATASET\"],
+    \"search_type\": \"FEELING_LUCKY\",
+    \"top_k\": 10
+  }" | jq .
+```
+
+## Fallback Behavior
+
+If Cognee is unreachable:
+1. Check if Brain is available: look for `project_brain.db` in current or parent directories
+2. If available: "Cognee is not running. Using Brain for this query instead." Run equivalent `/brain context --search "query"`
+3. If neither available: "No memory backend available. Start Cognee with `cognee server start` or initialize Brain with `/brain init`."
+
+## Prerequisites
+
+Cognee must be running and the project dataset must exist (created via `/cognee init`).
+
+```bash
+# Verify
+curl http://localhost:8000/health
+curl http://localhost:8000/api/v1/datasets | jq '.[].name'
+```

--- a/systems/cognee/skills/cognee-store/SKILL.md
+++ b/systems/cognee/skills/cognee-store/SKILL.md
@@ -1,0 +1,253 @@
+---
+name: cognee:store
+description: "Push project knowledge into the Cognee knowledge graph. Stores entities, decisions, events, relationships, and session context. End-of-session flush that extracts everything from the conversation and writes to the graph. Triggers on: 'cognee store', 'push to cognee', 'save to graph', 'remember this', 'log this decision'."
+---
+
+# /cognee-store — Push Knowledge to the Graph
+
+Stores structured knowledge into Cognee's knowledge graph. Functions as the write path for Coco's memory layer — maps entities, decisions, events, and relationships to graph nodes and edges with embeddings for later semantic retrieval.
+
+## Quick Reference
+
+```bash
+COGNEE="${COGNEE_BASE_URL:-http://localhost:8000}"
+DATASET="my-project"
+
+# Store a text fact (auto-cognifies)
+curl -s -X POST "$COGNEE/api/v1/remember" \
+  -F "datasetName=$DATASET" \
+  -F 'data={"entity": {"type": "decision", "text": "Use JWT for API auth", "date": "2026-06-30", "decided_by": "Rijul", "context": "Stateless, works with existing infra"}}' \
+  -F "run_in_background=false" | jq .
+
+# Store file-based knowledge
+curl -s -X POST "$COGNEE/api/v1/remember" \
+  -F "datasetName=$DATASET" \
+  -F "data=@/path/to/decision-log.md" \
+  -F "run_in_background=false" | jq .
+
+# Cognify existing data (process + build graph)
+curl -s -X POST "$COGNEE/api/v1/cognify" \
+  -H "Content-Type: application/json" \
+  -d '{"datasets": ["my-project"]}' | jq .
+```
+
+## Data Format
+
+All knowledge is stored as text, structured for Cognee's graph extraction. Use these formats:
+
+### Entities
+```
+ENTITY: {name} | TYPE: {person|team|system|module|org_unit|document}
+DESCRIPTION: {one-line description}
+METADATA: {key: value, ...}
+```
+
+### Decisions
+```
+DECISION: {text} | DATE: {YYYY-MM-DD}
+DECIDED_BY: {name}
+CONTEXT: {why this was decided, alternatives considered}
+IMPACT: {what changes as a result}
+```
+
+### Events
+```
+EVENT: {title} | DATE: {YYYY-MM-DD} | TYPE: {meeting|call|email|milestone|deploy}
+SUMMARY: {what happened}
+PARTICIPANTS: {comma-separated names}
+OUTCOMES: {decisions made, action items}
+```
+
+### Relationships
+```
+RELATIONSHIP: {entity_a} -> {entity_b} | TYPE: {member_of|owns|depends_on|reports_to|blocks|administers|scoped_to}
+CONTEXT: {why this relationship exists}
+```
+
+### Tasks
+```
+TASK: {description} | STATUS: {open|in_progress|blocked|waiting|done|cancelled}
+PRIORITY: {1 (highest) - 5 (lowest)}
+ASSIGNED_TO: {name}
+BLOCKED_BY: {task or entity reference}
+```
+
+## /cognee-store:update — End-of-Session Flush
+
+**This is the most important command.** When invoked, the agent MUST thoroughly review the entire conversation and write everything learned to Cognee. This is a forcing function — do not skip anything.
+
+### Procedure
+
+### Step 1: Check Cognee availability
+
+```bash
+COGNEE="${COGNEE_BASE_URL:-http://localhost:8000}"
+curl -s -o /dev/null -w "%{http_code}" "$COGNEE/health"
+```
+
+If not 200: "Cognee is not running. Start with `cognee server start`." → offer to use `/brain-update` instead.
+
+### Step 2: Verify dataset exists
+
+```bash
+curl -s "$COGNEE/api/v1/datasets" | jq -r '.[].name'
+```
+
+If the project dataset doesn't exist: "No dataset found for this project. Run `/cognee init` first."
+
+### Step 3: Scan the full conversation
+
+Go through every message from top to bottom. Extract:
+
+| Category | What to look for |
+|----------|-----------------|
+| **New entities** | Any person, team, role, system, module mentioned for the first time |
+| **New relationships** | Connections discovered: X owns Y, A reports to B |
+| **New decisions** | Anything decided, agreed, confirmed, resolved, or ruled out |
+| **New events** | Meetings, calls, emails read, milestones, deployments |
+| **New tasks** | Action items, to-dos, next steps, follow-ups |
+| **Task updates** | Existing tasks that changed status |
+| **Entity updates** | New info about existing entities |
+
+### Step 4: Present summary
+
+```
+COGNEE STORE SUMMARY
+====================
+Dataset:        my-project
+
+New entities:      3 (Alice Chen [person], PlatformHub [module], Auth Service [system])
+New decisions:     2 (Use JWT for API auth, Rate-limit at gateway level)
+New events:        1 (Architecture review call Jun 30)
+New tasks:         4 (Set up JWT middleware, Configure rate limiter, ...)
+Task updates:      2 (task #3 → blocked, task #5 → in_progress)
+New relationships: 1 (Auth Service depends_on PlatformHub)
+Entity updates:    1 (Alice Chen: added backend lead role)
+
+Total items to store: 13
+```
+
+### Step 5: Wait for confirmation
+
+Ask: **"Write all to Cognee? [Y/n/adjust]"**
+
+### Step 6: Execute writes
+
+On confirmation, format each item according to the data formats above and send as a single batch:
+
+```bash
+COGNEE="${COGNEE_BASE_URL:-http://localhost:8000}"
+
+# Build the payload as a multiline text document
+cat > /tmp/cognee-store-batch.txt << 'STORE_EOF'
+ENTITY: Alice Chen | TYPE: person
+DESCRIPTION: Backend lead on PlatformHub
+METADATA: {role: "backend lead", team: "Engineering"}
+
+ENTITY: PlatformHub | TYPE: module
+DESCRIPTION: Central platform for managing external access
+
+ENTITY: Auth Service | TYPE: system
+DESCRIPTION: Authentication and authorization service
+
+DECISION: Use JWT for API auth | DATE: 2026-06-30
+DECIDED_BY: Rijul
+CONTEXT: Stateless, works with existing infrastructure. Considered session tokens but JWT more scalable.
+IMPACT: All API endpoints will validate JWT tokens
+
+DECISION: Rate-limit at gateway level | DATE: 2026-06-30
+DECIDED_BY: Rijul
+CONTEXT: Prefer gateway-level rate limiting over per-service to avoid duplication
+IMPACT: API gateway configuration needs updating
+
+EVENT: Architecture review call | DATE: 2026-06-30 | TYPE: call
+SUMMARY: Reviewed authentication and rate-limiting architecture
+PARTICIPANTS: Rijul, Alice Chen
+OUTCOMES: JWT chosen for auth, rate-limiting at gateway
+
+RELATIONSHIP: Auth Service -> PlatformHub | TYPE: depends_on
+CONTEXT: Auth service validates tokens before requests reach PlatformHub
+
+TASK: Set up JWT middleware | STATUS: open
+PRIORITY: 1
+ASSIGNED_TO: Alice Chen
+
+TASK: Configure rate limiter at gateway | STATUS: open
+PRIORITY: 2
+ASSIGNED_TO: Alice Chen
+
+TASK: Update API docs with auth headers | STATUS: open
+PRIORITY: 3
+
+TASK: Add monitoring for rate-limit hits | STATUS: open
+PRIORITY: 4
+STORE_EOF
+
+# Send batch
+curl -s -X POST "$COGNEE/api/v1/remember" \
+  -F "datasetName=$DATASET" \
+  -F "data=@/tmp/cognee-store-batch.txt" \
+  -F "run_in_background=false" | jq .
+
+rm /tmp/cognee-store-batch.txt
+```
+
+### Step 7: Report
+
+```
+COGNEE STORE COMPLETE
+=====================
+Dataset:    my-project
+Stored:     13 items (3 entities, 2 decisions, 1 event, 4 tasks, 2 updates, 1 relationship)
+Cognified:  yes
+Graph:      updated with new nodes and edges
+
+Recall with: /cognee-recall "what did we decide about authentication"
+```
+
+## Behavior Rules
+
+### Auto-write (no confirmation needed)
+- Entity sync from external sources (MCP, APIs)
+- Task status updates
+- Event logging from emails and meetings
+- Changelog entries
+
+### Confirm-write (propose to user first)
+- New decisions
+- New relationships between entities
+- Bulk end-of-session flush (`/cognee-store:update`)
+
+### Inline store (single items during conversation)
+When a decision is made or important info surfaces mid-conversation, offer a lightweight store:
+
+```
+> "Should I store this decision in Cognee? [store / skip]"
+```
+
+If "store": format as single item and send via `/remember`.
+
+### Dedup
+Before storing, check if similar content already exists by doing a quick search:
+
+```bash
+curl -s -X POST "$COGNEE/api/v1/search" \
+  -H "Content-Type: application/json" \
+  -d "{\"query\": \"$SEARCH_TEXT\", \"datasets\": [\"$DATASET\"], \"search_type\": \"FEELING_LUCKY\", \"top_k\": 5}" | jq .
+```
+
+If high-confidence match found (>80% similarity), note it and skip: "Similar content already exists in graph. Skipping duplicate."
+
+### Batch efficiency
+Group all items into a single `/remember` call rather than sending individual requests. Cognee processes the batch and builds graph connections between items automatically.
+
+## Cognee vs Brain: When to use which for storing
+
+| Scenario | Use |
+|----------|-----|
+| Quick local decision log | Brain (SQLite, instant) |
+| Cross-project entity linking | Cognee (graph edges span datasets) |
+| Semantic search needed later | Cognee (embeddings enable fuzzy recall) |
+| Offline / no Cognee running | Brain (zero dependencies) |
+| Session context for auto-recall | Cognee (session-aware search) |
+| Both (belt and suspenders) | Store to both |

--- a/systems/cognee/skills/cognee/SKILL.md
+++ b/systems/cognee/skills/cognee/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: cognee
+description: "Knowledge graph memory backend powered by Cognee. Query, status check, dataset management, and backend switching between Brain and Cognee. Triggers on: 'cognee', 'knowledge graph', 'graph memory', 'switch memory', 'memory backend'."
+---
+
+# /cognee — Knowledge Graph Memory Backend
+
+A persistent knowledge graph memory system powered by [Cognee](https://github.com/coco-research/cognee). Stores entities, decisions, events, and relationships as graph nodes with embeddings, enabling semantic search across projects and sessions.
+
+## Quick Reference
+
+```bash
+COGNEE="http://localhost:8000"   # default; override with COGNEE_BASE_URL
+
+# Status check
+curl -s "$COGNEE/health" | jq .
+
+# List datasets
+curl -s "$COGNEE/api/v1/datasets" | jq .
+
+# Create a dataset for this project
+curl -s -X POST "$COGNEE/api/v1/datasets" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "my-project"}' | jq .
+
+# Quick semantic search
+curl -s -X POST "$COGNEE/api/v1/search" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "what did we decide about authentication", "search_type": "FEELING_LUCKY", "top_k": 10}' | jq .
+```
+
+## Sub-commands
+
+### /cognee status — Health check and dataset overview
+
+Check if Cognee is reachable and show available datasets.
+
+```bash
+COGNEE="${COGNEE_BASE_URL:-http://localhost:8000}"
+
+echo "=== Cognee Status ==="
+HEALTH=$(curl -s -o /dev/null -w "%{http_code}" "$COGNEE/health" 2>/dev/null)
+if [ "$HEALTH" = "200" ]; then
+    echo "Server:  RUNNING at $COGNEE"
+    echo ""
+    echo "Datasets:"
+    curl -s "$COGNEE/api/v1/datasets" | jq -r '.[] | "  • \(.name) (\(.id))"'
+else
+    echo "Server:  NOT REACHABLE"
+    echo ""
+    echo "Start Cognee:"
+    echo "  pip install cognee && cognee server start"
+fi
+```
+
+### /cognee init — Initialize a project dataset
+
+Create a Cognee dataset for the current project.
+
+**Procedure:**
+
+1. Ask the user for the **dataset name** (default: current directory name, slugified).
+2. Check if a dataset with that name already exists:
+
+```bash
+curl -s "$COGNEE/api/v1/datasets" | jq -r '.[].name'
+```
+
+3. If it exists: "Dataset 'X' already exists. Using it." → skip creation.
+4. If not: create it:
+
+```bash
+curl -s -X POST "$COGNEE/api/v1/datasets" \
+  -H "Content-Type: application/json" \
+  -d "{\"name\": \"$DATASET_NAME\"}" | jq .
+```
+
+5. Confirm:
+```
+COGNEE INITIALIZED
+==================
+Dataset:  {name} ({id})
+Endpoint: $COGNEE
+
+Next: Use /cognee-store to push knowledge, /cognee-recall to search.
+```
+
+### /cognee switch — Toggle between Brain and Cognee
+
+Switch which memory backend is primary for this project.
+
+**Options:**
+- `brain` → Use SQLite-based Brain (zero-dependency, per-project)
+- `cognee` → Use Cognee knowledge graph (semantic search, cross-project)
+- `both` → Use both (Brain for quick per-project lookup, Cognee for graph queries)
+
+**Behavior:**
+This sets a preference. Skills that support both backends will check this preference and route accordingly. Default behavior without explicit switch: Brain for local queries, Cognee for cross-project and semantic search.
+
+### /cognee graph — View entity relationships
+
+Show the knowledge graph for a specific entity or the current dataset.
+
+```bash
+# Get dataset ID first
+DATASET_ID=$(curl -s "$COGNEE/api/v1/datasets" | jq -r '.[] | select(.name=="my-project") | .id')
+
+# View graph
+curl -s "$COGNEE/api/v1/datasets/$DATASET_ID/graph" | jq .
+```
+
+## Architecture
+
+Cognee and Brain coexist. They are not mutually exclusive:
+
+```
+┌─────────────────────────────────────┐
+│           Coco Agent                │
+├─────────────────────────────────────┤
+│  /cognee-recall  │  /brain          │
+│  /cognee-store   │  /brain-update   │
+├─────────────────────────────────────┤
+│  Cognee (graph)  │  Brain (SQLite)   │
+│  localhost:8000  │  project_brain.db │
+└─────────────────────────────────────┘
+```
+
+- **Write path**: `/cognee-store` pushes to Cognee; `/brain-update` pushes to SQLite. You can write to both.
+- **Read path**: `/cognee-recall` for semantic/graph queries; `/brain` for structured relational queries.
+- **No sync between them** — they are independent stores. If you need consistency, pick one as primary and use the other as supplementary.
+
+## Behavior Rules
+
+### Detect Cognee availability
+Before any Cognee operation, check the health endpoint. If unreachable:
+- Tell the user: "Cognee is not running. Start it with `cognee server start` or install with `pip install cognee`."
+- Fall back gracefully: offer to use Brain instead for the same operation.
+
+### Dataset naming convention
+Default dataset name = project directory slug. For example:
+- `/home/user/MyProject` → `myproject`
+- `/home/user/E&C` → `e-and-c`
+
+User can override. Ask once, remember the mapping.
+
+### Multi-project awareness
+Unlike Brain (one DB per project folder), Cognee datasets are namespaced. An agent working across multiple projects can query multiple datasets in a single search:
+
+```bash
+curl -s -X POST "$COGNEE/api/v1/search" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "authentication decisions", "datasets": ["project-a", "project-b"], "search_type": "FEELING_LUCKY"}' | jq .
+```
+
+## Prerequisites
+
+Cognee must be installed and running:
+
+```bash
+pip install cognee
+cognee server start
+```
+
+Verify: `curl http://localhost:8000/health`


### PR DESCRIPTION
# Add Cognee Knowledge Graph Memory Bundle

Adds Cognee as an optional memory backend to Coco, following the existing system bundle pattern (like Brain, GSD, Team).

## What this adds

### New: `systems/cognee/` bundle (3 skills)

| Skill | Purpose |
|-------|---------|
| `/cognee` | Status check, dataset init, backend switching (brain ↔ cognee) |
| `/cognee-store` | Push entities, decisions, events, relationships into the knowledge graph. End-of-session flush. |
| `/cognee-recall` | Semantic + graph search across projects. Context injection for informed agent decisions. |

## Why Cognee

[Cognee](https://github.com/coco-research/cognee) is an open-source AI memory platform that gives agents persistent long-term memory via a self-hosted knowledge graph engine. Compared to the existing Brain bundle (SQLite):

| Feature | Brain (SQLite) | Cognee |
|---------|---------------|--------|
| Storage | Flat relational DB | Knowledge graph + embeddings |
| Search | Keyword + relational | Semantic + graph traversal + lexical (14 modes) |
| Cross-project | Manual aggregation | Native cross-dataset queries |
| Sessions | Stateless | Multi-turn session tracking |
| Auto-recall | Manual context query | Automatic memory injection |

## Design

- **Coexists with Brain** — not a replacement. Users pick one or both.
- **Zero new dependencies** — skills are pure Markdown with `curl` commands to Cognee's HTTP API.
- **Zero core changes** — follows the exact same pattern as `systems/brain/`. The install script auto-discovers any `systems/<name>/skills/` directory.
- **Graceful fallback** — if Cognee isn't running, skills offer to use Brain instead.

## Install

```bash
pip install cognee && cognee server start   # start Cognee
bash install.sh --adapter claude-code --systems cognee   # wire into Coco
```

## File count

- 3 SKILL.md files (cognee, cognee-store, cognee-recall)
- 1 README.md (bundle overview)
- README.md edits (system bundle count: 4→5, skills count: 146→149, added Cognee deep-dive section, updated demo)
- Zero changes to core Coco code or install scripts