### PR TITLE
docs(readme): describe coco-loop and scroll-world, document the bootstrap install gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ A standard install equips your workspace with a lightweight core; full activatio
 CoCo ships **149 skills** (66 core + 83 across bundles). These are not prompt snippets — each is a full agent instruction set with state management, verification logic, and error handling. A representative slice by category:
 
 ### Visual design & styling
-`ui-ux-pro-max` (50 styles, 21 palettes, 50 font pairings, 9 stacks) · `frontend-design` · `design-taste-frontend` · `redesign-existing-projects` · `axiom-liquid-glass` (Apple Liquid Glass, WWDC 2025) · `swiftui-liquid-glass` · `web-design-guidelines` · `tailwind-patterns` (Tailwind v4) · `vercel-react-best-practices` · `clone-website` · `c4-architecture` · `arb-review` · `expo-api-routes` · `ai-product`.
+`ui-ux-pro-max` (50 styles, 21 palettes, 50 font pairings, 9 stacks) · `frontend-design` · `design-taste-frontend` · `redesign-existing-projects` · `axiom-liquid-glass` (Apple Liquid Glass, WWDC 2025) · `swiftui-liquid-glass` · `web-design-guidelines` · `tailwind-patterns` (Tailwind v4) · `vercel-react-best-practices` · `clone-website` · `c4-architecture` · `arb-review` · `expo-api-routes` · `ai-product` · `scroll-world` (scroll-scrubbed, cut-free camera flythrough landing pages, generated end to end via Higgsfield).
 
 ### Engineering discipline & quality
 `brainstorming` · `writing-plans` · `executing-plans` · `subagent-driven-development` · `dispatching-parallel-agents` · `test-driven-development` · `systematic-debugging` · `requesting-code-review` · `receiving-code-review` · `verification-before-completion` · `finishing-a-development-branch` · `using-git-worktrees` · `code-verification` (7 bug-vector audit) · `generate-tests` · `api-design-principles` · `cli-anything` · `workflow-routing`.
@@ -202,7 +202,7 @@ CoCo ships **149 skills** (66 core + 83 across bundles). These are not prompt sn
 `coco-ads` (launch videos via HyperFrames) · `media-memory` (multimodal embeddings) · `doc-sync` · `ultra-think` · `browser-automation`.
 
 ### The CoCo platform itself
-`coco` (conversational router) · `coco-cli` · `skill-creator` · `writing-skills` · `find-skills`.
+`coco` (conversational router) · `coco-cli` · `coco-loop` (compiles a plain-language goal into a confirmed charter, then runs a bounded, propose-only autonomous loop) · `skill-creator` · `writing-skills` · `find-skills`.
 
 <details>
 <summary><strong>▸ Full catalog — every one of the 149 skills</strong></summary>
@@ -517,7 +517,21 @@ bash install.sh --adapter generic
 
 </td>
 </tr>
+<tr>
+<td colspan="2" valign="top">
+
+**One-line remote install**
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/coco-research/coco/main/bin/coco-bootstrap.sh)
+```
+*Clones Coco to `~/.coco`, then pauses and prints the commit hash, date, and message so you can verify it against [the latest commit on `main`](https://github.com/coco-research/coco/commits/main) before it runs `install.sh`. Type `y` to proceed. Pass `--yes` or set `COCO_BOOTSTRAP_YES=1` to skip the prompt for CI or scripted installs, and pass adapter/systems flags after `--`, e.g. `-- --adapter cursor --systems gsd`.*
+
+</td>
+</tr>
 </table>
+
+The install paths above are deliberately conservative: the remote bootstrap never runs code before you have confirmed the commit it cloned, `install.sh` only ever reads and symlinks files already inside the repository, the CI workflows that build and publish Coco pin their `setup-node` and `setup-python` Actions to commit SHAs rather than mutable tags, and nothing Coco does locally or in CI sends data anywhere. See [`SECURITY.md`](SECURITY.md) for the full policy.
 
 ---
 


### PR DESCRIPTION
Brings the README in line with what shipped in v1.2.0. Three real gaps, each verified against the tree rather than against the README's own claims.

**The remote bootstrap one-liner was undocumented.** `SECURITY.md` already refers to "the `bash <(curl -fsSL ...)` one-liner" as though the reader knows it exists, but the README never mentioned it. `git log -S"Quickest Install"` shows it was present before the rewrite in #22 and never came back after the confirmation gate landed in #49. There is now an "One-line remote install" row in the Installation Matrix giving the command, the confirmation-prompt behaviour, the `--yes` / `COCO_BOOTSTRAP_YES=1` bypass, and how to pass adapter and systems flags through it.

**The two new skills were invisible.** `coco-loop` and `scroll-world` appeared only inside the collapsed catalog block. Both now appear in the visible category slices with a short parenthetical.

**The security posture was scattered.** The confirmation gate, the pinned CI Actions, local-only execution and no telemetry each sat in disconnected places. One sentence after the Installation Matrix now ties them together and links `SECURITY.md`.

## A deliberate caveat on the pinning claim

Only `actions/setup-node` and `actions/setup-python` are pinned to full commit SHAs. `actions/checkout@v7` remains tag-pinned. The new wording names the two pinned actions rather than claiming blanket coverage, because the blanket claim would be false.

## Verified already correct, so left alone

Recounted independently against the tree: 149 skills (66 core, 68 GSD, 6 Brain, 9 Super Intelligence), 277 commands (35 core plus 242 generated), 34 agents, 389 personas across 9 departments and 70 cells, 15 rules, 3 workflows, 126 core-install assets, 867 total. All `--systems` and `--adapter` values, all internal links, and zero `rkz91` or `rijulkalra2000` references.

## Out of scope, reported not fixed

Three files carry stale counts and are worth a follow-up: `package.json` says 147 skills, `.claude-plugin.json` says "59 skills, 34 commands, 10 agents, 3 system bundles" which appears to date from v0.1.0, and `docs/getting-started.md` says "59 skills, 34 commands, 11 agents" and also omits the bootstrap one-liner.

## Gates

`check-command-refs.sh` PASS, `check-evidence-gate.sh` PASS, `build-index.py` regenerates with zero diff. Only `README.md` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)