### PR TITLE
security: SHA-pin Actions, least-privilege permissions, CSP, XSS fix, CVE floor bumps (rebase of #37)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint-and-test:
     runs-on: ubuntu-latest
@@ -13,17 +16,17 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
       - name: Set up Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '20'
 
       - name: Install pyyaml
-        run: pip install pyyaml
+        run: pip install pyyaml==6.0.2
 
       - name: Validate adapter manifests
         run: |

--- a/.github/workflows/lint-frontmatter.yml
+++ b/.github/workflows/lint-frontmatter.yml
@@ -12,6 +12,9 @@ on:
       - 'systems/**/SKILL.md'
       - 'workflows/**/*.md'
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -19,12 +22,12 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
       - name: Install pyyaml
-        run: pip install pyyaml
+        run: pip install pyyaml==6.0.2
 
       - name: Validate frontmatter
         run: |

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '20'
           registry-url: 'https://npm.pkg.github.com'

--- a/.github/workflows/publish-npmjs.yml
+++ b/.github/workflows/publish-npmjs.yml
@@ -14,6 +14,9 @@ on:
     types: [published]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -21,7 +24,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'

--- a/commands/design/mermaid.md
+++ b/commands/design/mermaid.md
@@ -93,6 +93,7 @@ For standalone documents or reports, use the ESM import pattern:
 <html>
 <head>
 <meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://esm.sh; connect-src 'self' https://esm.sh; style-src 'self' 'unsafe-inline'; img-src 'self' data:;">
 <title>Diagram</title>
 <style>
   body { font-family: Inter, system-ui, sans-serif; background: #1a1b26; color: #a9b1d6; max-width: 900px; margin: 40px auto; padding: 0 20px; }
@@ -177,7 +178,10 @@ If `beautiful-mermaid` cannot parse the diagram:
 
 ## Multi-Diagram Documents
 
-For documents with multiple diagrams (like PLATFORM-ANALYSIS.md):
+For documents with multiple diagrams (like PLATFORM-ANALYSIS.md). This is a `<script>`
+fragment, not a full document — ensure the `<head>` it's inserted into carries the same
+CSP meta tag as the standalone template above (`script-src`/`connect-src` scoped to
+`https://esm.sh`):
 
 ```html
 <script type="module">

--- a/skills/brainstorming/scripts/helper.js
+++ b/skills/brainstorming/scripts/helper.js
@@ -54,9 +54,9 @@
         indicator.textContent = 'Click an option above, then return to the terminal';
       } else if (selected.length === 1) {
         const label = selected[0].querySelector('h3, .content h3, .card-body h3')?.textContent?.trim() || selected[0].dataset.choice;
-        indicator.innerHTML = '<span class="selected-text">' + label + ' selected</span> — return to terminal to continue';
+        indicator.textContent = (label || '') + ' selected — return to terminal to continue';
       } else {
-        indicator.innerHTML = '<span class="selected-text">' + selected.length + ' selected</span> — return to terminal to continue';
+        indicator.textContent = selected.length + ' selected — return to terminal to continue';
       }
     }, 0);
   });

--- a/skills/openai-apps-mcp/templates/basic/package.json
+++ b/skills/openai-apps-mcp/templates/basic/package.json
@@ -9,14 +9,14 @@
     "preview": "wrangler dev"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.21.0",
-    "hono": "^4.10.2",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "hono": "^4.12.27",
     "zod": "^3.25.76"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.13.13",
     "@cloudflare/workers-types": "^4.20250531.0",
-    "vite": "^7.1.9",
-    "wrangler": "^4.42.2"
+    "vite": "^7.3.6",
+    "wrangler": "^4.107.0"
   }
 }

--- a/systems/superintelligence/HOW-IT-WORKS.html
+++ b/systems/superintelligence/HOW-IT-WORKS.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://esm.sh; connect-src 'self' https://esm.sh; style-src 'self' 'unsafe-inline'; img-src 'self' data:;">
 <title>Super Intelligence — How the Orchestrator Works</title>
 <style>
   :root {


### PR DESCRIPTION
This lands @imachiever's security work from #37. All four commits remain authored by **Rajat Bhatia <imachiever@gmail.com>**; this branch exists only because #37 could not be updated in place.

Supersedes #37. Please close that one in favour of this.

## Why it needed a rebase

#37 was opened on 2026-07-03 and had drifted into a real conflict. Merging it as drafted would have **regressed** `actions/setup-node` from **v7 back to v4** across three workflows, undoing the dependabot bump that already landed in #39.

## What I changed during conflict resolution

Only the Action pins. His SHA-pinning intent is preserved; the pins now target the versions `main` actually uses:

| Action | #37 as drafted | This branch |
|---|---|---|
| `setup-node` | `49933ea…` (**v4**, a regression) | `820762786026740c76f36085b0efc47a31fe5020` (**v7**) |
| `setup-python` | `a26af69…` (v5) | unchanged, `a26af69…` (v5) |

Both SHAs were verified two ways: each exists in the genuine upstream repository, and each matches what that tag currently points to. `actions/checkout` is deliberately left unpinned, as in the original PR.

## His changes, unmodified

- `permissions: contents: read` added to three workflows. Pure privilege narrowing.
- **Real DOM-XSS fix** in `skills/brainstorming/scripts/helper.js`: `innerHTML` with concatenated user-controlled label becomes `textContent`, with a null guard.
- CSP meta tag added to the generated diagram artifacts. Worth noting for reviewers that it retains `'unsafe-inline'` on `script-src` because the templates use inline modules, so it is a partial mitigation rather than a hard boundary.
- CVE floor bumps in the `openai-apps-mcp` template: `@modelcontextprotocol/sdk`, `hono`, `vite`, `wrangler`, all same-major.

## Verification

Every workflow parses as valid YAML, no conflict markers remain, `helper.js` passes `node --check`, the template `package.json` parses, and `check-command-refs.sh`, `check-evidence-gate.sh`, `install.sh` syntax and the index-freshness check all pass locally.

**Heads-up:** dependabot #44 proposes `setup-python` 5 → 7. Once these pins land, that PR will need its pin updated rather than just its version string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)