### PR TITLE
security: bootstrap confirmation gate + Cursor adapter safety (rebase of #38)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,6 +31,17 @@ Coco is a library of markdown artifacts and shell installers. The most likely se
 | Hardcoded credentials | high | Coco ships zero secrets; report any you find immediately |
 | Supply-chain via plugin recommendations | low | We link external plugins but don't bundle them |
 
+## Bootstrap installer behavior
+
+`bin/coco-bootstrap.sh` (the `bash <(curl -fsSL ...)` one-liner) now pauses for interactive
+confirmation before installing — it displays the cloned commit's hash, date, and message, and
+asks `[y/N]` before running `install.sh`. This is a deliberate behavior change from the prior
+zero-friction flow, added so users piping a remote script directly to their shell get a chance
+to verify what they're about to run.
+
+Pass `--yes` or set `COCO_BOOTSTRAP_YES=1` to preserve the old unattended behavior for CI or
+scripted installs.
+
 ## Out of scope
 
 - Issues in third-party AI tools (Claude Code, Cursor, Codex, etc.) — report to those projects

--- a/adapters/cursor/install.sh
+++ b/adapters/cursor/install.sh
@@ -20,10 +20,13 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
-run() { [[ $DRY_RUN -eq 1 ]] && echo "DRY: $*" || "$@"; }
+run() {
+  if [[ $DRY_RUN -eq 1 ]]; then echo "DRY: $*"; else "$@"; fi
+}
 
 link_dir() {
   local src=$1 dst=$2
+  [[ -e "$dst" && ! -L "$dst" ]] && { echo "Skip (exists, not symlink): $dst"; return; }
   [[ -L "$dst" ]] && run rm "$dst"
   run mkdir -p "$(dirname "$dst")"
   run ln -sf "$src" "$dst"

--- a/bin/coco-bootstrap.sh
+++ b/bin/coco-bootstrap.sh
@@ -2,7 +2,7 @@
 # coco-bootstrap.sh — one-shot installer
 #
 # Usage:
-#   bash <(curl -fsSL https://raw.githubusercontent.com/rkz91/coco/main/bin/coco-bootstrap.sh)
+#   bash <(curl -fsSL https://raw.githubusercontent.com/coco-research/coco/main/bin/coco-bootstrap.sh)
 #   bash <(curl -fsSL ...) -- --adapter cursor --systems gsd
 #   bash <(curl -fsSL ...) -- --dry-run
 #   COCO_DIR=~/tools/coco bash <(curl -fsSL ...)
@@ -17,7 +17,8 @@
 #   This script does NOT execute anything from the network directly. It uses
 #   `git clone` to fetch the full repository (TLS-verified), then pauses so
 #   you can inspect the commit hash before proceeding.
-#   To skip the pause in CI, set COCO_BOOTSTRAP_YES=1 or pass --yes.
+#   To skip the pause in CI, set COCO_BOOTSTRAP_YES=1 or pass --yes. Only the exact
+#   value 1 (or --yes) skips it; anything else, including 0, keeps the prompt.
 set -euo pipefail
 
 REPO_URL="https://github.com/coco-research/coco.git"
@@ -91,11 +92,11 @@ echo "│  Date   : $COMMIT_DATE"
 echo "│  Message: $COMMIT_MSG"
 echo "│"
 echo "│  Confirm this matches the latest release on GitHub:"
-echo "│  https://github.com/rkz91/coco/commits/main"
+echo "│  https://github.com/coco-research/coco/commits/main"
 echo "└──────────────────────────────────────────────────────────────────────┘"
 echo ""
 
-if [[ -z "$YES" ]]; then
+if [[ "$YES" != "1" ]]; then
   read -r -p "Proceed with installation? [y/N] " REPLY
   case "$REPLY" in
     [yY][eE][sS]|[yY]) ;;

--- a/bin/coco-bootstrap.sh
+++ b/bin/coco-bootstrap.sh
@@ -1,8 +1,43 @@
 #!/usr/bin/env bash
+# coco-bootstrap.sh — one-shot installer
+#
+# Usage:
+#   bash <(curl -fsSL https://raw.githubusercontent.com/rkz91/coco/main/bin/coco-bootstrap.sh)
+#   bash <(curl -fsSL ...) -- --adapter cursor --systems gsd
+#   bash <(curl -fsSL ...) -- --dry-run
+#   COCO_DIR=~/tools/coco bash <(curl -fsSL ...)
+#
+# Flags (passed through to install.sh after --, or set via env):
+#   --adapter <name>    claude-code | cursor | codex | generic
+#   --systems <list>    e.g. gsd,brain,team
+#   --dry-run           preview only, no writes
+#   --yes               skip the commit-verification prompt (for CI/scripted installs)
+#
+# Security:
+#   This script does NOT execute anything from the network directly. It uses
+#   `git clone` to fetch the full repository (TLS-verified), then pauses so
+#   you can inspect the commit hash before proceeding.
+#   To skip the pause in CI, set COCO_BOOTSTRAP_YES=1 or pass --yes.
 set -euo pipefail
 
 REPO_URL="https://github.com/coco-research/coco.git"
 INSTALL_DIR="${COCO_DIR:-$HOME/.coco}"
+YES="${COCO_BOOTSTRAP_YES:-}"
+PASS_THROUGH=()
+
+# Parse our own flags; collect the rest for install.sh
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --yes|-y) YES=1 ;;
+    --dry-run|--adapter|--systems)
+      PASS_THROUGH+=("$1")
+      [[ "$1" != "--dry-run" ]] && { shift; PASS_THROUGH+=("$1"); }
+      ;;
+    --) shift; PASS_THROUGH+=("$@"); break ;;
+    *) PASS_THROUGH+=("$1") ;;
+  esac
+  shift
+done
 
 detect_adapter() {
   if [[ -n "${CLAUDECODE:-}" || -d "$HOME/.claude/skills" ]]; then
@@ -16,37 +51,70 @@ detect_adapter() {
   fi
 }
 
-ADAPTER="${COCO_ADAPTER:-$(detect_adapter)}"
+# Inject --adapter if not already in pass-through args
+if ! printf '%s\0' "${PASS_THROUGH[@]+"${PASS_THROUGH[@]}"}" | grep -qz -- '--adapter'; then
+  PASS_THROUGH=("--adapter" "$(detect_adapter)" "${PASS_THROUGH[@]+"${PASS_THROUGH[@]}"}")
+fi
 
-echo "Installing Coco..."
-echo "Adapter: $ADAPTER"
+echo "Coco bootstrap"
 echo "Install directory: $INSTALL_DIR"
+echo "Adapter: $(printf '%s\n' "${PASS_THROUGH[@]+"${PASS_THROUGH[@]}"}" | grep -A1 '\-\-adapter' | tail -1 || echo auto)"
 
 if ! command -v git >/dev/null 2>&1; then
-  echo "Error: git is required but not installed."
+  echo "Error: git is required but not installed." >&2
   exit 1
 fi
 
+# ── Clone or update ──────────────────────────────────────────────────────────
 if [ -d "$INSTALL_DIR/.git" ]; then
-  echo "Coco already exists. Updating..."
-  git -C "$INSTALL_DIR" pull
+  echo "Coco already exists at $INSTALL_DIR. Pulling latest..."
+  git -C "$INSTALL_DIR" pull --ff-only
 else
   if [ -e "$INSTALL_DIR" ]; then
-    echo "Error: $INSTALL_DIR already exists but is not a Coco clone."
-    echo "Remove it manually or set COCO_DIR to a different path."
+    echo "Error: $INSTALL_DIR exists but is not a Coco clone." >&2
+    echo "Remove it manually or set COCO_DIR to a different path." >&2
     exit 1
   fi
   echo "Cloning Coco..."
-  git clone "$REPO_URL" "$INSTALL_DIR"
+  git clone --quiet "$REPO_URL" "$INSTALL_DIR"
 fi
 
-cd "$INSTALL_DIR"
+# ── Commit verification gate ─────────────────────────────────────────────────
+COMMIT_HASH="$(git -C "$INSTALL_DIR" rev-parse HEAD)"
+COMMIT_DATE="$(git -C "$INSTALL_DIR" log -1 --format='%ci' HEAD)"
+COMMIT_MSG="$(git -C "$INSTALL_DIR" log -1 --format='%s' HEAD)"
 
-if [ ! -f "install.sh" ]; then
-  echo "Error: install.sh not found."
+echo ""
+echo "┌─ Verify before you run ──────────────────────────────────────────────┐"
+echo "│  Commit : $COMMIT_HASH"
+echo "│  Date   : $COMMIT_DATE"
+echo "│  Message: $COMMIT_MSG"
+echo "│"
+echo "│  Confirm this matches the latest release on GitHub:"
+echo "│  https://github.com/rkz91/coco/commits/main"
+echo "└──────────────────────────────────────────────────────────────────────┘"
+echo ""
+
+if [[ -z "$YES" ]]; then
+  read -r -p "Proceed with installation? [y/N] " REPLY
+  case "$REPLY" in
+    [yY][eE][sS]|[yY]) ;;
+    *)
+      echo "Aborted. The clone is at $INSTALL_DIR — inspect it, then run:"
+      echo "  bash \"$INSTALL_DIR/install.sh\" ${PASS_THROUGH[*]+"${PASS_THROUGH[*]}"}"
+      exit 0
+      ;;
+  esac
+fi
+
+# ── Install ──────────────────────────────────────────────────────────────────
+if [ ! -f "$INSTALL_DIR/install.sh" ]; then
+  echo "Error: install.sh not found in cloned repo." >&2
   exit 1
 fi
 
-bash install.sh --adapter "$ADAPTER"
+bash "$INSTALL_DIR/install.sh" "${PASS_THROUGH[@]+"${PASS_THROUGH[@]}"}"
 
+echo ""
 echo "Coco installed successfully at $INSTALL_DIR"
+echo "Commit: $COMMIT_HASH"

--- a/skills/find-skills/SKILL.md
+++ b/skills/find-skills/SKILL.md
@@ -94,6 +94,18 @@ npx skills add <owner/repo@skill> -g -y
 
 The `-g` flag installs globally (user-level) and `-y` skips confirmation prompts.
 
+**Before you run this command on the user's behalf**, the `owner/repo@skill` identifier
+came from search results you don't control (skills.sh, GitHub) — an attacker can publish
+a well-named, well-described malicious package that ranks for a target query. Since `-y`
+skips the CLI's own confirmation prompt, you are the only checkpoint before code from an
+arbitrary third party lands on the user's machine. So:
+
+1. Display the exact resolved `owner/repo@skill` string, the repo URL, and a short
+   description/README excerpt to the user.
+2. Get an explicit affirmative reply that references that specific package — a prior
+   generic "yes, install it" from earlier in the conversation is not sufficient.
+3. Only then run the install command above.
+
 ## Common Skill Categories
 
 When searching, consider these common categories:


### PR DESCRIPTION
This lands @imachiever's work from #38. His three commits remain authored by **Rajat Bhatia <imachiever@gmail.com>**; this branch exists only because #38 could not be updated in place from here.

Supersedes #38. Please close that one in favour of this.

## His changes, unmodified

- **A confirmation gate in `bin/coco-bootstrap.sh`.** The installer is a curl-pipe-to-bash entry point, so it now clones first, prints the commit hash, date and message, and pauses for `[y/N]` before running `install.sh`. The default is fail-closed: anything other than `y`/`yes` aborts and tells you where the clone is so you can inspect it.
- **Two real shell bugs fixed in `adapters/cursor/install.sh`**: a `link_dir()` that could silently clobber a real file, and an `A && B || C` dry-run pattern that could execute the real command if the `echo` failed. Both are textbook SC2015 fixes.
- **Prompt-injection guidance** in `find-skills`, telling the agent to surface and confirm the resolved package name before running `npx skills add … -y` on someone's behalf.

## Two follow-ups I added, as a separate commit

**1. The remaining `rkz91` URLs are now `coco-research`.** This is the substantive one. That account renamed to `coco-research` on 2026-07-18 and an unrelated third party registered the vacated username the day before. Two of the three occurrences were the documented curl-pipe-to-bash install command and the "verify this commit" link, so if that account ever creates a repository named `coco`, both would have pointed at content they control. The third, `REPO_URL`, was already corrected on `main` and the rebase picked it up.

**2. `COCO_BOOTSTRAP_YES=0` used to SKIP the confirmation prompt.** The guard tested `-z "$YES"` (empty) rather than the value, so anyone setting `0` to mean "off" got the opposite of what they asked for. Now only the exact value `1`, or `--yes`, skips it.

Verified behaviourally: unset → prompt shown, `0` → prompt shown, `1` → prompt skipped.

## Verification

`bash -n` passes on the bootstrap script and every adapter installer. No `rkz91` references remain. `check-command-refs.sh`, `check-evidence-gate.sh` and the index-freshness check all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)