### PR TITLE
feat(skills): add journey-map skill (owner's own)

### DIFF
--- a/skills/INDEX.md
+++ b/skills/INDEX.md
@@ -2,7 +2,7 @@
 
 Auto-generated. Run `python3 scripts/build-index.py` to refresh.
 
-**Total: 69 skills** (top-level only — see `systems/<bundle>/skills/` for bundle-only skills).
+**Total: 70 skills** (top-level only — see `systems/<bundle>/skills/` for bundle-only skills).
 
 ## Design
 
@@ -57,6 +57,7 @@ Auto-generated. Run `python3 scripts/build-index.py` to refresh.
 | [finishing-a-development-branch](finishing-a-development-branch/SKILL.md) | Use when implementation is complete, all tests pass, and you need to decide how to integrate the work - guides completion of development work by presenting stru |
 | [frontend-design](frontend-design/SKILL.md) | Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts,  |
 | [humanizer](humanizer/SKILL.md) | Remove signs of AI-generated writing from text. Use when editing or reviewing text to make it sound more natural and human-written. Based on Wikipedia's compreh |
+| [journey-map](journey-map/SKILL.md) | Loads full context for a React Flow (@xyflow/react) user journey mapping project. Use when working on, extending, debugging, or building features for the journe |
 | [karpathy-guidelines](karpathy-guidelines/SKILL.md) | Behavioral guidelines to reduce common LLM coding mistakes. Use when writing, reviewing, or refactoring code to avoid overcomplication, make surgical changes, s |
 | [meta:media](meta:media/SKILL.md) | Multimodal memory — ingest, embed, and search media (images, video, audio, files) with Gemini Embedding 2 + ChromaDB |
 | [openai-agents](openai-agents/SKILL.md) | Build AI applications with OpenAI Agents SDK - text agents, voice agents, multi-agent handoffs, tools with Zod schemas, guardrails, and streaming. Prevents 11 d |

--- a/skills/journey-map/SKILL.md
+++ b/skills/journey-map/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: journey-map
+description: >
+  Loads full context for a React Flow (@xyflow/react) user journey mapping
+  project. Use when working on, extending, debugging, or building features for
+  the journey map tool. Triggers on: "journey map project", "open journey map",
+  "work on journey map", "build user journey", "react flow journey project",
+  "journey-map app", or any request to add features like swimlanes,
+  emotion curves, persona nodes, touchpoints, or pain point markers.
+---
+
+# Journey Map Project
+
+## Project
+
+- **Locating it:** this skill does not assume a fixed install path. See
+  "Locating the Project" below before running any commands.
+- **Stack:** React 19 + Vite + TypeScript + `@xyflow/react` (React Flow v12)
+- **Purpose:** Rich user journey map tool for PMs and UX researchers
+
+## Locating the Project
+
+Before making changes, find the project root:
+
+1. If the user gives a path, use it.
+2. Otherwise search common locations, e.g.:
+   ```bash
+   find "$HOME" -maxdepth 5 -iname "journey-map" -type d 2>/dev/null
+   ```
+3. If nothing is found, ask the user where the project lives.
+
+## Dev Commands
+
+Run from the project root located above:
+
+```bash
+npm run dev      # start dev server (Vite)
+npm run build    # production build
+npm run preview  # preview build
+```
+
+## Stack
+
+Single package: `@xyflow/react` (React Flow v12). There is no AntV X6
+dependency — the project fully migrated off X6, and no `--legacy-peer-deps`
+flag is needed on React 19.
+
+See `references/packages.md` for imports, node pattern, layout constants, file structure.
+
+## Implemented Features
+
+| Feature | Mechanism |
+|---|---|
+| Swimlanes (persona rows) | `swimlaneBg` node type — wide colored band, zIndex=0 |
+| Stage headers + narratives | `stageHeader` / `stageNarr` node types |
+| Touchpoint cards | `touchpoint` node — seq badge, timing chip, emoji, title, badges |
+| Emotion curve | `EmotionCurve.tsx` SVG component below canvas |
+| Ad-hoc cross-flow | `AdHocFlow.tsx` component below canvas |
+| Pan + zoom | React Flow built-in |
+| Minimap | React Flow `<MiniMap>` |
+| Controls | React Flow `<Controls>` |
+| Persona focus/dim | `focusPersona` state → opacity on non-focused touchpoints |
+| Detail panel | Click touchpoint → slide-in right panel |
+
+## References
+
+- Full package list + versions + plugin roles: `references/packages.md`
+- React Flow (MIT licensed, https://github.com/xyflow/xyflow) is the only
+  graph engine this project uses.

--- a/skills/journey-map/references/packages.md
+++ b/skills/journey-map/references/packages.md
@@ -1,0 +1,94 @@
+# React Flow Package Reference
+
+> **Note:** Migrated from AntV X6 → `@xyflow/react` (React Flow v12). X6 removed entirely.
+
+## Installed Package
+
+| Package | Version | Role |
+|---|---|---|
+| `@xyflow/react` | ^12.x | Core graph engine — canvas, nodes, edges, pan/zoom/minimap/controls |
+
+## Key Imports
+
+```ts
+import {
+  ReactFlow,
+  ReactFlowProvider,
+  Background,
+  Controls,
+  MiniMap,
+  useNodesState,
+  useEdgesState,
+  type Node,
+  type NodeProps,
+  type NodeMouseHandler,
+} from '@xyflow/react'
+import '@xyflow/react/dist/style.css'
+```
+
+## Custom Node Pattern
+
+```tsx
+// 1. Define component
+function MyNode({ data }: { data: MyData }) {
+  return <div style={{ width: '100%', height: '100%' }}>...</div>
+}
+
+// 2. Register
+const nodeTypes = { myNode: MyNode }
+
+// 3. Use in ReactFlow
+<ReactFlow nodes={nodes} nodeTypes={nodeTypes} />
+```
+
+## Node Object Shape
+
+```ts
+{
+  id: 'unique-id',
+  type: 'myNode',                    // maps to nodeTypes key
+  position: { x: 100, y: 200 },
+  data: { ...yourData },
+  style: { width: 240, height: 200 }, // controls RF layout
+  draggable: true,
+  selectable: true,
+  connectable: false,
+  zIndex: 5,
+}
+```
+
+## Project Structure
+
+```
+src/
+├── data/journey.ts          ← all data + layout constants
+├── nodes/
+│   ├── StageHeaderNode.tsx  ← navy stage column header
+│   ├── StageNarrNode.tsx    ← dark narrative bar
+│   ├── LaneLabelNode.tsx    ← persona label (left col)
+│   ├── SwimlaneNode.tsx     ← colored bg band per persona
+│   └── TouchpointNode.tsx   ← main card (seq, timing, emoji, badges)
+├── utils/buildGraph.ts      ← generates nodes[] from data
+├── components/
+│   ├── EmotionCurve.tsx     ← SVG curve below canvas
+│   └── AdHocFlow.tsx        ← ad-hoc cross-flow section
+└── App.tsx                  ← ReactFlowProvider + layout
+```
+
+## Layout Constants (from data/journey.ts)
+
+```ts
+LABEL_W = 200    // lane label column width
+STAGE_W = 240    // each stage column width
+GAP     = 8      // gap between cells
+HEADER_H = 64    // stage header row height
+NARR_H   = 96    // stage narrative row height
+LANE_H   = 200   // persona lane height
+
+stageX(n) = LABEL_W + GAP + n * (STAGE_W + GAP)  // x of stage n
+laneY(i)  = HEADER_H + GAP + NARR_H + GAP + i * (LANE_H + GAP)  // y of lane i
+```
+
+## Peer Dep Note
+
+`@xyflow/react` v12 works cleanly with React 19. No `--legacy-peer-deps` needed.


### PR DESCRIPTION
Adds the owner's `journey-map` project-context loader (no upstream). Pre-publish fixes: removed a hardcoded absolute home path (now locates the project by name) and corrected stale AntV X6 references (project migrated to @xyflow/react / React Flow v12, MIT). No credits row (owner's own work). Regenerated index. Gates green; message genericized. Handoff Task 2.