### PR TITLE
chore(release): cut v1.1.0

### DIFF
--- a/.claude-plugin.json
+++ b/.claude-plugin.json
@@ -2,7 +2,7 @@
   "name": "coco",
   "displayName": "Coco",
   "description": "An entire team. Wherever your AI lives. 59 skills, 34 commands, 10 agents, 3 system bundles for project orchestration, knowledge tracking, and multi-agent pipelines. Open-core, vendor-neutral.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "Coco Inc",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/coco-research/coco",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) · Versioning: 
 
 ## [Unreleased]
 
+---
+
+## [1.1.0] — 2026-07-18
+
 ### Changed
 
 - **Rebranded to CoCo Super Intelligence.** The README now leads with the 389-persona advisory board as the hero capability, with the orchestration framework (skills, persistent state, portability) as the supporting layer. Added new brand lockups (`assets/logo-si.svg` / `logo-si-light.svg`) and a refreshed social card (`assets/og-image.svg`); the original `coco` mark (`logo.svg` / `logo-light.svg`) is preserved unchanged.

--- a/Formula/coco.rb
+++ b/Formula/coco.rb
@@ -14,12 +14,12 @@
 class Coco < Formula
   desc "Open-source AI workflow framework — skills, agents, commands, multi-agent orchestration"
   homepage "https://github.com/coco-research/coco"
-  url "https://github.com/coco-research/coco/archive/refs/tags/v1.0.0.tar.gz"
-  sha256 "8b34573808129125d123bced8fdf770c2be58c33718e0acf4b444a5989a8187e"
+  url "https://github.com/coco-research/coco/archive/refs/tags/v1.1.0.tar.gz"
+  sha256 "0000000000000000000000000000000000000000000000000000000000000000" # set after v1.1.0 tag
   # Open-core: MIT core (see LICENSE) + proprietary Super Intelligence
   # (see systems/superintelligence/LICENSE). Not a single SPDX identifier.
   license :cannot_represent
-  version "1.0.0"
+  version "1.1.0"
 
   depends_on "git"
   depends_on "bash"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Open-core (MIT core · proprietary Super Intelligence) · installs in 90 seconds
 <br>
 
 [![License: Open-core](https://img.shields.io/badge/License-Open--core-yellow.svg?style=for-the-badge)](LICENSE)
-[![Version](https://img.shields.io/badge/version-1.0.0-blue?style=for-the-badge)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.1.0-blue?style=for-the-badge)](CHANGELOG.md)
 [![Skills](https://img.shields.io/badge/skills-147-emerald?style=for-the-badge)](skills/)
 [![Commands](https://img.shields.io/badge/commands-277-indigo?style=for-the-badge)](commands/)
 [![Personas](https://img.shields.io/badge/personas-389-violet?style=for-the-badge)](systems/superintelligence/)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coco-research/coco-cli",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "CoCo Super Intelligence — summon an advisory board of 389 world-class minds inside your AI coding session. A vendor-neutral orchestration layer for Claude Code, Cursor, and Codex: 147 skills, 277 commands, 34 agents, and disk-persistent state. 100% local, no telemetry. Open-core: MIT core, proprietary Super Intelligence.",
   "bin": {
     "coco": "./bin/coco.js"


### PR DESCRIPTION
Bumps the release version 1.0.0 → 1.1.0 to match the Spec Version bump and the rebrand + open-core relicense.

- README version badge, `package.json`, `.claude-plugin.json`, `Formula/coco.rb` (version + tag URL) → **1.1.0**
- CHANGELOG `[Unreleased]` → **`[1.1.0]` — 2026-07-18**

**Follow-up in this same flow:** the Formula `sha256` is a placeholder here. After this merges I'll tag `v1.1.0`, create the GitHub release, compute the real tarball checksum, and open a second PR to set it (mirrors how #30 set the v1.0.0 sha).