### PR TITLE
chore(release): bump Spec Version to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ Security contributions in this release are by [@imachiever](https://github.com/i
 
 - **Corrected asset counts** for the two new skills. Skills 147 to **149** (core 64 to **66**), total addressable assets 865 to **867**, core install 124 to **126** active assets.
 
+### Changed
+
+- **Bumped Spec Version 1.1.0 to 1.2.0** so that it tracks the release version.
+
 ---
 
 ## [1.1.0] — 2026-07-18

--- a/README.md
+++ b/README.md
@@ -612,7 +612,7 @@ npx @coco-research/coco-cli update
 ## Technical Specifications
 
 <table>
-<tr><td><strong>Spec Version</strong></td><td>1.1.0</td></tr>
+<tr><td><strong>Spec Version</strong></td><td>1.2.0</td></tr>
 <tr><td><strong>License</strong></td><td>Open-core — <a href="LICENSE">MIT</a> core; Super Intelligence is <a href="systems/superintelligence/LICENSE">proprietary</a></td></tr>
 <tr><td><strong>Total Skills</strong></td><td>149 with all bundles installed (66 Core + 68 GSD + 6 Brain + 9 Super Intelligence)</td></tr>
 <tr><td><strong>Slash Commands</strong></td><td>277 with all bundles — 35 Core (shipped) + 242 Super Intelligence (225 per-team + 17 cross-team, generated at install)</td></tr>


### PR DESCRIPTION
Bumps the README **Spec Version** field from 1.1.0 to 1.2.0, per maintainer direction, so that it tracks the release version.

In #50 I had left it at 1.1.0 on the reasoning that v1.2.0 adds skills and security fixes without changing any schema or contract, and flagged the assumption for review. The maintainer's call is that Spec Version should follow the release version, so this corrects it before the tag is cut.

The v1.2.0 CHANGELOG section now records the bump under `### Changed`. The historical reference to the 1.0.0 to 1.1.0 bump in the 1.1.0 section is left untouched, since it accurately describes that release.

Landing this before tagging so that `v1.2.0` contains the correct value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)