### PR TITLE
security: bootstrap confirmation gate, Cursor adapter safety, prompt-injection hardening

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,6 +31,17 @@ Coco is a library of markdown artifacts and shell installers. The most likely se
 | Hardcoded credentials | high | Coco ships zero secrets; report any you find immediately |
 | Supply-chain via plugin recommendations | low | We link external plugins but don't bundle them |
 
+## Bootstrap installer behavior
+
+`bin/coco-bootstrap.sh` (the `bash <(curl -fsSL ...)` one-liner) now pauses for interactive
+confirmation before installing — it displays the cloned commit's hash, date, and message, and
+asks `[y/N]` before running `install.sh`. This is a deliberate behavior change from the prior
+zero-friction flow, added so users piping a remote script directly to their shell get a chance
+to verify what they're about to run.
+
+Pass `--yes` or set `COCO_BOOTSTRAP_YES=1` to preserve the old unattended behavior for CI or
+scripted installs.
+
 ## Out of scope
 
 - Issues in third-party AI tools (Claude Code, Cursor, Codex, etc.) — report to those projects

--- a/adapters/cursor/install.sh
+++ b/adapters/cursor/install.sh
@@ -20,10 +20,13 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
-run() { [[ $DRY_RUN -eq 1 ]] && echo "DRY: $*" || "$@"; }
+run() {
+  if [[ $DRY_RUN -eq 1 ]]; then echo "DRY: $*"; else "$@"; fi
+}
 
 link_dir() {
   local src=$1 dst=$2
+  [[ -e "$dst" && ! -L "$dst" ]] && { echo "Skip (exists, not symlink): $dst"; return; }
   [[ -L "$dst" ]] && run rm "$dst"
   run mkdir -p "$(dirname "$dst")"
   run ln -sf "$src" "$dst"

--- a/bin/coco-bootstrap.sh
+++ b/bin/coco-bootstrap.sh
@@ -1,8 +1,43 @@
 #!/usr/bin/env bash
+# coco-bootstrap.sh — one-shot installer
+#
+# Usage:
+#   bash <(curl -fsSL https://raw.githubusercontent.com/rkz91/coco/main/bin/coco-bootstrap.sh)
+#   bash <(curl -fsSL ...) -- --adapter cursor --systems gsd
+#   bash <(curl -fsSL ...) -- --dry-run
+#   COCO_DIR=~/tools/coco bash <(curl -fsSL ...)
+#
+# Flags (passed through to install.sh after --, or set via env):
+#   --adapter <name>    claude-code | cursor | codex | generic
+#   --systems <list>    e.g. gsd,brain,team
+#   --dry-run           preview only, no writes
+#   --yes               skip the commit-verification prompt (for CI/scripted installs)
+#
+# Security:
+#   This script does NOT execute anything from the network directly. It uses
+#   `git clone` to fetch the full repository (TLS-verified), then pauses so
+#   you can inspect the commit hash before proceeding.
+#   To skip the pause in CI, set COCO_BOOTSTRAP_YES=1 or pass --yes.
 set -euo pipefail
 
 REPO_URL="https://github.com/rkz91/coco.git"
 INSTALL_DIR="${COCO_DIR:-$HOME/.coco}"
+YES="${COCO_BOOTSTRAP_YES:-}"
+PASS_THROUGH=()
+
+# Parse our own flags; collect the rest for install.sh
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --yes|-y) YES=1 ;;
+    --dry-run|--adapter|--systems)
+      PASS_THROUGH+=("$1")
+      [[ "$1" != "--dry-run" ]] && { shift; PASS_THROUGH+=("$1"); }
+      ;;
+    --) shift; PASS_THROUGH+=("$@"); break ;;
+    *) PASS_THROUGH+=("$1") ;;
+  esac
+  shift
+done
 
 detect_adapter() {
   if [[ -n "${CLAUDECODE:-}" || -d "$HOME/.claude/skills" ]]; then
@@ -16,37 +51,70 @@ detect_adapter() {
   fi
 }
 
-ADAPTER="${COCO_ADAPTER:-$(detect_adapter)}"
+# Inject --adapter if not already in pass-through args
+if ! printf '%s\0' "${PASS_THROUGH[@]+"${PASS_THROUGH[@]}"}" | grep -qz -- '--adapter'; then
+  PASS_THROUGH=("--adapter" "$(detect_adapter)" "${PASS_THROUGH[@]+"${PASS_THROUGH[@]}"}")
+fi
 
-echo "Installing Coco..."
-echo "Adapter: $ADAPTER"
+echo "Coco bootstrap"
 echo "Install directory: $INSTALL_DIR"
+echo "Adapter: $(printf '%s\n' "${PASS_THROUGH[@]+"${PASS_THROUGH[@]}"}" | grep -A1 '\-\-adapter' | tail -1 || echo auto)"
 
 if ! command -v git >/dev/null 2>&1; then
-  echo "Error: git is required but not installed."
+  echo "Error: git is required but not installed." >&2
   exit 1
 fi
 
+# ── Clone or update ──────────────────────────────────────────────────────────
 if [ -d "$INSTALL_DIR/.git" ]; then
-  echo "Coco already exists. Updating..."
-  git -C "$INSTALL_DIR" pull
+  echo "Coco already exists at $INSTALL_DIR. Pulling latest..."
+  git -C "$INSTALL_DIR" pull --ff-only
 else
   if [ -e "$INSTALL_DIR" ]; then
-    echo "Error: $INSTALL_DIR already exists but is not a Coco clone."
-    echo "Remove it manually or set COCO_DIR to a different path."
+    echo "Error: $INSTALL_DIR exists but is not a Coco clone." >&2
+    echo "Remove it manually or set COCO_DIR to a different path." >&2
     exit 1
   fi
   echo "Cloning Coco..."
-  git clone "$REPO_URL" "$INSTALL_DIR"
+  git clone --quiet "$REPO_URL" "$INSTALL_DIR"
 fi
 
-cd "$INSTALL_DIR"
+# ── Commit verification gate ─────────────────────────────────────────────────
+COMMIT_HASH="$(git -C "$INSTALL_DIR" rev-parse HEAD)"
+COMMIT_DATE="$(git -C "$INSTALL_DIR" log -1 --format='%ci' HEAD)"
+COMMIT_MSG="$(git -C "$INSTALL_DIR" log -1 --format='%s' HEAD)"
 
-if [ ! -f "install.sh" ]; then
-  echo "Error: install.sh not found."
+echo ""
+echo "┌─ Verify before you run ──────────────────────────────────────────────┐"
+echo "│  Commit : $COMMIT_HASH"
+echo "│  Date   : $COMMIT_DATE"
+echo "│  Message: $COMMIT_MSG"
+echo "│"
+echo "│  Confirm this matches the latest release on GitHub:"
+echo "│  https://github.com/rkz91/coco/commits/main"
+echo "└──────────────────────────────────────────────────────────────────────┘"
+echo ""
+
+if [[ -z "$YES" ]]; then
+  read -r -p "Proceed with installation? [y/N] " REPLY
+  case "$REPLY" in
+    [yY][eE][sS]|[yY]) ;;
+    *)
+      echo "Aborted. The clone is at $INSTALL_DIR — inspect it, then run:"
+      echo "  bash \"$INSTALL_DIR/install.sh\" ${PASS_THROUGH[*]+"${PASS_THROUGH[*]}"}"
+      exit 0
+      ;;
+  esac
+fi
+
+# ── Install ──────────────────────────────────────────────────────────────────
+if [ ! -f "$INSTALL_DIR/install.sh" ]; then
+  echo "Error: install.sh not found in cloned repo." >&2
   exit 1
 fi
 
-bash install.sh --adapter "$ADAPTER"
+bash "$INSTALL_DIR/install.sh" "${PASS_THROUGH[@]+"${PASS_THROUGH[@]}"}"
 
+echo ""
 echo "Coco installed successfully at $INSTALL_DIR"
+echo "Commit: $COMMIT_HASH"

--- a/skills/find-skills/SKILL.md
+++ b/skills/find-skills/SKILL.md
@@ -94,6 +94,18 @@ npx skills add <owner/repo@skill> -g -y
 
 The `-g` flag installs globally (user-level) and `-y` skips confirmation prompts.
 
+**Before you run this command on the user's behalf**, the `owner/repo@skill` identifier
+came from search results you don't control (skills.sh, GitHub) — an attacker can publish
+a well-named, well-described malicious package that ranks for a target query. Since `-y`
+skips the CLI's own confirmation prompt, you are the only checkpoint before code from an
+arbitrary third party lands on the user's machine. So:
+
+1. Display the exact resolved `owner/repo@skill` string, the repo URL, and a short
+   description/README excerpt to the user.
+2. Get an explicit affirmative reply that references that specific package — a prior
+   generic "yes, install it" from earlier in the conversation is not sufficient.
+3. Only then run the install command above.
+
 ## Common Skill Categories
 
 When searching, consider these common categories:


### PR DESCRIPTION
## Summary

Three fixes that touch runtime behavior — each deliberately scoped to preserve the documented contract wherever possible. Part 2 of 3 PRs split by risk tier (see #37 for the "merge today" safe-hardening tier); this one deserves a slower, more deliberate look since one item is a genuine, intentional behavior change.

- **Bootstrap confirmation gate** (`bin/coco-bootstrap.sh`) — the `bash <(curl -fsSL ...)` one-liner previously git-cloned and immediately ran `install.sh` with zero pause and zero visibility into what was about to execute. Now displays the cloned commit's hash/date/message and asks `[y/N]` before proceeding. **This is an intentional, documented behavior change** — pass `--yes` or set `COCO_BOOTSTRAP_YES=1` to preserve the old unattended flow for CI/scripted installs. Documented in `SECURITY.md` (deliberately not `README.md` — that file is independently contended by two other open PRs upstream, #31 and #36, and touching it here would create an avoidable merge conflict).
- **Cursor adapter safety** (`adapters/cursor/install.sh`) — brought `link_dir()`/`run()` in line with the Claude Code adapter's already-safer versions: guards against silently overwriting a real file (not just a symlink) at the destination, and replaces a `shellcheck SC2015`-flagged `A && B || C` pattern with explicit `if/then/else` (the old form could execute the real command even in dry-run mode if the `echo` failed, e.g. on `SIGPIPE`).
- **Prompt-injection hardening** (`skills/find-skills/SKILL.md`) — Step 4 documents `npx skills add <owner/repo@skill> -g -y`, where `-y` skips the CLI's own confirmation and the package identifier comes entirely from search results (skills.sh, GitHub) that an attacker can influence by publishing a well-named malicious package. **Deliberately did not remove `-y` from the documented command** — that would change what a human running it directly in a terminal experiences, a real change to a documented CLI invocation. Instead added agent-instruction guidance only: before the agent invokes the install on the user's behalf, it must show the resolved package identity and get explicit confirmation referencing that specific package. Zero change to the documented command, flag, or CLI output.

## Test plan

- [x] `bash -n` syntax check on all shell scripts
- [x] `bash tests/check-command-refs.sh` / `check-evidence-gate.sh` — PASS
- [x] INDEX drift check — zero drift (confirmed the find-skills edit doesn't touch `description:` frontmatter, only body content)
- [x] Functional test of the bootstrap gate's accept path (`COCO_BOOTSTRAP_YES=1`) — confirmation skipped, install proceeds to completion
- [x] Functional test of the bootstrap gate's decline path (piped `n`) — prompt shown, correctly aborts before `install.sh` runs, clean exit
- [x] Cursor adapter dry-run smoke test — output shape unchanged from before the fix
- [x] Independent re-verification from a fresh clone — matches all claims above