### PR TITLE
docs: correct two published claims (brag license, persona validation gate)

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -13,7 +13,7 @@ CoCo stands on the shoulders of excellent open-source work. This file credits ev
 | **visual-explainer** by nicobailon | The `visual-explainer` skill — generates self-contained HTML diagrams, reviews, plans, recaps, and slide decks | https://github.com/nicobailon/visual-explainer | MIT |
 | **ai-website-cloner-template** by JCodesMore | The site-cloning structure behind the clone-website skill | https://github.com/JCodesMore/ai-website-cloner-template | See upstream |
 | **agents.md** community | The vendor-neutral agent context standard CoCo's adapters follow | https://agents.md/ | — |
-| **brag** by Shunit Haviv | The `coco-ads` launch-video skill — flow, tone presets, storyboard rubric, and bundled audio (vendored and re-voiced in CoCo's style) | https://github.com/latent-spaces/brag | No license published |
+| **brag** by Shunit Haviv Hakimi | The `coco-ads` launch-video skill — flow, tone presets, storyboard rubric, and bundled audio (vendored and re-voiced in CoCo's style); upstream MIT notice retained at `skills/coco-ads/LICENSE` | https://github.com/latent-spaces/brag | MIT (Copyright (c) 2026 Shunit Haviv Hakimi) |
 | **HyperFrames** by HeyGen | The HTML-composition + local render engine `coco-ads` drives via `npx hyperframes` (lint / validate / render) | https://www.npmjs.com/package/hyperframes | See upstream |
 | **"Happy Beats / Business Moves"** by ende.app | Bundled music beds used by `coco-ads` | https://ende.app | See upstream |
 | **Kenney.nl** | Bundled CC0 sound effects used by `coco-ads` | https://kenney.nl | CC0 (public domain) |

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The meta-orchestrator uses a staged algorithm so it never has to load the entire
 
 ### Persona build & validation pipeline
 
-The 389-persona roster was compiled with a systematic multi-tier workflow. Candidate generation was evaluated across local Qwen (via LM Studio), a hosted small model, and Gemini Flash, but **Claude research agents proved the quality winner** for resolving historical data and citing verifiable signal. Every persona then passes a validation gate (`validate_persona.py`) requiring at least 4 live, non-404 evidence URLs, a valid home team, zero fabricated quotes, and at least 2 verified recent signals (or persistent archetype signals for historical figures).
+The 389-persona roster was compiled with a systematic multi-tier workflow. Candidate generation was evaluated across local Qwen (via LM Studio), a hosted small model, and Gemini Flash, but **Claude research agents proved the quality winner** for resolving historical data and citing verifiable signal. Personas are checked by an advisory validation gate (`validate_persona.py`) that enforces five things: every required frontmatter field is present; at least 4 cited URLs resolve live (non-404); every `public_stance` carries an `evidence_url`, so no stance is uncited; at least 2 recent signals within 12 months (or 2 persistent signals for historical archetypes); and any `pairs_well_with` / `productive_conflict_with` slug refers to a real roster member. Two limits are worth stating plainly: the gate confirms that a stance is *cited*, not that a quotation is authentic, and `home_team` is only checked for presence, not validated against the list of real teams. A `NEEDS-TOPUP` verdict is advisory — it does not currently affect which personas a council selects at runtime.
 
 ---
 

--- a/skills/coco-ads/LICENSE
+++ b/skills/coco-ads/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Shunit Haviv Hakimi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/coco-ads/SKILL.md
+++ b/skills/coco-ads/SKILL.md
@@ -11,7 +11,7 @@ You built it. Now let CoCo make the ad.
 
 `/coco-ads` turns the current project into a short (15–25s), polished, shareable launch video using the HyperFrames toolchain, rendered **locally**. It is narrow, opinionated, and fast.
 
-> **Credit / lineage.** This skill adapts the launch-video flow from [**brag** by Shunit Haviv](https://github.com/latent-spaces/brag) and runs on the [**HyperFrames**](https://www.npmjs.com/package/hyperframes) HTML-composition + render engine by HeyGen. Bundled music is "Happy Beats / Business Moves" by ende.app; bundled SFX are CC0 (Kenney.nl). See [`CREDITS.md`](../../CREDITS.md). Re-implemented in CoCo's voice with attribution; upstream `brag` ships without an explicit license.
+> **Credit / lineage.** This skill adapts the launch-video flow from [**brag** by Shunit Haviv](https://github.com/latent-spaces/brag) and runs on the [**HyperFrames**](https://www.npmjs.com/package/hyperframes) HTML-composition + render engine by HeyGen. Bundled music is "Happy Beats / Business Moves" by ende.app; bundled SFX are CC0 (Kenney.nl). See [`CREDITS.md`](../../CREDITS.md). Re-implemented in CoCo's voice with attribution. Upstream `brag` is MIT-licensed (Copyright (c) 2026 Shunit Haviv Hakimi); its notice is retained at [`LICENSE`](LICENSE) in this skill directory.
 
 ## Requirements
 


### PR DESCRIPTION
Two factual errors currently visible to the public, both verified against source before changing.

**1. brag's license.** `CREDITS.md` said *"No license published"*. Upstream `latent-spaces/brag` is **MIT, Copyright (c) 2026 Shunit Haviv Hakimi** (verified via `gh api repos/latent-spaces/brag/license`). Corrected. `skills/coco-ads/SKILL.md` repeated the same false claim and is corrected too. Because `coco-ads` vendors brag's flow and bundled audio, brag's MIT notice is now retained at `skills/coco-ads/LICENSE` — MIT requires the notice to travel with substantial portions, and it was missing.

**2. The persona validation gate.** README claimed the gate requires *"a valid home team"* and *"zero fabricated quotes"*. Reading `validate_persona.py`, neither is accurate: `home_team` appears in `REQUIRED` and is therefore **presence-checked only**, never compared against the real team list; and the anti-fabrication check enforces that every `public_stance` carries an `evidence_url` — it establishes that a stance is *cited*, not that a quotation is authentic. The README now describes the five checks the code actually performs, and states that a `NEEDS-TOPUP` verdict is advisory and does not affect runtime persona selection.

Deliberately **not** included: asset-count reconciliation (`package.json`, `.claude-plugin.json`, `docs/getting-started.md`, registry counts). Those are being changed concurrently and must be reconciled in one dedicated pass against a settled tree.

Gates green.