### PR TITLE
fix(formula): set real sha256 for v1.2.0 tarball

### DIFF
--- a/Formula/coco.rb
+++ b/Formula/coco.rb
@@ -15,7 +15,7 @@ class Coco < Formula
   desc "Open-source AI workflow framework — skills, agents, commands, multi-agent orchestration"
   homepage "https://github.com/coco-research/coco"
   url "https://github.com/coco-research/coco/archive/refs/tags/v1.2.0.tar.gz"
-  sha256 "0000000000000000000000000000000000000000000000000000000000000000" # set after v1.2.0 tag
+  sha256 "3ef5ebf532f6404a385f053e0ad36813ad08da1fc04249fb3e3e3ac79631528f"
   # Open-core: MIT core (see LICENSE) + proprietary Super Intelligence
   # (see systems/superintelligence/LICENSE). Not a single SPDX identifier.
   license :cannot_represent


### PR DESCRIPTION
Sets the Homebrew formula checksum now that the `v1.2.0` tag is published.

#50 deliberately shipped a zeroed placeholder, because GitHub only generates the source tarball once the tag exists, so the digest cannot be known in advance. This is the same two-step used for v1.1.0 in #43.

```
sha256 3ef5ebf532f6404a385f053e0ad36813ad08da1fc04249fb3e3e3ac79631528f
```

Verified by downloading `archive/refs/tags/v1.2.0.tar.gz` twice and confirming both digests match, against a 28,352,673-byte tarball that `file` confirms is real gzip data. `ruby -c Formula/coco.rb` reports Syntax OK.

With this merged, the Homebrew tap is safe to publish for v1.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)