### PR TITLE
fix(funding): point Sponsors at coco-research, not the reclaimed rkz91 username

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,8 +1,13 @@
 # GitHub Sponsors / funding configuration
 # Enable Sponsors for the maintainer to surface a "Sponsor" button on the repo page.
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+#
+# Must stay in sync with the account that owns this repository. This previously read
+# `rkz91`, the account's name before the 2026-07-18 rename to `coco-research`. That
+# username was then registered by an unrelated third party, so the funding pointer no
+# longer referred to this project's maintainer.
 
-github: [rkz91]
+github: [coco-research]
 # patreon: ""
 # open_collective: ""
 # ko_fi: ""


### PR DESCRIPTION
`.github/FUNDING.yml` still read `github: [rkz91]` — the account name this project used **before** the 2026-07-18 rename to `coco-research`.

That username did not stay vacant. An unrelated third party registered it:

| | account | id | created |
|---|---|---|---|
| This project | `coco-research` | `68911604` | 2020-07-28 |
| Reclaimed username | `rkz91` | `306070752` | **2026-07-17** |

So the repository's funding pointer referred to a stranger rather than the maintainer. That account's only public repository is a fork named `coco-super-intelligence-`, created the same day it was registered.

## Severity, stated accurately

**No funds could have been misdirected yet.** I checked via GraphQL `hasSponsorsListing`, and that account has no Sponsors listing, so GitHub renders no Sponsor button today. The real risk is that this becomes a live misdirection the moment they enable Sponsors, which is entirely outside this project's control. That is why it is worth fixing now rather than later.

## Related exposure, not fixed here

`github.com/rkz91/coco` still resolves to this repository, but only because that account has not created a repository named exactly `coco`. If it ever does, GitHub's rename redirect breaks in their favour and any stale `rkz91/coco` link points at them. This matters because `bin/coco-bootstrap.sh` is a curl-pipe-to-bash installer.

`main` is otherwise clean: `REPO_URL` already points at `coco-research`, and the only other occurrence is a historical line in `CHANGELOG.md` that correctly describes the migration and should stay as-is.

**Note for reviewers of PR #38:** that PR adds two *new* hardcoded `rkz91` URLs, including its own "verify the commit here" link. Those should be changed to `coco-research` before it merges.

## Verification

YAML parses to `{'github': ['coco-research']}`. `check-command-refs.sh`, `check-evidence-gate.sh`, `install.sh` syntax, and the index-freshness check all pass locally. No generated files affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)