### PR TITLE
chore(license): relicense to open-core (proprietary Super Intelligence); spec 1.1.0

### DIFF
--- a/.claude-plugin.json
+++ b/.claude-plugin.json
@@ -1,10 +1,10 @@
 {
   "name": "coco",
   "displayName": "Coco",
-  "description": "An entire team. Wherever your AI lives. 59 skills, 34 commands, 10 agents, 3 system bundles for project orchestration, knowledge tracking, and multi-agent pipelines. MIT, vendor-neutral.",
+  "description": "An entire team. Wherever your AI lives. 59 skills, 34 commands, 10 agents, 3 system bundles for project orchestration, knowledge tracking, and multi-agent pipelines. Open-core, vendor-neutral.",
   "version": "1.0.0",
   "author": "Coco Inc",
-  "license": "MIT",
+  "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/coco-research/coco",
   "repository": {
     "type": "git",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) · Versioning: 
 
 - **Rebranded to CoCo Super Intelligence.** The README now leads with the 389-persona advisory board as the hero capability, with the orchestration framework (skills, persistent state, portability) as the supporting layer. Added new brand lockups (`assets/logo-si.svg` / `logo-si-light.svg`) and a refreshed social card (`assets/og-image.svg`); the original `coco` mark (`logo.svg` / `logo-light.svg`) is preserved unchanged.
 - **Repository migrated to the `coco-research` GitHub org.** All URLs, the npm scope (`@coco-research/coco-cli`), the Homebrew tap reference, and the publish workflows now point to `coco-research` instead of `rkz91`.
+- **Relicensed to open-core.** The CoCo core stays MIT, but the Super Intelligence System (`systems/superintelligence/`) is now proprietary — source-available for reference, all rights reserved (see `systems/superintelligence/LICENSE`). The root `LICENSE` carves it out; `package.json`/`.claude-plugin.json` now declare `SEE LICENSE IN LICENSE`, the Homebrew formula uses `:cannot_represent`, and the README badge/labels read "Open-core." Bumped **Spec Version 1.0.0 → 1.1.0**. Note: MIT grants already made on prior releases of the Super Intelligence System remain valid for those snapshots; the change is forward-only.
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,9 @@ Frontmatter must validate against [`docs/architecture.md`](docs/architecture.md)
 
 ## Licensing
 
-Contributions are MIT-licensed under the project's [LICENSE](LICENSE). By submitting a PR, you agree your contribution is so licensed.
+CoCo is open-core. Contributions to the **core** are MIT-licensed under the project's [LICENSE](LICENSE); by submitting a PR touching the core, you agree your contribution is so licensed.
+
+The **Super Intelligence System** (`systems/superintelligence/`) is proprietary — see [`systems/superintelligence/LICENSE`](systems/superintelligence/LICENSE). It is not accepting external contributions under an open-source license; please open an issue before proposing changes there.
 
 ---
 

--- a/Formula/coco.rb
+++ b/Formula/coco.rb
@@ -16,7 +16,9 @@ class Coco < Formula
   homepage "https://github.com/coco-research/coco"
   url "https://github.com/coco-research/coco/archive/refs/tags/v1.0.0.tar.gz"
   sha256 "8b34573808129125d123bced8fdf770c2be58c33718e0acf4b444a5989a8187e"
-  license "MIT"
+  # Open-core: MIT core (see LICENSE) + proprietary Super Intelligence
+  # (see systems/superintelligence/LICENSE). Not a single SPDX identifier.
+  license :cannot_represent
   version "1.0.0"
 
   depends_on "git"

--- a/LICENSE
+++ b/LICENSE
@@ -2,6 +2,14 @@ MIT License
 
 Copyright (c) 2026 Coco Inc
 
+SCOPE: This MIT license governs the CoCo core — all contents of this
+repository EXCEPT the directory `systems/superintelligence/`. The Super
+Intelligence System in `systems/superintelligence/` is proprietary and is
+licensed separately under `systems/superintelligence/LICENSE`; the grant
+below does not apply to it. Certain vendored third-party components (for
+example, some skills under `skills/`) carry their own upstream licenses,
+which continue to govern those components; see `CREDITS.md`.
+
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@
 
 CoCo Super Intelligence is the orchestration layer that turns Claude Code, Cursor, or Codex into an entire engineering department: routed expert panels that deliberate and decide, then **147 skills**, **277 commands**, and disk-persistent state that ship what they decided.
 
-Free · MIT · installs in 90 seconds · 100% local · no telemetry
+Open-core (MIT core · proprietary Super Intelligence) · installs in 90 seconds · 100% local · no telemetry
 
 <br>
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)](https://opensource.org/license/mit)
+[![License: Open-core](https://img.shields.io/badge/License-Open--core-yellow.svg?style=for-the-badge)](LICENSE)
 [![Version](https://img.shields.io/badge/version-1.0.0-blue?style=for-the-badge)](CHANGELOG.md)
 [![Skills](https://img.shields.io/badge/skills-147-emerald?style=for-the-badge)](skills/)
 [![Commands](https://img.shields.io/badge/commands-277-indigo?style=for-the-badge)](commands/)
@@ -612,8 +612,8 @@ npx @coco-research/coco-cli update
 ## Technical Specifications
 
 <table>
-<tr><td><strong>Spec Version</strong></td><td>1.0.0</td></tr>
-<tr><td><strong>License</strong></td><td><a href="https://opensource.org/license/mit">MIT</a></td></tr>
+<tr><td><strong>Spec Version</strong></td><td>1.1.0</td></tr>
+<tr><td><strong>License</strong></td><td>Open-core — <a href="LICENSE">MIT</a> core; Super Intelligence is <a href="systems/superintelligence/LICENSE">proprietary</a></td></tr>
 <tr><td><strong>Total Skills</strong></td><td>147 with all bundles installed (64 Core + 68 GSD + 6 Brain + 9 Super Intelligence)</td></tr>
 <tr><td><strong>Slash Commands</strong></td><td>277 with all bundles — 35 Core (shipped) + 242 Super Intelligence (225 per-team + 17 cross-team, generated at install)</td></tr>
 <tr><td><strong>Specialized Agents</strong></td><td>34 (10 Core + 24 GSD Bundle)</td></tr>
@@ -663,7 +663,7 @@ Re-run the installer with the new adapter flag (e.g. <code>bash install.sh --ada
 
 ## Contributing & Community
 
-CoCo is MIT-licensed and contributions are welcome.
+CoCo is open-core: the core is MIT-licensed and contributions are welcome. The Super Intelligence System (`systems/superintelligence/`) is proprietary — see [`systems/superintelligence/LICENSE`](systems/superintelligence/LICENSE).
 
 - **Start here:** [`CONTRIBUTING.md`](CONTRIBUTING.md) — how to add a skill, command, agent, or adapter.
 - **Good first issues:** [help wanted / good first issue](https://github.com/coco-research/coco/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) — small, well-scoped tasks for newcomers.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coco-research/coco-cli",
   "version": "1.0.0",
-  "description": "CoCo Super Intelligence — summon an advisory board of 389 world-class minds inside your AI coding session. A vendor-neutral orchestration layer for Claude Code, Cursor, and Codex: 147 skills, 277 commands, 34 agents, and disk-persistent state. 100% local, no telemetry, MIT.",
+  "description": "CoCo Super Intelligence — summon an advisory board of 389 world-class minds inside your AI coding session. A vendor-neutral orchestration layer for Claude Code, Cursor, and Codex: 147 skills, 277 commands, 34 agents, and disk-persistent state. 100% local, no telemetry. Open-core: MIT core, proprietary Super Intelligence.",
   "bin": {
     "coco": "./bin/coco.js"
   },
@@ -27,7 +27,7 @@
     "productivity"
   ],
   "author": "Coco Inc",
-  "license": "MIT",
+  "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/coco-research/coco",
   "repository": {
     "type": "git",

--- a/systems/superintelligence/LICENSE
+++ b/systems/superintelligence/LICENSE
@@ -1,0 +1,42 @@
+CoCo Super Intelligence — Proprietary License
+
+Copyright (c) 2026 Coco Inc. All rights reserved.
+
+This directory (`systems/superintelligence/` and all of its contents — the
+expert persona registries, research corpora, team definitions, generators,
+and documentation, collectively the "Super Intelligence System") is
+PROPRIETARY and is NOT covered by the MIT license that governs the rest of
+this repository.
+
+No license or right is granted to any person to use, copy, modify, merge,
+publish, distribute, sublicense, sell, or create derivative works of the
+Super Intelligence System, in whole or in part, except as expressly
+authorized in writing by Coco Inc.
+
+The source of the Super Intelligence System is made visible in this
+repository for reference and transparency only. Visibility of the source
+does not grant any of the rights withheld above.
+
+Permitted without separate authorization:
+  - Running the Super Intelligence System locally as installed by this
+    project's installer for your own use.
+
+Not permitted without prior written authorization from Coco Inc:
+  - Redistributing the Super Intelligence System or any substantial portion
+    of it, modified or unmodified.
+  - Incorporating it, or derivatives of it, into any other product or
+    project, commercial or non-commercial.
+  - Publishing, mirroring, or repackaging it outside this repository.
+
+Third-party materials referenced or cited within the Super Intelligence
+System (for example, quoted public statements and linked sources) remain the
+property of their respective owners and are used for attribution and research.
+
+THE SUPER INTELLIGENCE SYSTEM IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES,
+OR OTHER LIABILITY ARISING FROM, OUT OF, OR IN CONNECTION WITH THE SUPER
+INTELLIGENCE SYSTEM OR ITS USE.
+
+For licensing inquiries, contact Coco Inc.


### PR DESCRIPTION
## Summary

Relicenses CoCo to **open-core** and bumps the spec version.

- **Core stays MIT.** Everything except `systems/superintelligence/` remains MIT-licensed and copyable.
- **Super Intelligence is now proprietary.** New `systems/superintelligence/LICENSE` — source-available for reference, **all rights reserved**. Root `LICENSE` gains an explicit carve-out excluding that directory (and notes vendored third-party skill licenses still govern their own components).
- **Spec Version 1.0.0 → 1.1.0.**

## Label/metadata updates

- `README.md` — badge → "Open-core", tagline, license row, and the Contributing blurb all reflect the split.
- `package.json` / `.claude-plugin.json` — `"license": "SEE LICENSE IN LICENSE"`; descriptions say "open-core".
- `Formula/coco.rb` — `license :cannot_represent` (open-core isn't a single SPDX id).
- `CONTRIBUTING.md` — core contributions MIT; SI not accepting OSS contributions.
- `CHANGELOG.md` — documented under `[Unreleased]`.

## ⚠️ Important caveats (not legal advice)

- **Forward-only.** The SI System was previously published under MIT (since PR #18, 2026-06-01). MIT grants already made on those snapshots are irrevocable — this change binds new commits onward only.
- **Source-available ≠ secret.** SI source stays visible/forkable in the public repo; the proprietary license makes reuse *unlawful*, not *impossible*. A private-repo move would be needed for true protection (tracked separately if desired).

## Verification

- [x] `python3 scripts/build-index.py` — zero INDEX drift
- [x] `package.json` / `.claude-plugin.json` — valid JSON
- [x] No stray "MIT" project-license claims remain (only intended "MIT core" phrasings + third-party attributions in CREDITS)
