### PR TITLE
fix(formula): set real sha256 for v1.1.0 tarball

### DIFF
--- a/Formula/coco.rb
+++ b/Formula/coco.rb
@@ -15,7 +15,7 @@ class Coco < Formula
   desc "Open-source AI workflow framework — skills, agents, commands, multi-agent orchestration"
   homepage "https://github.com/coco-research/coco"
   url "https://github.com/coco-research/coco/archive/refs/tags/v1.1.0.tar.gz"
-  sha256 "0000000000000000000000000000000000000000000000000000000000000000" # set after v1.1.0 tag
+  sha256 "e6024602266408f51f8fef2f7e4abc8d7c67c98ee5fae45b00ea799684d86cf0"
   # Open-core: MIT core (see LICENSE) + proprietary Super Intelligence
   # (see systems/superintelligence/LICENSE). Not a single SPDX identifier.
   license :cannot_represent


### PR DESCRIPTION
Sets the Homebrew formula `sha256` to the real checksum of the published `v1.1.0` source tarball (was a placeholder in #42).

- Tarball: https://github.com/coco-research/coco/archive/refs/tags/v1.1.0.tar.gz
- sha256: `e6024602266408f51f8fef2f7e4abc8d7c67c98ee5fae45b00ea799684d86cf0`

`brew install coco-research/coco/coco` now resolves to v1.1.0.