### PR TITLE
fix(index): make the generator count the whole tree and stop emitting dead links

### DIFF
--- a/agents/INDEX.md
+++ b/agents/INDEX.md
@@ -2,6 +2,8 @@
 
 Auto-generated. Run `python3 scripts/build-index.py` to refresh.
 
+**Total: 34 agents** — 10 core, 24 across 1 bundles.
+
 ## Core agents (10)
 
 | Agent | Description |
@@ -17,31 +19,31 @@ Auto-generated. Run `python3 scripts/build-index.py` to refresh.
 | [typescript-pro](typescript-pro.md) | name: typescript-pro |
 | [ui-ux-designer](ui-ux-designer.md) | name: ui-ux-designer |
 
-## Bundle: systems (24 agents)
+## Bundle: gsd (24 agents)
 
 | Agent | Description |
 |-------|-------------|
-| [gsd-advisor-researcher](../systems/systems/agents/gsd-advisor-researcher.md) | name: gsd-advisor-researcher |
-| [gsd-assumptions-analyzer](../systems/systems/agents/gsd-assumptions-analyzer.md) | name: gsd-assumptions-analyzer |
-| [gsd-code-fixer](../systems/systems/agents/gsd-code-fixer.md) | name: gsd-code-fixer |
-| [gsd-code-reviewer](../systems/systems/agents/gsd-code-reviewer.md) | name: gsd-code-reviewer |
-| [gsd-codebase-mapper](../systems/systems/agents/gsd-codebase-mapper.md) | name: gsd-codebase-mapper |
-| [gsd-debugger](../systems/systems/agents/gsd-debugger.md) | name: gsd-debugger |
-| [gsd-doc-verifier](../systems/systems/agents/gsd-doc-verifier.md) | name: gsd-doc-verifier |
-| [gsd-doc-writer](../systems/systems/agents/gsd-doc-writer.md) | name: gsd-doc-writer |
-| [gsd-executor](../systems/systems/agents/gsd-executor.md) | name: gsd-executor |
-| [gsd-integration-checker](../systems/systems/agents/gsd-integration-checker.md) | name: gsd-integration-checker |
-| [gsd-intel-updater](../systems/systems/agents/gsd-intel-updater.md) | name: gsd-intel-updater |
-| [gsd-nyquist-auditor](../systems/systems/agents/gsd-nyquist-auditor.md) | name: gsd-nyquist-auditor |
-| [gsd-phase-researcher](../systems/systems/agents/gsd-phase-researcher.md) | name: gsd-phase-researcher |
-| [gsd-plan-checker](../systems/systems/agents/gsd-plan-checker.md) | name: gsd-plan-checker |
-| [gsd-planner](../systems/systems/agents/gsd-planner.md) | name: gsd-planner |
-| [gsd-project-researcher](../systems/systems/agents/gsd-project-researcher.md) | name: gsd-project-researcher |
-| [gsd-research-synthesizer](../systems/systems/agents/gsd-research-synthesizer.md) | name: gsd-research-synthesizer |
-| [gsd-roadmapper](../systems/systems/agents/gsd-roadmapper.md) | name: gsd-roadmapper |
-| [gsd-security-auditor](../systems/systems/agents/gsd-security-auditor.md) | name: gsd-security-auditor |
-| [gsd-ui-auditor](../systems/systems/agents/gsd-ui-auditor.md) | name: gsd-ui-auditor |
-| [gsd-ui-checker](../systems/systems/agents/gsd-ui-checker.md) | name: gsd-ui-checker |
-| [gsd-ui-researcher](../systems/systems/agents/gsd-ui-researcher.md) | name: gsd-ui-researcher |
-| [gsd-user-profiler](../systems/systems/agents/gsd-user-profiler.md) | name: gsd-user-profiler |
-| [gsd-verifier](../systems/systems/agents/gsd-verifier.md) | name: gsd-verifier |
+| [gsd-advisor-researcher](../systems/gsd/agents/gsd-advisor-researcher.md) | name: gsd-advisor-researcher |
+| [gsd-assumptions-analyzer](../systems/gsd/agents/gsd-assumptions-analyzer.md) | name: gsd-assumptions-analyzer |
+| [gsd-code-fixer](../systems/gsd/agents/gsd-code-fixer.md) | name: gsd-code-fixer |
+| [gsd-code-reviewer](../systems/gsd/agents/gsd-code-reviewer.md) | name: gsd-code-reviewer |
+| [gsd-codebase-mapper](../systems/gsd/agents/gsd-codebase-mapper.md) | name: gsd-codebase-mapper |
+| [gsd-debugger](../systems/gsd/agents/gsd-debugger.md) | name: gsd-debugger |
+| [gsd-doc-verifier](../systems/gsd/agents/gsd-doc-verifier.md) | name: gsd-doc-verifier |
+| [gsd-doc-writer](../systems/gsd/agents/gsd-doc-writer.md) | name: gsd-doc-writer |
+| [gsd-executor](../systems/gsd/agents/gsd-executor.md) | name: gsd-executor |
+| [gsd-integration-checker](../systems/gsd/agents/gsd-integration-checker.md) | name: gsd-integration-checker |
+| [gsd-intel-updater](../systems/gsd/agents/gsd-intel-updater.md) | name: gsd-intel-updater |
+| [gsd-nyquist-auditor](../systems/gsd/agents/gsd-nyquist-auditor.md) | name: gsd-nyquist-auditor |
+| [gsd-phase-researcher](../systems/gsd/agents/gsd-phase-researcher.md) | name: gsd-phase-researcher |
+| [gsd-plan-checker](../systems/gsd/agents/gsd-plan-checker.md) | name: gsd-plan-checker |
+| [gsd-planner](../systems/gsd/agents/gsd-planner.md) | name: gsd-planner |
+| [gsd-project-researcher](../systems/gsd/agents/gsd-project-researcher.md) | name: gsd-project-researcher |
+| [gsd-research-synthesizer](../systems/gsd/agents/gsd-research-synthesizer.md) | name: gsd-research-synthesizer |
+| [gsd-roadmapper](../systems/gsd/agents/gsd-roadmapper.md) | name: gsd-roadmapper |
+| [gsd-security-auditor](../systems/gsd/agents/gsd-security-auditor.md) | name: gsd-security-auditor |
+| [gsd-ui-auditor](../systems/gsd/agents/gsd-ui-auditor.md) | name: gsd-ui-auditor |
+| [gsd-ui-checker](../systems/gsd/agents/gsd-ui-checker.md) | name: gsd-ui-checker |
+| [gsd-ui-researcher](../systems/gsd/agents/gsd-ui-researcher.md) | name: gsd-ui-researcher |
+| [gsd-user-profiler](../systems/gsd/agents/gsd-user-profiler.md) | name: gsd-user-profiler |
+| [gsd-verifier](../systems/gsd/agents/gsd-verifier.md) | name: gsd-verifier |

--- a/commands/INDEX.md
+++ b/commands/INDEX.md
@@ -66,7 +66,7 @@ Auto-generated. Run `python3 scripts/build-index.py` to refresh.
 
 | Slash | Description |
 |-------|-------------|
-| [`/util:architecture-review`](util/architecture-review.md) |  |
+| [`/util:architecture-review`](util/architecture-review.md) | Comprehensive architecture review with design patterns analysis and improvement recommendations |
 | [`/util:create-architecture-documentation`](util/create-architecture-documentation.md) | Generate comprehensive architecture documentation with diagrams, ADRs, and interactive visualization |
 | [`/util:refactor-code`](util/refactor-code.md) |  |
 | [`/util:ss`](util/ss.md) | View the latest N screenshots from Desktop (default 1) |

--- a/commands/util/architecture-review.md
+++ b/commands/util/architecture-review.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Glob, Grep, Bash
-argument-hint: [scope] | --modules | --patterns | --dependencies | --security
+argument-hint: "[scope] | --modules | --patterns | --dependencies | --security"
 description: Comprehensive architecture review with design patterns analysis and improvement recommendations
 ---
 

--- a/scripts/build-index.py
+++ b/scripts/build-index.py
@@ -2,7 +2,8 @@
 """Auto-generate INDEX.md files from frontmatter.
 
 Generates:
-  skills/INDEX.md                    — full skill catalog
+  skills/INDEX.md                    — full skill catalog (core, grouped by domain,
+                                       then one section per bundle)
   commands/INDEX.md                  — full command catalog
   agents/INDEX.md                    — agent catalog
   systems/INDEX.md                   — system bundle catalog
@@ -10,8 +11,21 @@ Generates:
 
 Run from repo root:
   python3 scripts/build-index.py
+
+Counting rule: the only trustworthy oracle for "how many skills exist" is a walk of
+the whole tree. Narrow globs have twice produced undercounts here, because skills live
+in four structurally different places:
+
+  skills/<name>/SKILL.md                     core
+  systems/<bundle>/skills/<name>/SKILL.md    conventional bundle
+  systems/<bundle>/<name>/SKILL.md           superintelligence (no skills/ subdir)
+  adapters/<adapter>/skills/<name>/SKILL.md  adapter-specific
+
+If you add a fifth shape, add it to SKILL_SOURCES below, and check the printed total
+against `find . -name 'SKILL.md' -not -path './.git/*' | wc -l`.
 """
 
+import os
 import sys
 import pathlib
 import yaml
@@ -19,8 +33,25 @@ from collections import defaultdict
 
 ROOT = pathlib.Path(__file__).parent.parent.resolve()
 
+# (glob, index of the parent directory that names the bundle, or None for core skills)
+# Depths differ per shape, so the bundle index is declared alongside its glob rather
+# than assumed. Assuming one depth for all shapes is what produced a bundle literally
+# named "systems".
+SKILL_SOURCES = [
+    ('skills/*/SKILL.md', None),
+    ('systems/*/skills/*/SKILL.md', 2),
+    ('systems/*/*/SKILL.md', 1),
+    ('adapters/*/skills/*/SKILL.md', 2),
+]
 
-def parse_frontmatter(path):
+
+def parse_frontmatter(path, strict=True):
+    """Return the frontmatter mapping, or None when there is no frontmatter block.
+
+    A YAML syntax error is reported rather than swallowed. Returning None on a parse
+    error is indistinguishable from "this file has no frontmatter", which silently
+    produced blank description rows in the generated catalogs.
+    """
     text = path.read_text()
     if not text.startswith('---'):
         return None
@@ -29,25 +60,44 @@ def parse_frontmatter(path):
         return None
     try:
         return yaml.safe_load(parts[1]) or {}
-    except yaml.YAMLError:
+    except yaml.YAMLError as exc:
+        rel = path.relative_to(ROOT)
+        msg = str(exc).replace('\n', ' ')
+        if strict:
+            print(f'ERROR: {rel}: malformed YAML frontmatter: {msg}', file=sys.stderr)
+            raise SystemExit(1)
+        print(f'WARNING: {rel}: malformed YAML frontmatter: {msg}', file=sys.stderr)
         return None
+
+
+def link_from(index_dir, target_path):
+    """Relative link from a generated index to a repo-relative target path."""
+    return os.path.relpath(target_path, index_dir)
 
 
 def collect_skills():
     skills = []
-    for p in sorted(ROOT.glob('skills/*/SKILL.md')):
-        fm = parse_frontmatter(p) or {}
-        name = fm.get('name', p.parent.name)
-        desc = fm.get('description', '').strip().strip('"').strip("'")
-        domain = fm.get('domain', 'unspecified')
-        skills.append({'name': name, 'desc': desc, 'domain': domain, 'path': p.relative_to(ROOT)})
-
-    for p in sorted(ROOT.glob('systems/*/skills/*/SKILL.md')):
-        fm = parse_frontmatter(p) or {}
-        name = fm.get('name', p.parent.name)
-        desc = fm.get('description', '').strip().strip('"').strip("'")
-        bundle = p.parents[2].name
-        skills.append({'name': name, 'desc': desc, 'domain': f'system:{bundle}', 'path': p.relative_to(ROOT), 'bundle': bundle})
+    seen = set()
+    for glob, bundle_at in SKILL_SOURCES:
+        for p in sorted(ROOT.glob(glob)):
+            if p in seen:
+                continue
+            seen.add(p)
+            fm = parse_frontmatter(p) or {}
+            directory = p.parent.name
+            entry = {
+                # `name` is display text only, never a path. 26 skills have a
+                # frontmatter name that differs from their directory and 3 have none,
+                # which is what produced dead links when name was used as the href.
+                'name': fm.get('name') or directory,
+                'dir': directory,
+                'desc': (fm.get('description') or '').strip().strip('"').strip("'"),
+                'domain': fm.get('domain', 'unspecified'),
+                'path': p.relative_to(ROOT),
+            }
+            if bundle_at is not None:
+                entry['bundle'] = p.parents[bundle_at].name
+            skills.append(entry)
     return skills
 
 
@@ -57,13 +107,19 @@ def collect_commands():
         fm = parse_frontmatter(p) or {}
         ns = p.parent.name
         cname = p.stem
-        if cname == '_index':
-            slash = f'/{ns}'
-        else:
-            slash = f'/{ns}:{cname}'
-        desc = fm.get('description', '').strip().strip('"').strip("'") if fm else ''
-        commands.append({'slash': slash, 'namespace': ns, 'name': cname, 'desc': desc, 'path': p.relative_to(ROOT)})
+        slash = f'/{ns}' if cname == '_index' else f'/{ns}:{cname}'
+        desc = (fm.get('description') or '').strip().strip('"').strip("'") if fm else ''
+        commands.append({'slash': slash, 'namespace': ns, 'name': cname,
+                         'desc': desc, 'path': p.relative_to(ROOT)})
     return commands
+
+
+def _first_prose_line(path):
+    for line in path.read_text().split('\n'):
+        line = line.strip()
+        if line and not line.startswith('---') and not line.startswith('#'):
+            return line[:200]
+    return ''
 
 
 def collect_agents():
@@ -71,50 +127,55 @@ def collect_agents():
     for p in sorted(ROOT.glob('agents/*.md')):
         if p.name in ('README.md', 'INDEX.md'):
             continue
-        text = p.read_text()
-        first_line = ''
-        for line in text.split('\n'):
-            line = line.strip()
-            if line and not line.startswith('---') and not line.startswith('#'):
-                first_line = line[:200]
-                break
-        agents.append({'name': p.stem, 'desc': first_line, 'path': p.relative_to(ROOT)})
+        agents.append({'name': p.stem, 'desc': _first_prose_line(p),
+                       'path': p.relative_to(ROOT)})
 
+    # systems/<bundle>/agents/<name>.md is three levels deep, so the bundle is
+    # parents[1]. parents[2] here yields the literal string "systems", which produced
+    # 24 links to a nonexistent systems/systems/agents/ directory.
     for p in sorted(ROOT.glob('systems/*/agents/*.md')):
-        bundle = p.parents[2].name
-        text = p.read_text()
-        first_line = ''
-        for line in text.split('\n'):
-            line = line.strip()
-            if line and not line.startswith('---') and not line.startswith('#'):
-                first_line = line[:200]
-                break
-        agents.append({'name': p.stem, 'desc': first_line, 'path': p.relative_to(ROOT), 'bundle': bundle})
+        if p.name in ('README.md', 'INDEX.md'):
+            continue
+        agents.append({'name': p.stem, 'desc': _first_prose_line(p),
+                       'path': p.relative_to(ROOT), 'bundle': p.parents[1].name})
     return agents
+
+
+def _skill_table(rows):
+    return ['| Skill | Description |', '|-------|-------------|'] + rows
 
 
 def write_skills_index(skills):
     out = ROOT / 'skills' / 'INDEX.md'
+    core = [s for s in skills if 'bundle' not in s]
     by_domain = defaultdict(list)
+    for s in core:
+        by_domain[s['domain']].append(s)
+    by_bundle = defaultdict(list)
     for s in skills:
         if 'bundle' in s:
-            continue
-        by_domain[s['domain']].append(s)
+            by_bundle[s['bundle']].append(s)
 
     lines = ['# Skills Index', '',
-             f'Auto-generated. Run `python3 scripts/build-index.py` to refresh.', '',
-             f'**Total: {sum(len(v) for v in by_domain.values())} skills** (top-level only — see `systems/<bundle>/skills/` for bundle-only skills).', '']
+             'Auto-generated. Run `python3 scripts/build-index.py` to refresh.', '',
+             f'**Total: {len(skills)} skills** — {len(core)} core, '
+             f'{len(skills) - len(core)} across {len(by_bundle)} bundles.', '']
 
-    for domain in sorted(by_domain.keys()):
-        lines.append(f'## {domain.title()}')
-        lines.append('')
-        lines.append('| Skill | Description |')
-        lines.append('|-------|-------------|')
-        for s in sorted(by_domain[domain], key=lambda x: x['name']):
-            link = f'[{s["name"]}]({s["name"]}/SKILL.md)'
+    def rows(items):
+        built = []
+        for s in sorted(items, key=lambda x: x['dir']):
+            href = link_from('skills', s['path'])
             desc = s['desc'].replace('\n', ' ').replace('|', '\\|')[:160]
-            lines.append(f'| {link} | {desc} |')
-        lines.append('')
+            built.append(f'| [{s["name"]}]({href}) | {desc} |')
+        return built
+
+    for domain in sorted(by_domain):
+        lines += [f'## {domain.title()} ({len(by_domain[domain])})', '']
+        lines += _skill_table(rows(by_domain[domain])) + ['']
+
+    for bundle in sorted(by_bundle):
+        lines += [f'## Bundle: {bundle} ({len(by_bundle[bundle])} skills)', '']
+        lines += _skill_table(rows(by_bundle[bundle])) + ['']
 
     out.write_text('\n'.join(lines))
     print(f'Wrote {out.relative_to(ROOT)}')
@@ -127,14 +188,11 @@ def write_commands_index(commands):
         by_ns[c['namespace']].append(c)
 
     lines = ['# Commands Index', '',
-             f'Auto-generated. Run `python3 scripts/build-index.py` to refresh.', '',
+             'Auto-generated. Run `python3 scripts/build-index.py` to refresh.', '',
              f'**Total: {len(commands)} commands across {len(by_ns)} namespaces.**', '']
 
-    for ns in sorted(by_ns.keys()):
-        lines.append(f'## {ns}')
-        lines.append('')
-        lines.append('| Slash | Description |')
-        lines.append('|-------|-------------|')
+    for ns in sorted(by_ns):
+        lines += [f'## {ns}', '', '| Slash | Description |', '|-------|-------------|']
         for c in sorted(by_ns[ns], key=lambda x: x['name']):
             link = f'[`{c["slash"]}`]({ns}/{c["name"]}.md)'
             desc = c['desc'].replace('\n', ' ').replace('|', '\\|')[:160]
@@ -154,26 +212,84 @@ def write_agents_index(agents):
             by_bundle[a['bundle']].append(a)
 
     lines = ['# Agents Index', '',
-             f'Auto-generated. Run `python3 scripts/build-index.py` to refresh.', '']
+             'Auto-generated. Run `python3 scripts/build-index.py` to refresh.', '',
+             f'**Total: {len(agents)} agents** — {len(top)} core, '
+             f'{len(agents) - len(top)} across {len(by_bundle)} bundles.', '']
+
+    def emit(heading, items):
+        block = [heading, '', '| Agent | Description |', '|-------|-------------|']
+        for a in sorted(items, key=lambda x: x['name']):
+            href = link_from('agents', a['path'])
+            desc = a['desc'].replace('|', '\\|')[:160]
+            block.append(f'| [{a["name"]}]({href}) | {desc} |')
+        return block + ['']
 
     if top:
-        lines += [f'## Core agents ({len(top)})', '',
-                  '| Agent | Description |',
-                  '|-------|-------------|']
-        for a in sorted(top, key=lambda x: x['name']):
-            desc = a['desc'].replace('|', '\\|')[:160]
-            lines.append(f'| [{a["name"]}]({a["name"]}.md) | {desc} |')
-        lines.append('')
+        lines += emit(f'## Core agents ({len(top)})', top)
+    for bundle in sorted(by_bundle):
+        lines += emit(f'## Bundle: {bundle} ({len(by_bundle[bundle])} agents)',
+                      by_bundle[bundle])
 
-    for bundle in sorted(by_bundle.keys()):
-        lines += [f'## Bundle: {bundle} ({len(by_bundle[bundle])} agents)', '',
-                  '| Agent | Description |',
-                  '|-------|-------------|']
-        for a in sorted(by_bundle[bundle], key=lambda x: x['name']):
-            desc = a['desc'].replace('|', '\\|')[:160]
-            link = f'[{a["name"]}](../systems/{bundle}/agents/{a["name"]}.md)'
-            lines.append(f'| {link} | {desc} |')
-        lines.append('')
+    out.write_text('\n'.join(lines))
+    print(f'Wrote {out.relative_to(ROOT)}')
+
+
+def write_systems_index(skills, agents):
+    """Catalog every bundle-like container under systems/ and adapters/.
+
+    The module docstring promised this file for a long time without it ever being
+    written, which left bundles the least legible part of the repository.
+    """
+    out = ROOT / 'systems' / 'INDEX.md'
+    skills_by_bundle = defaultdict(int)
+    for s in skills:
+        if 'bundle' in s:
+            skills_by_bundle[s['bundle']] += 1
+    agents_by_bundle = defaultdict(int)
+    for a in agents:
+        if 'bundle' in a:
+            agents_by_bundle[a['bundle']] += 1
+
+    containers = []
+    for base in ('systems', 'adapters'):
+        base_dir = ROOT / base
+        if not base_dir.is_dir():
+            continue
+        for d in sorted(p for p in base_dir.iterdir() if p.is_dir()):
+            n_cmds = (len(list(d.glob('commands/*.md')))
+                      + len(list(d.glob('commands/*/*.md'))))
+            containers.append({
+                'base': base,
+                'name': d.name,
+                'skills': skills_by_bundle.get(d.name, 0),
+                'agents': agents_by_bundle.get(d.name, 0),
+                'commands': n_cmds,
+                'files': sum(1 for f in d.rglob('*') if f.is_file()),
+            })
+
+    lines = ['# System Bundles Index', '',
+             'Auto-generated. Run `python3 scripts/build-index.py` to refresh.', '',
+             'Bundles under `systems/` are opt-in via `install.sh --systems <name>`. '
+             'Directories under `adapters/` ship with their adapter instead and are not '
+             'selectable with that flag.', '',
+             '| Bundle | Location | Skills | Agents | Commands | Files |',
+             '|--------|----------|-------:|-------:|---------:|------:|']
+    for c in containers:
+        lines.append(f'| {c["name"]} | `{c["base"]}/{c["name"]}/` | {c["skills"]} '
+                     f'| {c["agents"]} | {c["commands"]} | {c["files"]} |')
+    lines.append('')
+
+    # Only flag inert entries under systems/. An adapter with no bundle skills is
+    # normal — adapters install the framework itself and were never --systems targets,
+    # so listing them here would misrepresent them as broken.
+    inert = [c['name'] for c in containers
+             if c['base'] == 'systems'
+             and c['skills'] == 0 and c['agents'] == 0 and c['commands'] == 0]
+    if inert:
+        lines += ['> **Advertised as a bundle but installs no artifacts:** '
+                  + ', '.join(f'`{n}`' for n in inert)
+                  + '. These directories hold documentation only, so passing them to '
+                    '`--systems` has no effect.', '']
 
     out.write_text('\n'.join(lines))
     print(f'Wrote {out.relative_to(ROOT)}')
@@ -184,24 +300,21 @@ def write_by_domain_views(skills):
     out_dir.mkdir(parents=True, exist_ok=True)
     by_domain = defaultdict(list)
     for s in skills:
-        if 'bundle' in s:
-            continue
         by_domain[s['domain']].append(s)
 
     for domain, items in by_domain.items():
-        if domain == 'unspecified':
+        if domain == 'unspecified' or domain.startswith('system:'):
             continue
         slug = domain.replace('/', '-')
         out = out_dir / f'{slug}.md'
         lines = [f'# {domain.title()} skills', '',
                  f'Auto-generated view. Filtered to `domain: {domain}` skills.', '',
                  f'**{len(items)} skills.**', '',
-                 '| Skill | Description |',
-                 '|-------|-------------|']
-        for s in sorted(items, key=lambda x: x['name']):
+                 '| Skill | Description |', '|-------|-------------|']
+        for s in sorted(items, key=lambda x: x['dir']):
+            href = link_from('docs/by-domain', s['path'])
             desc = s['desc'].replace('|', '\\|')[:200]
-            link = f'[{s["name"]}](../../skills/{s["name"]}/SKILL.md)'
-            lines.append(f'| {link} | {desc} |')
+            lines.append(f'| [{s["name"]}]({href}) | {desc} |')
         out.write_text('\n'.join(lines))
         print(f'Wrote {out.relative_to(ROOT)}')
 
@@ -214,8 +327,10 @@ def main():
     write_skills_index(skills)
     write_commands_index(commands)
     write_agents_index(agents)
+    write_systems_index(skills, agents)
     write_by_domain_views(skills)
-    print(f'\nDone. Skills: {len(skills)} · Commands: {len(commands)} · Agents: {len(agents)}')
+    print(f'\nDone. Skills: {len(skills)} · Commands: {len(commands)} · '
+          f'Agents: {len(agents)}')
 
 
 if __name__ == '__main__':

--- a/skills/INDEX.md
+++ b/skills/INDEX.md
@@ -2,15 +2,15 @@
 
 Auto-generated. Run `python3 scripts/build-index.py` to refresh.
 
-**Total: 68 skills** (top-level only — see `systems/<bundle>/skills/` for bundle-only skills).
+**Total: 179 skills** — 68 core, 111 across 6 bundles.
 
-## Design
+## Design (1)
 
 | Skill | Description |
 |-------|-------------|
 | [tailwind-patterns](tailwind-patterns/SKILL.md) | Tailwind CSS v4 principles. CSS-first configuration, container queries, modern patterns, design token architecture. Use when building with Tailwind v4 or migrat |
 
-## Engineering
+## Engineering (3)
 
 | Skill | Description |
 |-------|-------------|
@@ -18,31 +18,31 @@ Auto-generated. Run `python3 scripts/build-index.py` to refresh.
 | [c4-architecture](c4-architecture/SKILL.md) | Generate architecture documentation using C4 model Mermaid diagrams. Use when asked to create architecture diagrams, document system architecture, visualize sof |
 | [generate-tests](generate-tests/SKILL.md) | Generate complete test coverage for any file, component, or module. Covers unit tests, integration tests, edge cases, error handling, and mocking — adapted to w |
 
-## Foundational
+## Foundational (2)
 
 | Skill | Description |
 |-------|-------------|
 | [coco](coco/SKILL.md) | CoCo — your AI PM brain. Unified interface wrapping skills, commands, and knowledge tools. Invoke /coco to activate. |
 | [ultra-think](ultra-think/SKILL.md) | Deep, multi-dimensional analysis and problem solving. Activates systematic reasoning across technical, business, user, and system perspectives. Generates multip |
 
-## Pm
+## Pm (1)
 
 | Skill | Description |
 |-------|-------------|
 | [ai-product](ai-product/SKILL.md) | Expert in shipping production-grade AI-powered features — LLM integration patterns, RAG architecture, prompt engineering that scales, AI UX that users trust, sa |
 
-## Unspecified
+## Unspecified (61)
 
 | Skill | Description |
 |-------|-------------|
-| [OpenAI Apps MCP](OpenAI Apps MCP/SKILL.md) | Build ChatGPT apps with MCP servers on Cloudflare Workers. Extend ChatGPT with custom tools and interactive widgets (HTML/JS UI).  Use when: developing ChatGPT  |
-| [PRD Mastery: Context-Aware, Expert-Driven, and Token-Efficient Refinement](PRD Mastery: Context-Aware, Expert-Driven, and Token-Efficient Refinement/SKILL.md) | A skill that blends the wisdom of top industry experts, ensures token-efficient PRDs, and organizes outputs in a clear folder structure. |
 | [agent-lightning](agent-lightning/SKILL.md) | Train and optimize AI agents using Microsoft's Agent Lightning framework with reinforcement learning. Use when setting up agent training, instrumenting agents w |
 | [ai-marketing-videos](ai-marketing-videos/SKILL.md) | Create AI marketing videos for ads, promos, product launches, and brand content. Models: Veo, Seedance, Wan, FLUX for visuals, Kokoro for voiceover. Types: prod |
 | [api-design-principles](api-design-principles/SKILL.md) | Master REST and GraphQL API design principles to build intuitive, scalable, and maintainable APIs that delight developers. Use when designing new APIs, reviewin |
+| [pmstudio-arb](arb-review/SKILL.md) | Generate an Architecture Review Board (ARB) presentation in Coco Inc's standard 11-slide format. Use when someone asks to "create an ARB deck", "architecture re |
 | [axiom-liquid-glass](axiom-liquid-glass/SKILL.md) | Apple Liquid Glass design system — comprehensive design philosophy, implementation guide, and technical API reference from WWDC 2025. Covers design principles ( |
 | [brainstorming](brainstorming/SKILL.md) | You MUST use this before any creative work - creating features, building components, adding functionality, or modifying behavior. Explores user intent, requirem |
 | [browser-automation](browser-automation/SKILL.md) | Browser automation for AI agents. Two providers — agent-browser (local CLI with Playwright) and agentic-browser (cloud via inference.sh). Both use the same @e r |
+| [pmstudio-changelog](change-log/SKILL.md) | Create or update a structured change log for a product or platform. Use when someone asks to "create a change log", "log this change", "what changed", "update t |
 | [cli-anything](cli-anything/SKILL.md) | Wrap any command-line tool into a JSON-emitting agent skill. Use when you want to make a CLI reliably callable and parseable by an AI agent — introspect its --h |
 | [clone-website](clone-website/SKILL.md) | Clone any website into a pixel-perfect single-file HTML prototype. Extracts design tokens, assets, CSS computed styles, interaction patterns, and content via Pl |
 | [coco-ads](coco-ads/SKILL.md) | Turn the project you just shipped into a short, polished, shareable launch video (an "ad") using HyperFrames. Use when someone says "/coco-ads", "make a launch  |
@@ -51,35 +51,35 @@ Auto-generated. Run `python3 scripts/build-index.py` to refresh.
 | [code-verification](code-verification/SKILL.md) | Post-implementation verification system that catches AI-introduced bugs. Covers 7 categories — TDZ errors, import mismatches, reference integrity, dead code, Re |
 | [design-taste-frontend](design-taste-frontend/SKILL.md) | Anti-slop frontend skill for landing pages, portfolios, and redesigns. The agent reads the brief, infers the right design direction, and ships interfaces that d |
 | [dispatching-parallel-agents](dispatching-parallel-agents/SKILL.md) | Use when facing 2+ independent tasks that can be worked on without shared state or sequential dependencies |
+| [pmstudio-sync](doc-sync/SKILL.md) | Use when a project has linked documentation artifacts (PRDs, presentations, meeting notes, architecture maps) that must stay synchronized. Detects which source  |
+| [pmstudio-dr](dr-plan/SKILL.md) | Generate a Disaster Recovery plan with RTO/RPO targets. Use when someone asks to "create a DR plan", "disaster recovery", "business continuity", or "RTO RPO". D |
 | [executing-plans](executing-plans/SKILL.md) | Use when you have a written implementation plan to execute in a separate session with review checkpoints |
 | [expo-api-routes](expo-api-routes/SKILL.md) | Guidelines for creating API routes in Expo Router with EAS Hosting |
 | [find-skills](find-skills/SKILL.md) | Helps users discover and install agent skills when they ask questions like "how do I do X", "find a skill for X", "is there a skill that can...", or express int |
 | [finishing-a-development-branch](finishing-a-development-branch/SKILL.md) | Use when implementation is complete, all tests pass, and you need to decide how to integrate the work - guides completion of development work by presenting stru |
 | [frontend-design](frontend-design/SKILL.md) | Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts,  |
 | [humanizer](humanizer/SKILL.md) | Remove signs of AI-generated writing from text. Use when editing or reviewing text to make it sound more natural and human-written. Based on Wikipedia's compreh |
+| [pmstudio-irp](irp/SKILL.md) | Generate an Incident Response Plan (IRP) with severity classification, escalation procedures, and communication templates. Use when someone asks to "create an i |
 | [journey-map](journey-map/SKILL.md) | Loads full context for a React Flow (@xyflow/react) user journey mapping project. Use when working on, extending, debugging, or building features for the journe |
 | [karpathy-guidelines](karpathy-guidelines/SKILL.md) | Behavioral guidelines to reduce common LLM coding mistakes. Use when writing, reviewing, or refactoring code to avoid overcomplication, make surgical changes, s |
-| [meta:media](meta:media/SKILL.md) | Multimodal memory — ingest, embed, and search media (images, video, audio, files) with Gemini Embedding 2 + ChromaDB |
+| [meta:media](media-memory/SKILL.md) | Multimodal memory — ingest, embed, and search media (images, video, audio, files) with Gemini Embedding 2 + ChromaDB |
+| [pmstudio-meeting-notes](meeting-notes/SKILL.md) | Generate structured meeting notes from transcripts or pasted text. Use when someone says "meeting notes", "process this transcript", "summarize this call", "not |
+| [pmstudio-nfr](nfr-tracker/SKILL.md) | Detailed completeness audit of all project documents. Use when someone asks "are we ready for production", "audit our docs", "readiness check", "nfr tracker", o |
 | [openai-agents](openai-agents/SKILL.md) | Build AI applications with OpenAI Agents SDK - text agents, voice agents, multi-agent handoffs, tools with Zod schemas, guardrails, and streaming. Prevents 11 d |
 | [openai-api](openai-api/SKILL.md) | Build with OpenAI stateless APIs - Chat Completions (GPT-5.2, o3), Realtime voice, Batch API (50% savings), Embeddings, DALL-E 3, Whisper, and TTS. Prevents 16  |
+| [OpenAI Apps MCP](openai-apps-mcp/SKILL.md) | Build ChatGPT apps with MCP servers on Cloudflare Workers. Extend ChatGPT with custom tools and interactive widgets (HTML/JS UI).  Use when: developing ChatGPT  |
 | [openai-whisper](openai-whisper/SKILL.md) | Speech-to-text transcription via OpenAI Whisper. Supports two modes — Local CLI (no API key, runs on-device) and Cloud API (fast, scalable, requires OPENAI_API_ |
 | [pmstudio](pmstudio/SKILL.md) | PM Studio command center. Use for a quick overview of available commands and document inventory. Use when someone says "pmstudio", "show commands", "what can I  |
-| [pmstudio-arb](pmstudio-arb/SKILL.md) | Generate an Architecture Review Board (ARB) presentation in Coco Inc's standard 11-slide format. Use when someone asks to "create an ARB deck", "architecture re |
-| [pmstudio-changelog](pmstudio-changelog/SKILL.md) | Create or update a structured change log for a product or platform. Use when someone asks to "create a change log", "log this change", "what changed", "update t |
-| [pmstudio-comms](pmstudio-comms/SKILL.md) | Generate templated stakeholder communications from project context. Use when someone asks to "write a go-live email", "create a status update", "onboard someone |
-| [pmstudio-dr](pmstudio-dr/SKILL.md) | Generate a Disaster Recovery plan with RTO/RPO targets. Use when someone asks to "create a DR plan", "disaster recovery", "business continuity", or "RTO RPO". D |
-| [pmstudio-init](pmstudio-init/SKILL.md) | Use when starting a new project, onboarding to an existing product, or setting up a documentation ecosystem for any initiative. Scaffolds the standard document  |
-| [pmstudio-irp](pmstudio-irp/SKILL.md) | Generate an Incident Response Plan (IRP) with severity classification, escalation procedures, and communication templates. Use when someone asks to "create an i |
-| [pmstudio-meeting-notes](pmstudio-meeting-notes/SKILL.md) | Generate structured meeting notes from transcripts or pasted text. Use when someone says "meeting notes", "process this transcript", "summarize this call", "not |
-| [pmstudio-nfr](pmstudio-nfr/SKILL.md) | Detailed completeness audit of all project documents. Use when someone asks "are we ready for production", "audit our docs", "readiness check", "nfr tracker", o |
-| [pmstudio-recovery](pmstudio-recovery/SKILL.md) | Generate detailed service restoration runbooks with step-by-step procedures. Use when someone asks to "create recovery procedures", "restoration runbook", "reco |
-| [pmstudio-sync](pmstudio-sync/SKILL.md) | Use when a project has linked documentation artifacts (PRDs, presentations, meeting notes, architecture maps) that must stay synchronized. Detects which source  |
 | [prd-generator](prd-generator/SKILL.md) | Generate comprehensive Product Requirements Documents (PRDs) for product managers. Use this skill when users ask to "create a PRD", "write product requirements" |
+| [PRD Mastery: Context-Aware, Expert-Driven, and Token-Efficient Refinement](prd-mastery/SKILL.md) | A skill that blends the wisdom of top industry experts, ensures token-efficient PRDs, and organizes outputs in a clear folder structure. |
+| [pmstudio-init](project-docs/SKILL.md) | Use when starting a new project, onboarding to an existing product, or setting up a documentation ecosystem for any initiative. Scaffolds the standard document  |
 | [receiving-code-review](receiving-code-review/SKILL.md) | Use when receiving code review feedback, before implementing suggestions, especially if feedback seems unclear or technically questionable - requires technical  |
+| [pmstudio-recovery](recovery-plan/SKILL.md) | Generate detailed service restoration runbooks with step-by-step procedures. Use when someone asks to "create recovery procedures", "restoration runbook", "reco |
 | [redesign-existing-projects](redesign-existing-projects/SKILL.md) | Upgrades existing websites and apps to premium quality. Audits current design, identifies generic AI patterns, and applies high-end design standards without bre |
 | [requesting-code-review](requesting-code-review/SKILL.md) | Use when completing tasks, implementing major features, or before merging to verify work meets requirements |
 | [scroll-world](scroll-world/SKILL.md) | Build an immersive scroll-scrubbed "fly through the world" landing page for any industry or brand using Higgsfield. As the visitor scrolls, a pre-rendered camer |
 | [skill-creator](skill-creator/SKILL.md) | Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends Claude's capabil |
+| [pmstudio-comms](stakeholder-comms/SKILL.md) | Generate templated stakeholder communications from project context. Use when someone asks to "write a go-live email", "create a status update", "onboard someone |
 | [subagent-driven-development](subagent-driven-development/SKILL.md) | Use when executing implementation plans with independent tasks in the current session |
 | [swiftui-liquid-glass](swiftui-liquid-glass/SKILL.md) | Implement, review, or improve SwiftUI features using the iOS 26+ Liquid Glass API. Use when asked to adopt Liquid Glass in new SwiftUI UI, refactor an existing  |
 | [systematic-debugging](systematic-debugging/SKILL.md) | Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes |
@@ -96,3 +96,144 @@ Auto-generated. Run `python3 scripts/build-index.py` to refresh.
 | [workflow-routing](workflow-routing/SKILL.md) | Use at the start of any task to route between Superpowers skills and GSD commands based on project state, task scope, and context signals. Fires before other sk |
 | [writing-plans](writing-plans/SKILL.md) | Use when you have a spec or requirements for a multi-step task, before touching code |
 | [writing-skills](writing-skills/SKILL.md) | Use when creating new skills, editing existing skills, or verifying skills work before deployment |
+
+## Bundle: brain (6 skills)
+
+| Skill | Description |
+|-------|-------------|
+| [brain](../systems/brain/skills/brain/SKILL.md) | SQLite-based project knowledge tracker. Manages entities, relationships, tasks, threads, decisions, and events per project folder. Use /brain to query or update |
+| [brain:export](../systems/brain/skills/brain-export/SKILL.md) | Auto-generate a slim CLAUDE.local.md from brain DB. Preserves manual behavior rules. Produces ~1,200 token auto-generated context section with key people, syste |
+| [brain:init](../systems/brain/skills/brain-init/SKILL.md) | Initialize a project_brain.db in the current project folder. Creates the database, project record, then scans existing files (CLAUDE.local.md, memory files, doc |
+| [brain:rescan](../systems/brain/skills/brain-rescan/SKILL.md) | Incremental rescan of project folder. Detects new/changed files since last scan, extracts knowledge from CLAUDE.local.md, memory files, and doc inventory, and u |
+| [brain:update](../systems/brain/skills/brain-update/SKILL.md) | End-of-session brain flush. Scans the full conversation, extracts all new entities, decisions, tasks, events, relationships, and updates, presents a summary, an |
+| [brain:wiki](../systems/brain/skills/brain-wiki/SKILL.md) | Browse, search, and generate Wikipedia-style knowledge articles from the brain. Auto-generated from brain DB entities, emails, docs, and decisions. |
+
+## Bundle: cognee (3 skills)
+
+| Skill | Description |
+|-------|-------------|
+| [cognee](../systems/cognee/skills/cognee/SKILL.md) | Knowledge graph memory backend powered by Cognee. Query, status check, dataset management, and backend switching between Brain and Cognee. Triggers on: 'cognee' |
+| [cognee:recall](../systems/cognee/skills/cognee-recall/SKILL.md) | Semantic and graph search across Cognee knowledge graph. Queries project memory, finds related entities and decisions, injects results as agent context. Trigger |
+| [cognee:store](../systems/cognee/skills/cognee-store/SKILL.md) | Push project knowledge into the Cognee knowledge graph. Stores entities, decisions, events, relationships, and session context. End-of-session flush that extrac |
+
+## Bundle: cursor (5 skills)
+
+| Skill | Description |
+|-------|-------------|
+| [create-rule](../adapters/cursor/skills/create-rule/SKILL.md) | Create Cursor rules for persistent AI guidance. Use when the user wants to create a rule, add coding standards, set up project conventions, configure file-speci |
+| [create-skill](../adapters/cursor/skills/create-skill/SKILL.md) | Guides users through creating effective Agent Skills for Cursor. Use when the user wants to create, write, or author a new skill, or asks about skill structure, |
+| [create-subagent](../adapters/cursor/skills/create-subagent/SKILL.md) | Create custom subagents for specialized AI tasks. Use when the user wants to create a new type of subagent, set up task-specific agents, configure code reviewer |
+| [migrate-to-skills](../adapters/cursor/skills/migrate-to-skills/SKILL.md) | Convert 'Applied intelligently' Cursor rules (.cursor/rules/*.mdc) and slash commands (.cursor/commands/*.md) to Agent Skills format (.cursor/skills/). Use when |
+| [update-cursor-settings](../adapters/cursor/skills/update-cursor-settings/SKILL.md) | Modify Cursor/VSCode user settings in settings.json. Use when the user wants to change editor settings, preferences, configuration, themes, font size, tab size, |
+
+## Bundle: gsd (68 skills)
+
+| Skill | Description |
+|-------|-------------|
+| [gsd-add-backlog](../systems/gsd/skills/gsd-add-backlog/SKILL.md) | Add an idea to the backlog parking lot (999.x numbering) |
+| [gsd-add-phase](../systems/gsd/skills/gsd-add-phase/SKILL.md) | Add phase to end of current milestone in roadmap |
+| [gsd-add-tests](../systems/gsd/skills/gsd-add-tests/SKILL.md) | Generate tests for a completed phase based on UAT criteria and implementation |
+| [gsd-add-todo](../systems/gsd/skills/gsd-add-todo/SKILL.md) | Capture idea or task as todo from current conversation context |
+| [gsd-analyze-dependencies](../systems/gsd/skills/gsd-analyze-dependencies/SKILL.md) | Analyze phase dependencies and suggest Depends on entries for ROADMAP.md |
+| [gsd-audit-fix](../systems/gsd/skills/gsd-audit-fix/SKILL.md) | Autonomous audit-to-fix pipeline — find issues, classify, fix, test, commit |
+| [gsd-audit-milestone](../systems/gsd/skills/gsd-audit-milestone/SKILL.md) | Audit milestone completion against original intent before archiving |
+| [gsd-audit-uat](../systems/gsd/skills/gsd-audit-uat/SKILL.md) | Cross-phase audit of all outstanding UAT and verification items |
+| [gsd-autonomous](../systems/gsd/skills/gsd-autonomous/SKILL.md) | Run all remaining phases autonomously — discuss→plan→execute per phase |
+| [gsd-check-todos](../systems/gsd/skills/gsd-check-todos/SKILL.md) | List pending todos and select one to work on |
+| [gsd-cleanup](../systems/gsd/skills/gsd-cleanup/SKILL.md) | Archive accumulated phase directories from completed milestones |
+| [gsd-code-review](../systems/gsd/skills/gsd-code-review/SKILL.md) | Review source files changed during a phase for bugs, security issues, and code quality problems |
+| [gsd-code-review-fix](../systems/gsd/skills/gsd-code-review-fix/SKILL.md) | Auto-fix issues found by code review in REVIEW.md. Spawns fixer agent, commits each fix atomically, produces REVIEW-FIX.md summary. |
+| [gsd-complete-milestone](../systems/gsd/skills/gsd-complete-milestone/SKILL.md) | Archive completed milestone and prepare for next version |
+| [gsd-debug](../systems/gsd/skills/gsd-debug/SKILL.md) | Systematic debugging with persistent state across context resets |
+| [gsd-discuss-phase](../systems/gsd/skills/gsd-discuss-phase/SKILL.md) | Gather phase context through adaptive questioning before planning. Use --auto to skip interactive questions (Claude picks recommended defaults). Use --chain for |
+| [gsd-do](../systems/gsd/skills/gsd-do/SKILL.md) | Route freeform text to the right GSD command automatically |
+| [gsd-docs-update](../systems/gsd/skills/gsd-docs-update/SKILL.md) | Generate or update project documentation verified against the codebase |
+| [gsd-execute-phase](../systems/gsd/skills/gsd-execute-phase/SKILL.md) | Execute all plans in a phase with wave-based parallelization |
+| [gsd-explore](../systems/gsd/skills/gsd-explore/SKILL.md) | Socratic ideation and idea routing — think through ideas before committing to plans |
+| [gsd-fast](../systems/gsd/skills/gsd-fast/SKILL.md) | Execute a trivial task inline — no subagents, no planning overhead |
+| [gsd-forensics](../systems/gsd/skills/gsd-forensics/SKILL.md) | Post-mortem investigation for failed GSD workflows — analyzes git history, artifacts, and state to diagnose what went wrong |
+| [gsd-health](../systems/gsd/skills/gsd-health/SKILL.md) | Diagnose planning directory health and optionally repair issues |
+| [gsd-help](../systems/gsd/skills/gsd-help/SKILL.md) | Show available GSD commands and usage guide |
+| [gsd-import](../systems/gsd/skills/gsd-import/SKILL.md) | Ingest external plans with conflict detection against project decisions before writing anything. |
+| [gsd-insert-phase](../systems/gsd/skills/gsd-insert-phase/SKILL.md) | Insert urgent work as decimal phase (e.g., 72.1) between existing phases |
+| [gsd-intel](../systems/gsd/skills/gsd-intel/SKILL.md) | Query, inspect, or refresh codebase intelligence files in .planning/intel/ |
+| [gsd-join-discord](../systems/gsd/skills/gsd-join-discord/SKILL.md) | Join the GSD Discord community |
+| [gsd-list-phase-assumptions](../systems/gsd/skills/gsd-list-phase-assumptions/SKILL.md) | Surface Claude's assumptions about a phase approach before planning |
+| [gsd-list-workspaces](../systems/gsd/skills/gsd-list-workspaces/SKILL.md) | List active GSD workspaces and their status |
+| [gsd-manager](../systems/gsd/skills/gsd-manager/SKILL.md) | Interactive command center for managing multiple phases from one terminal |
+| [gsd-map-codebase](../systems/gsd/skills/gsd-map-codebase/SKILL.md) | Analyze codebase with parallel mapper agents to produce .planning/codebase/ documents |
+| [gsd-milestone-summary](../systems/gsd/skills/gsd-milestone-summary/SKILL.md) | Generate a comprehensive project summary from milestone artifacts for team onboarding and review |
+| [gsd-new-milestone](../systems/gsd/skills/gsd-new-milestone/SKILL.md) | Start a new milestone cycle — update PROJECT.md and route to requirements |
+| [gsd-new-project](../systems/gsd/skills/gsd-new-project/SKILL.md) | Initialize a new project with deep context gathering and PROJECT.md |
+| [gsd-new-workspace](../systems/gsd/skills/gsd-new-workspace/SKILL.md) | Create an isolated workspace with repo copies and independent .planning/ |
+| [gsd-next](../systems/gsd/skills/gsd-next/SKILL.md) | Automatically advance to the next logical step in the GSD workflow |
+| [gsd-note](../systems/gsd/skills/gsd-note/SKILL.md) | Zero-friction idea capture. Append, list, or promote notes to todos. |
+| [gsd-pause-work](../systems/gsd/skills/gsd-pause-work/SKILL.md) | Create context handoff when pausing work mid-phase |
+| [gsd-plan-milestone-gaps](../systems/gsd/skills/gsd-plan-milestone-gaps/SKILL.md) | Create phases to close all gaps identified by milestone audit |
+| [gsd-plan-phase](../systems/gsd/skills/gsd-plan-phase/SKILL.md) | Create detailed phase plan (PLAN.md) with verification loop |
+| [gsd-plant-seed](../systems/gsd/skills/gsd-plant-seed/SKILL.md) | Capture a forward-looking idea with trigger conditions — surfaces automatically at the right milestone |
+| [gsd-pr-branch](../systems/gsd/skills/gsd-pr-branch/SKILL.md) | Create a clean PR branch by filtering out .planning/ commits — ready for code review |
+| [gsd-profile-user](../systems/gsd/skills/gsd-profile-user/SKILL.md) | Generate developer behavioral profile and create Claude-discoverable artifacts |
+| [gsd-progress](../systems/gsd/skills/gsd-progress/SKILL.md) | Check project progress, show context, and route to next action (execute or plan) |
+| [gsd-quick](../systems/gsd/skills/gsd-quick/SKILL.md) | Execute a quick task with GSD guarantees (atomic commits, state tracking) but skip optional agents |
+| [gsd-reapply-patches](../systems/gsd/skills/gsd-reapply-patches/SKILL.md) | Reapply local modifications after a GSD update |
+| [gsd-remove-phase](../systems/gsd/skills/gsd-remove-phase/SKILL.md) | Remove a future phase from roadmap and renumber subsequent phases |
+| [gsd-remove-workspace](../systems/gsd/skills/gsd-remove-workspace/SKILL.md) | Remove a GSD workspace and clean up worktrees |
+| [gsd-research-phase](../systems/gsd/skills/gsd-research-phase/SKILL.md) | Research how to implement a phase (standalone - usually use /gsd-plan-phase instead) |
+| [gsd-resume-work](../systems/gsd/skills/gsd-resume-work/SKILL.md) | Resume work from previous session with full context restoration |
+| [gsd-review](../systems/gsd/skills/gsd-review/SKILL.md) | Request cross-AI peer review of phase plans from external AI CLIs |
+| [gsd-review-backlog](../systems/gsd/skills/gsd-review-backlog/SKILL.md) | Review and promote backlog items to active milestone |
+| [gsd-scan](../systems/gsd/skills/gsd-scan/SKILL.md) | Rapid codebase assessment — lightweight alternative to /gsd-map-codebase |
+| [gsd-secure-phase](../systems/gsd/skills/gsd-secure-phase/SKILL.md) | Retroactively verify threat mitigations for a completed phase |
+| [gsd-session-report](../systems/gsd/skills/gsd-session-report/SKILL.md) | Generate a session report with token usage estimates, work summary, and outcomes |
+| [gsd-set-profile](../systems/gsd/skills/gsd-set-profile/SKILL.md) | Switch model profile for GSD agents (quality/balanced/budget/inherit) |
+| [gsd-settings](../systems/gsd/skills/gsd-settings/SKILL.md) | Configure GSD workflow toggles and model profile |
+| [gsd-ship](../systems/gsd/skills/gsd-ship/SKILL.md) | Create PR, run review, and prepare for merge after verification passes |
+| [gsd-stats](../systems/gsd/skills/gsd-stats/SKILL.md) | Display project statistics — phases, plans, requirements, git metrics, and timeline |
+| [gsd-thread](../systems/gsd/skills/gsd-thread/SKILL.md) | Manage persistent context threads for cross-session work |
+| [gsd-ui-phase](../systems/gsd/skills/gsd-ui-phase/SKILL.md) | Generate UI design contract (UI-SPEC.md) for frontend phases |
+| [gsd-ui-review](../systems/gsd/skills/gsd-ui-review/SKILL.md) | Retroactive 6-pillar visual audit of implemented frontend code |
+| [gsd-undo](../systems/gsd/skills/gsd-undo/SKILL.md) | Safe git revert. Roll back phase or plan commits using the phase manifest with dependency checks. |
+| [gsd-update](../systems/gsd/skills/gsd-update/SKILL.md) | Update GSD to latest version with changelog display |
+| [gsd-validate-phase](../systems/gsd/skills/gsd-validate-phase/SKILL.md) | Retroactively audit and fill Nyquist validation gaps for a completed phase |
+| [gsd-verify-work](../systems/gsd/skills/gsd-verify-work/SKILL.md) | Validate built features through conversational UAT |
+| [gsd-workstreams](../systems/gsd/skills/gsd-workstreams/SKILL.md) | Manage parallel workstreams — list, create, switch, status, progress, complete, and resume |
+
+## Bundle: hyperframes (20 skills)
+
+| Skill | Description |
+|-------|-------------|
+| [embedded-captions](../systems/hyperframes/skills/embedded-captions/SKILL.md) | Add captions or subtitles to an existing single-subject talking-head video without editing the footage. Use for plain verbatim captions, cinematic captions embe |
+| [faceless-explainer](../systems/hyperframes/skills/faceless-explainer/SKILL.md) | Turn arbitrary text — an article, notes, a topic, a brief — into a faceless explainer video: there is no site or footage to capture, so the visuals are invented |
+| [figma](../systems/hyperframes/skills/figma/SKILL.md) | Import Figma content into a HyperFrames composition — rendered assets, brand tokens, components, storyboard sections → reconstructed motion (frames read as stat |
+| [general-video](../systems/hyperframes/skills/general-video/SKILL.md) | Author or edit a custom HyperFrames composition when no specialized workflow fits, or when BRIEF.md sets flow: companion. Use for longer or multi-scene pieces,  |
+| [hyperframes](../systems/hyperframes/skills/hyperframes/SKILL.md) | Mandatory entry point: read this first for any request to make, create, edit, animate, or render a video, animation, or motion graphic, including a promo, expla |
+| [hyperframes-animation](../systems/hyperframes/skills/hyperframes-animation/SKILL.md) | All animation knowledge for HyperFrames — atomic motion rules, multi-phase scene blueprints, scene transitions, broader motion-design techniques, AND the seven  |
+| [hyperframes-cli](../systems/hyperframes/skills/hyperframes-cli/SKILL.md) | Use the HyperFrames CLI development loop: init, add, catalog, capture, lint, check, snapshot, compare, grade-compare, preview, play, present, beats, keyframes,  |
+| [hyperframes-core](../systems/hyperframes/skills/hyperframes-core/SKILL.md) | The HyperFrames composition contract — build one renderable project. Use for composition structure, the `data-*` timing attributes, `class="clip"`, tracks, sub- |
+| [hyperframes-creative](../systems/hyperframes/skills/hyperframes-creative/SKILL.md) | Non-animation creative direction for HyperFrames videos. Use for design spec (frame.md / design.md) handling, palettes, typography, narration, beat planning, au |
+| [hyperframes-keyframes](../systems/hyperframes/skills/hyperframes-keyframes/SKILL.md) | Use when a HyperFrames composition needs seek-safe 2D/3D keyframes, GSAP timelines, CSS keyframes, Anime.js, WAAPI, FLIP, paths, masks, SVG morph/draw, text tra |
+| [hyperframes-registry](../systems/hyperframes/skills/hyperframes-registry/SKILL.md) | Install, discover, and wire registry blocks and components into HyperFrames compositions. Use when running hyperframes add or hyperframes catalog, installing on |
+| [media-use](../systems/hyperframes/skills/media-use/SKILL.md) | Agent Media OS, the single skill for every media need in a HyperFrames project. Resolve BGM, SFX, image, icon, brand logo, voice, color grade, or LUT into a fro |
+| [motion-graphics](../systems/hyperframes/skills/motion-graphics/SKILL.md) | A short, design-led motion graphic where motion is the message — kinetic typography, stat count-up, chart/data-viz hit, logo sting / brand lockup, lower-third / |
+| [music-to-video](../systems/hyperframes/skills/music-to-video/SKILL.md) | Turn a music track (an audio file, a video to pull audio from, or a track generated from a mood brief) into a beat-synced video — lyric video, slideshow, or kin |
+| [pr-to-video](../systems/hyperframes/skills/pr-to-video/SKILL.md) | Turn a GitHub pull request (a PR URL, owner/repo#N, or 'this PR' in a checked-out repo) into a code-change explainer video — changelog, feature reveal, fix, or  |
+| [product-launch-video](../systems/hyperframes/skills/product-launch-video/SKILL.md) | Turn a product or marketing URL, pasted script, or brief into a product launch / promo video — SaaS promos, feature reveals, product demos, app and company laun |
+| [remotion-to-hyperframes](../systems/hyperframes/skills/remotion-to-hyperframes/SKILL.md) | Port an existing Remotion (React) composition's source to HyperFrames HTML. Use ONLY on an explicit ask to port/convert/migrate/translate a Remotion source — on |
+| [slideshow](../systems/hyperframes/skills/slideshow/SKILL.md) | Author a HyperFrames slideshow — a presentation, pitch deck, or interactive deck with discrete slides, fragment reveals, branching, hotspot navigation, and buil |
+| [talking-head-recut](../systems/hyperframes/skills/talking-head-recut/SKILL.md) | Package an existing talking-head / interview / podcast video with timed, designed GRAPHIC OVERLAY cards — kinetic titles, lower-thirds, data callouts, quotes, s |
+| [website-to-video](../systems/hyperframes/skills/website-to-video/SKILL.md) | Capture a general website/URL and turn it into a video OF the site — tour, showcase, or social clip built from captured screenshots and the site's own brand ass |
+
+## Bundle: superintelligence (9 skills)
+
+| Skill | Description |
+|-------|-------------|
+| [ai](../systems/superintelligence/ai/SKILL.md) |  |
+| [data-analytics-super-intelligence](../systems/superintelligence/data-analytics/SKILL.md) |  |
+| [engineering](../systems/superintelligence/engineering/SKILL.md) |  |
+| [finance-super-intelligence](../systems/superintelligence/finance/SKILL.md) |  |
+| [gtm-super-intelligence](../systems/superintelligence/gtm/SKILL.md) |  |
+| [product-design](../systems/superintelligence/product-design/SKILL.md) |  |
+| [risk-compliance-super-intelligence](../systems/superintelligence/risk-compliance/SKILL.md) |  |
+| [strategy-super-intelligence](../systems/superintelligence/strategy/SKILL.md) |  |
+| [trading-super-intelligence](../systems/superintelligence/trading/SKILL.md) |  |

--- a/systems/INDEX.md
+++ b/systems/INDEX.md
@@ -1,0 +1,21 @@
+# System Bundles Index
+
+Auto-generated. Run `python3 scripts/build-index.py` to refresh.
+
+Bundles under `systems/` are opt-in via `install.sh --systems <name>`. Directories under `adapters/` ship with their adapter instead and are not selectable with that flag.
+
+| Bundle | Location | Skills | Agents | Commands | Files |
+|--------|----------|-------:|-------:|---------:|------:|
+| brain | `systems/brain/` | 6 | 0 | 0 | 18 |
+| cognee | `systems/cognee/` | 3 | 0 | 0 | 4 |
+| gsd | `systems/gsd/` | 68 | 24 | 0 | 93 |
+| hyperframes | `systems/hyperframes/` | 20 | 0 | 0 | 928 |
+| superintelligence | `systems/superintelligence/` | 9 | 0 | 0 | 1159 |
+| team | `systems/team/` | 0 | 0 | 0 | 2 |
+| claude-code | `adapters/claude-code/` | 0 | 0 | 0 | 3 |
+| codex | `adapters/codex/` | 0 | 0 | 0 | 3 |
+| cursor | `adapters/cursor/` | 5 | 0 | 0 | 8 |
+| generic | `adapters/generic/` | 0 | 0 | 0 | 3 |
+| vscode-continue | `adapters/vscode-continue/` | 0 | 0 | 0 | 3 |
+
+> **Advertised as a bundle but installs no artifacts:** `team`. These directories hold documentation only, so passing them to `--systems` has no effect.


### PR DESCRIPTION
## Why

`scripts/build-index.py` reported **165** skills where the tree holds **179**, and every count claim in the repository derives from that number. Worse, the CI step "Verify INDEX is up to date" enforced the wrong output as canonical — regenerating produced a clean tree, so the undercount looked correct.

This is upstream of every other counting problem in the repo. Fix the ruler before trusting any measurement it produced.

## Six defects, all in the generator

**1. Narrow globs.** `collect_skills()` globbed only `skills/*/SKILL.md` and `systems/*/skills/*/SKILL.md`. Two whole locations were invisible: `adapters/*/skills/*/SKILL.md` (5 skills) and `systems/*/*/SKILL.md` (9 superintelligence team skills, which have **no** `skills/` subdirectory). The four shapes now live in one `SKILL_SOURCES` table that declares each glob alongside the parent index naming its bundle, because the depths genuinely differ — and assuming one depth for all of them is what caused defect 4.

**2. Bundled skills were discarded.** `write_skills_index()` and `write_by_domain_views()` both contained `if 'bundle' in s: continue`, dropping all 111 bundled skills from every skill index. They are now grouped under `## Bundle: <name>` headings, reusing the shape `write_agents_index()` already used rather than inventing new grouping code.

**3. Links were built from the frontmatter name, not the directory.** 26 skills have a `name` that differs from their directory and 3 have none at all, producing **13 dead links** in `skills/INDEX.md`. Paths are now computed with `os.path.relpath` from the real file location, so they are correct from any index depth.

**4. The agents bundle was off by one.** `systems/<bundle>/agents/<name>.md` is three levels deep, so `parents[2]` resolved to the literal string `systems` — giving `agents/INDEX.md` a bundle named "systems" and **24 links** into a nonexistent `systems/systems/agents/` directory.

**5. `systems/INDEX.md` was promised and never written.** The module docstring advertised a bundle catalogue that did not exist, leaving bundles the least legible part of the repo. `write_systems_index()` now emits one — and it automatically flags any directory advertised as a bundle that installs no artifacts.

**6. A YAML parse error was silently swallowed.** `parse_frontmatter()` caught `yaml.YAMLError` and returned `None`, which is indistinguishable from "this file has no frontmatter". It now names the file and the error and exits non-zero. That immediately surfaced the real cause of a blank description row: `commands/util/architecture-review.md` had an unquoted `argument-hint` whose pipe characters YAML read as a block-scalar indicator. Quoting it restores the description.

## Verification

Every command run and its output read, not inferred from an exit code.

| Check | Before | After |
|---|---|---|
| `find . -name 'SKILL.md' -not -path './.git/*' \| wc -l` | 179 | 179 |
| `python3 scripts/build-index.py` reports | **165** | **179** |
| Dead links across all generated indexes | **37** (13 skills + 24 agents) | **0** of 220 |
| `systems/INDEX.md` | absent | present |
| Generator run twice | — | byte-identical output |
| `bash tests/check-command-refs.sh` | PASS | PASS |
| `bash tests/check-evidence-gate.sh` | PASS | PASS |
| `bash tests/smoke.sh` | 18/0 | 18/0 |
| `arch-index` fixtures | 15/15 | 15/15 |
| All four adapter dry-runs | exit 0 | exit 0 |

## What the new index shows

`skills/INDEX.md` now accounts for all 179 as **68 core + 111 across 6 bundles**. `systems/INDEX.md` renders the bundle table and emits:

> **Advertised as a bundle but installs no artifacts:** `team`

which surfaces a real finding automatically rather than requiring an audit to notice it.

One thing deliberately left visible rather than fixed: 61 of the 68 core skills group under **Unspecified**, because they lack the `domain` field that `CONTRIBUTING.md:47` and `docs/guides/migration.md:194` both declare **required**. That backfill is separate work. This change makes the gap legible instead of hiding it behind a filter.

## Not in scope

Stale count claims in `README.md`, `package.json`, `.claude-plugin.json` and `docs/` are untouched. They should be corrected from measurement once this generator is trustworthy, and correcting them in the same PR that changes the measuring tool would make the diff impossible to review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)