### PR TITLE
feat(skills): implement the declared domain taxonomy across every core skill

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,9 +88,13 @@ deprecated: <reason>           # if set, artifact is hidden from default views
 | `meta` | Tooling about tooling (skill creation, artifact lint) |
 
 Domain is used to:
-- Generate `docs/by-domain/<domain>.md` indexes
-- Filter listings (`coco list skills --domain=pm`)
-- Apply role-based install flags (`install.sh --domains pm,foundational`)
+- Generate `docs/by-domain/<domain>.md` indexes, and group `skills/INDEX.md` by domain.
+  Both are produced by `scripts/build-index.py`.
+
+Domain-based *filtering* is not implemented. There is no `coco list` subcommand and
+`install.sh` accepts no `--domains` flag; earlier revisions of this document described
+both as though they existed. Every skill now declares a domain, so either could be
+built on top of that, but neither ships today.
 
 ### Adapters
 

--- a/docs/by-domain/design.md
+++ b/docs/by-domain/design.md
@@ -2,8 +2,23 @@
 
 Auto-generated view. Filtered to `domain: design` skills.
 
-**1 skills.**
+**14 skills.**
 
 | Skill | Description |
 |-------|-------------|
+| [ai-marketing-videos](../../skills/ai-marketing-videos/SKILL.md) | Create AI marketing videos for ads, promos, product launches, and brand content.
+Models: Veo, Seedance, Wan, FLUX for visuals, Kokoro for voiceover.
+Types: product demos, testimonials, explainers, soc |
+| [axiom-liquid-glass](../../skills/axiom-liquid-glass/SKILL.md) | Apple Liquid Glass design system — comprehensive design philosophy, implementation guide, and technical API reference from WWDC 2025. Covers design principles (iOS-native glass hierarchy, restraint ov |
+| [clone-website](../../skills/clone-website/SKILL.md) | Clone any website into a pixel-perfect single-file HTML prototype. Extracts design tokens, assets, CSS computed styles, interaction patterns, and content via Playwright. Outputs a self-contained HTML  |
+| [coco-ads](../../skills/coco-ads/SKILL.md) | Turn the project you just shipped into a short, polished, shareable launch video (an "ad") using HyperFrames. Use when someone says "/coco-ads", "make a launch video", "brag about this", "turn this in |
+| [design-taste-frontend](../../skills/design-taste-frontend/SKILL.md) | Anti-slop frontend skill for landing pages, portfolios, and redesigns. The agent reads the brief, infers the right design direction, and ships interfaces that do not look templated. Real design system |
+| [frontend-design](../../skills/frontend-design/SKILL.md) | Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples inclu |
+| [journey-map](../../skills/journey-map/SKILL.md) | Loads full context for a React Flow (@xyflow/react) user journey mapping project. Use when working on, extending, debugging, or building features for the journey map tool. Triggers on: "journey map pr |
+| [redesign-existing-projects](../../skills/redesign-existing-projects/SKILL.md) | Upgrades existing websites and apps to premium quality. Audits current design, identifies generic AI patterns, and applies high-end design standards without breaking functionality. Works with any CSS  |
+| [scroll-world](../../skills/scroll-world/SKILL.md) | Build an immersive scroll-scrubbed "fly through the world" landing page for any industry or brand using Higgsfield. As the visitor scrolls, a pre-rendered camera flies from outside each scene into its |
+| [swiftui-liquid-glass](../../skills/swiftui-liquid-glass/SKILL.md) | Implement, review, or improve SwiftUI features using the iOS 26+ Liquid Glass API. Use when asked to adopt Liquid Glass in new SwiftUI UI, refactor an existing feature to Liquid Glass, or review Liqui |
 | [tailwind-patterns](../../skills/tailwind-patterns/SKILL.md) | Tailwind CSS v4 principles. CSS-first configuration, container queries, modern patterns, design token architecture. Use when building with Tailwind v4 or migrating from v3. |
+| [ui-ux-pro-max](../../skills/ui-ux-pro-max/SKILL.md) | UI/UX design intelligence. 50 styles, 21 palettes, 50 font pairings, 20 charts, 9 stacks (React, Next.js, Vue, Svelte, SwiftUI, React Native, Flutter, Tailwind, shadcn/ui). Actions: plan, build, creat |
+| [visual-explainer](../../skills/visual-explainer/SKILL.md) | Generate self-contained HTML visual explanations for systems, code changes, plans, data, and technical concepts. Use for diagrams, architecture overviews, diff or plan reviews, project recaps, compari |
+| [web-design-guidelines](../../skills/web-design-guidelines/SKILL.md) | Review UI code for Web Interface Guidelines compliance. Use when asked to "review my UI", "check accessibility", "audit design", "review UX", or "check my site against best practices". |

--- a/docs/by-domain/engineering.md
+++ b/docs/by-domain/engineering.md
@@ -2,10 +2,33 @@
 
 Auto-generated view. Filtered to `domain: engineering` skills.
 
-**3 skills.**
+**20 skills.**
 
 | Skill | Description |
 |-------|-------------|
+| [agent-lightning](../../skills/agent-lightning/SKILL.md) | Train and optimize AI agents using Microsoft's Agent Lightning framework with reinforcement learning. Use when setting up agent training, instrumenting agents with tracing, configuring LightningStore, |
+| [api-design-principles](../../skills/api-design-principles/SKILL.md) | Master REST and GraphQL API design principles to build intuitive, scalable, and maintainable APIs that delight developers. Use when designing new APIs, reviewing API specifications, or establishing AP |
 | [arch-index](../../skills/arch-index/SKILL.md) | Build and validate .arch/index.json — a committed map from each architectural component of this repository to the real directories and files that implement it, pinned to a git commit, with every path  |
+| [browser-automation](../../skills/browser-automation/SKILL.md) | Browser automation for AI agents. Two providers — agent-browser (local CLI with Playwright) and agentic-browser (cloud via inference.sh). Both use the same @e ref-based workflow for navigating pages,  |
 | [c4-architecture](../../skills/c4-architecture/SKILL.md) | Generate architecture documentation using C4 model Mermaid diagrams. Use when asked to create architecture diagrams, document system architecture, visualize software structure, or generate context/con |
+| [code-verification](../../skills/code-verification/SKILL.md) | Post-implementation verification system that catches AI-introduced bugs. Covers 7 categories — TDZ errors, import mismatches, reference integrity, dead code, React state/effects, mock isolation, and C |
+| [expo-api-routes](../../skills/expo-api-routes/SKILL.md) | Guidelines for creating API routes in Expo Router with EAS Hosting |
+| [finishing-a-development-branch](../../skills/finishing-a-development-branch/SKILL.md) | Use when implementation is complete, all tests pass, and you need to decide how to integrate the work - guides completion of development work by presenting structured options for merge, PR, or cleanup |
 | [generate-tests](../../skills/generate-tests/SKILL.md) | Generate complete test coverage for any file, component, or module. Covers unit tests, integration tests, edge cases, error handling, and mocking — adapted to whatever testing framework the project us |
+| [meta:media](../../skills/media-memory/SKILL.md) | Multimodal memory — ingest, embed, and search media (images, video, audio, files) with Gemini Embedding 2 + ChromaDB |
+| [openai-agents](../../skills/openai-agents/SKILL.md) | Build AI applications with OpenAI Agents SDK - text agents, voice agents, multi-agent handoffs, tools with Zod schemas, guardrails, and streaming. Prevents 11 documented errors.
+
+Use when: building ag |
+| [openai-api](../../skills/openai-api/SKILL.md) | Build with OpenAI stateless APIs - Chat Completions (GPT-5.2, o3), Realtime voice, Batch API (50% savings), Embeddings, DALL-E 3, Whisper, and TTS. Prevents 16 documented errors.
+
+Use when: implementi |
+| [OpenAI Apps MCP](../../skills/openai-apps-mcp/SKILL.md) | Build ChatGPT apps with MCP servers on Cloudflare Workers. Extend ChatGPT with custom tools and interactive widgets (HTML/JS UI).
+
+Use when: developing ChatGPT extensions, implementing MCP servers, or |
+| [openai-whisper](../../skills/openai-whisper/SKILL.md) | Speech-to-text transcription via OpenAI Whisper. Supports two modes — Local CLI (no API key, runs on-device) and Cloud API (fast, scalable, requires OPENAI_API_KEY). Use when the user needs to transcr |
+| [receiving-code-review](../../skills/receiving-code-review/SKILL.md) | Use when receiving code review feedback, before implementing suggestions, especially if feedback seems unclear or technically questionable - requires technical rigor and verification, not performative |
+| [requesting-code-review](../../skills/requesting-code-review/SKILL.md) | Use when completing tasks, implementing major features, or before merging to verify work meets requirements |
+| [test-driven-development](../../skills/test-driven-development/SKILL.md) | Use when implementing any feature or bugfix, before writing implementation code |
+| [using-git-worktrees](../../skills/using-git-worktrees/SKILL.md) | Use when starting feature work that needs isolation from current workspace or before executing implementation plans - creates isolated git worktrees with smart directory selection and safety verificat |
+| [vercel-react-best-practices](../../skills/vercel-react-best-practices/SKILL.md) | React and Next.js performance optimization guidelines from Vercel Engineering. This skill should be used when writing, reviewing, or refactoring React/Next.js code to ensure optimal performance patter |
+| [voice-ai](../../skills/voice-ai/SKILL.md) | Voice AI architecture and implementation guide. Covers two architectures: speech-to-speech (OpenAI Realtime API, lowest latency) and pipeline (STT->LLM->TTS, more control). Includes provider-specific  |

--- a/docs/by-domain/foundational.md
+++ b/docs/by-domain/foundational.md
@@ -2,9 +2,22 @@
 
 Auto-generated view. Filtered to `domain: foundational` skills.
 
-**2 skills.**
+**13 skills.**
 
 | Skill | Description |
 |-------|-------------|
+| [brainstorming](../../skills/brainstorming/SKILL.md) | You MUST use this before any creative work - creating features, building components, adding functionality, or modifying behavior. Explores user intent, requirements and design before implementation. |
 | [coco](../../skills/coco/SKILL.md) | CoCo — your AI PM brain. Unified interface wrapping skills, commands, and knowledge tools. Invoke /coco to activate. |
+| [dispatching-parallel-agents](../../skills/dispatching-parallel-agents/SKILL.md) | Use when facing 2+ independent tasks that can be worked on without shared state or sequential dependencies |
+| [executing-plans](../../skills/executing-plans/SKILL.md) | Use when you have a written implementation plan to execute in a separate session with review checkpoints |
+| [humanizer](../../skills/humanizer/SKILL.md) | Remove signs of AI-generated writing from text. Use when editing or reviewing
+text to make it sound more natural and human-written. Based on Wikipedia's
+comprehensive "Signs of AI writing" guide. Dete |
+| [karpathy-guidelines](../../skills/karpathy-guidelines/SKILL.md) | Behavioral guidelines to reduce common LLM coding mistakes. Use when writing, reviewing, or refactoring code to avoid overcomplication, make surgical changes, surface assumptions, and define verifiabl |
+| [subagent-driven-development](../../skills/subagent-driven-development/SKILL.md) | Use when executing implementation plans with independent tasks in the current session |
+| [systematic-debugging](../../skills/systematic-debugging/SKILL.md) | Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes |
 | [ultra-think](../../skills/ultra-think/SKILL.md) | Deep, multi-dimensional analysis and problem solving. Activates systematic reasoning across technical, business, user, and system perspectives. Generates multiple solutions with trade-offs, then synth |
+| [using-superpowers](../../skills/using-superpowers/SKILL.md) | Use when starting any conversation - establishes how to find and use skills, requiring Skill tool invocation before ANY response including clarifying questions |
+| [verification-before-completion](../../skills/verification-before-completion/SKILL.md) | Use when about to claim work is complete, fixed, or passing, before committing or creating PRs - requires running verification commands and confirming output before making any success claims; evidence |
+| [workflow-routing](../../skills/workflow-routing/SKILL.md) | Use at the start of any task to route between Superpowers skills and GSD commands based on project state, task scope, and context signals. Fires before other skills when both systems are installed. |
+| [writing-plans](../../skills/writing-plans/SKILL.md) | Use when you have a spec or requirements for a multi-step task, before touching code |

--- a/docs/by-domain/meta.md
+++ b/docs/by-domain/meta.md
@@ -1,0 +1,14 @@
+# Meta skills
+
+Auto-generated view. Filtered to `domain: meta` skills.
+
+**6 skills.**
+
+| Skill | Description |
+|-------|-------------|
+| [cli-anything](../../skills/cli-anything/SKILL.md) | Wrap any command-line tool into a JSON-emitting agent skill. Use when you want to make a CLI reliably callable and parseable by an AI agent — introspect its --help, define a structured-output (--json) |
+| [coco-cli](../../skills/coco-cli/SKILL.md) | Install, update, version-check, or uninstall the Coco open-source AI workflow framework via its CLI (@coco-research/coco-cli, run with npx). Use when setting up Coco on a machine, pulling the latest i |
+| [coco-loop](../../skills/coco-loop/SKILL.md) | Start a safe, governed autonomous loop from a plain-language goal. Use when the user says /coco-loop, "run an autonomous loop", "keep my build green for N hours", "work on X autonomously for a while", |
+| [find-skills](../../skills/find-skills/SKILL.md) | Helps users discover and install agent skills when they ask questions like "how do I do X", "find a skill for X", "is there a skill that can...", or express interest in extending capabilities. This sk |
+| [skill-creator](../../skills/skill-creator/SKILL.md) | Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends Claude's capabilities with specialized knowledge, workfl |
+| [writing-skills](../../skills/writing-skills/SKILL.md) | Use when creating new skills, editing existing skills, or verifying skills work before deployment |

--- a/docs/by-domain/ops.md
+++ b/docs/by-domain/ops.md
@@ -1,0 +1,13 @@
+# Ops skills
+
+Auto-generated view. Filtered to `domain: ops` skills.
+
+**5 skills.**
+
+| Skill | Description |
+|-------|-------------|
+| [pmstudio-arb](../../skills/arb-review/SKILL.md) | Generate an Architecture Review Board (ARB) presentation in Coco Inc's standard 11-slide format. Use when someone asks to "create an ARB deck", "architecture review presentation", "prepare for archite |
+| [pmstudio-dr](../../skills/dr-plan/SKILL.md) | Generate a Disaster Recovery plan with RTO/RPO targets. Use when someone asks to "create a DR plan", "disaster recovery", "business continuity", or "RTO RPO". Do NOT use for step-by-step restoration r |
+| [pmstudio-irp](../../skills/irp/SKILL.md) | Generate an Incident Response Plan (IRP) with severity classification, escalation procedures, and communication templates. Use when someone asks to "create an incident response plan", "IRP", "incident |
+| [pmstudio-nfr](../../skills/nfr-tracker/SKILL.md) | Detailed completeness audit of all project documents. Use when someone asks "are we ready for production", "audit our docs", "readiness check", "nfr tracker", or "what's missing". Do NOT use for a qui |
+| [pmstudio-recovery](../../skills/recovery-plan/SKILL.md) | Generate detailed service restoration runbooks with step-by-step procedures. Use when someone asks to "create recovery procedures", "restoration runbook", "recovery steps", "how to restore service", o |

--- a/docs/by-domain/pm.md
+++ b/docs/by-domain/pm.md
@@ -1,9 +1,18 @@
-# Pm skills
+# PM skills
 
 Auto-generated view. Filtered to `domain: pm` skills.
 
-**1 skills.**
+**10 skills.**
 
 | Skill | Description |
 |-------|-------------|
 | [ai-product](../../skills/ai-product/SKILL.md) | Expert in shipping production-grade AI-powered features — LLM integration patterns, RAG architecture, prompt engineering that scales, AI UX that users trust, safety and guardrails, streaming, and cost |
+| [pmstudio-changelog](../../skills/change-log/SKILL.md) | Create or update a structured change log for a product or platform. Use when someone asks to "create a change log", "log this change", "what changed", "update the change log", "release notes", or "cha |
+| [pmstudio-sync](../../skills/doc-sync/SKILL.md) | Use when a project has linked documentation artifacts (PRDs, presentations, meeting notes, architecture maps) that must stay synchronized. Detects which source files changed, identifies downstream doc |
+| [pmstudio-meeting-notes](../../skills/meeting-notes/SKILL.md) | Generate structured meeting notes from transcripts or pasted text. Use when someone says "meeting notes", "process this transcript", "summarize this call", "notes from today's meeting", or pastes/refe |
+| [pmstudio](../../skills/pmstudio/SKILL.md) | PM Studio command center. Use for a quick overview of available commands and document inventory. Use when someone says "pmstudio", "show commands", "what can I generate", or "project status". Do NOT u |
+| [prd-generator](../../skills/prd-generator/SKILL.md) | Generate comprehensive Product Requirements Documents (PRDs) for product managers. Use this skill when users ask to "create a PRD", "write product requirements", "document a feature", or need help str |
+| [PRD Mastery: Context-Aware, Expert-Driven, and Token-Efficient Refinement](../../skills/prd-mastery/SKILL.md) | A skill that blends the wisdom of top industry experts, ensures token-efficient PRDs, and organizes outputs in a clear folder structure. |
+| [pmstudio-init](../../skills/project-docs/SKILL.md) | Use when starting a new project, onboarding to an existing product, or setting up a documentation ecosystem for any initiative. Scaffolds the standard document set, folder structure, project memory, a |
+| [pmstudio-comms](../../skills/stakeholder-comms/SKILL.md) | Generate templated stakeholder communications from project context. Use when someone asks to "write a go-live email", "create a status update", "onboard someone", "write an announcement", "steerco upd |
+| [task-prd-creator](../../skills/task-prd-creator/SKILL.md) | Use this skill when users request new features, enhancements, bug fixes, or any work that needs planning. Creates structured task files and PRDs (Product Requirements Documents) before implementation. |

--- a/scripts/build-index.py
+++ b/scripts/build-index.py
@@ -45,6 +45,22 @@ SKILL_SOURCES = [
 ]
 
 
+# Display names for the six declared domains. `str.title()` renders "pm" as "Pm",
+# which is wrong for an initialism and is user-facing in every generated index.
+DOMAIN_LABELS = {
+    'foundational': 'Foundational',
+    'pm': 'PM',
+    'engineering': 'Engineering',
+    'design': 'Design',
+    'ops': 'Ops',
+    'meta': 'Meta',
+}
+
+
+def domain_label(slug):
+    return DOMAIN_LABELS.get(slug, slug.replace('-', ' ').title())
+
+
 def parse_frontmatter(path, strict=True):
     """Return the frontmatter mapping, or None when there is no frontmatter block.
 
@@ -170,7 +186,7 @@ def write_skills_index(skills):
         return built
 
     for domain in sorted(by_domain):
-        lines += [f'## {domain.title()} ({len(by_domain[domain])})', '']
+        lines += [f'## {domain_label(domain)} ({len(by_domain[domain])})', '']
         lines += _skill_table(rows(by_domain[domain])) + ['']
 
     for bundle in sorted(by_bundle):
@@ -307,7 +323,7 @@ def write_by_domain_views(skills):
             continue
         slug = domain.replace('/', '-')
         out = out_dir / f'{slug}.md'
-        lines = [f'# {domain.title()} skills', '',
+        lines = [f'# {domain_label(domain)} skills', '',
                  f'Auto-generated view. Filtered to `domain: {domain}` skills.', '',
                  f'**{len(items)} skills.**', '',
                  '| Skill | Description |', '|-------|-------------|']

--- a/skills/INDEX.md
+++ b/skills/INDEX.md
@@ -4,98 +4,103 @@ Auto-generated. Run `python3 scripts/build-index.py` to refresh.
 
 **Total: 179 skills** — 68 core, 111 across 6 bundles.
 
-## Design (1)
+## Design (14)
 
 | Skill | Description |
 |-------|-------------|
+| [ai-marketing-videos](ai-marketing-videos/SKILL.md) | Create AI marketing videos for ads, promos, product launches, and brand content. Models: Veo, Seedance, Wan, FLUX for visuals, Kokoro for voiceover. Types: prod |
+| [axiom-liquid-glass](axiom-liquid-glass/SKILL.md) | Apple Liquid Glass design system — comprehensive design philosophy, implementation guide, and technical API reference from WWDC 2025. Covers design principles ( |
+| [clone-website](clone-website/SKILL.md) | Clone any website into a pixel-perfect single-file HTML prototype. Extracts design tokens, assets, CSS computed styles, interaction patterns, and content via Pl |
+| [coco-ads](coco-ads/SKILL.md) | Turn the project you just shipped into a short, polished, shareable launch video (an "ad") using HyperFrames. Use when someone says "/coco-ads", "make a launch  |
+| [design-taste-frontend](design-taste-frontend/SKILL.md) | Anti-slop frontend skill for landing pages, portfolios, and redesigns. The agent reads the brief, infers the right design direction, and ships interfaces that d |
+| [frontend-design](frontend-design/SKILL.md) | Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts,  |
+| [journey-map](journey-map/SKILL.md) | Loads full context for a React Flow (@xyflow/react) user journey mapping project. Use when working on, extending, debugging, or building features for the journe |
+| [redesign-existing-projects](redesign-existing-projects/SKILL.md) | Upgrades existing websites and apps to premium quality. Audits current design, identifies generic AI patterns, and applies high-end design standards without bre |
+| [scroll-world](scroll-world/SKILL.md) | Build an immersive scroll-scrubbed "fly through the world" landing page for any industry or brand using Higgsfield. As the visitor scrolls, a pre-rendered camer |
+| [swiftui-liquid-glass](swiftui-liquid-glass/SKILL.md) | Implement, review, or improve SwiftUI features using the iOS 26+ Liquid Glass API. Use when asked to adopt Liquid Glass in new SwiftUI UI, refactor an existing  |
 | [tailwind-patterns](tailwind-patterns/SKILL.md) | Tailwind CSS v4 principles. CSS-first configuration, container queries, modern patterns, design token architecture. Use when building with Tailwind v4 or migrat |
+| [ui-ux-pro-max](ui-ux-pro-max/SKILL.md) | UI/UX design intelligence. 50 styles, 21 palettes, 50 font pairings, 20 charts, 9 stacks (React, Next.js, Vue, Svelte, SwiftUI, React Native, Flutter, Tailwind, |
+| [visual-explainer](visual-explainer/SKILL.md) | Generate self-contained HTML visual explanations for systems, code changes, plans, data, and technical concepts. Use for diagrams, architecture overviews, diff  |
+| [web-design-guidelines](web-design-guidelines/SKILL.md) | Review UI code for Web Interface Guidelines compliance. Use when asked to "review my UI", "check accessibility", "audit design", "review UX", or "check my site  |
 
-## Engineering (3)
-
-| Skill | Description |
-|-------|-------------|
-| [arch-index](arch-index/SKILL.md) | Build and validate .arch/index.json — a committed map from each architectural component of this repository to the real directories and files that implement it,  |
-| [c4-architecture](c4-architecture/SKILL.md) | Generate architecture documentation using C4 model Mermaid diagrams. Use when asked to create architecture diagrams, document system architecture, visualize sof |
-| [generate-tests](generate-tests/SKILL.md) | Generate complete test coverage for any file, component, or module. Covers unit tests, integration tests, edge cases, error handling, and mocking — adapted to w |
-
-## Foundational (2)
-
-| Skill | Description |
-|-------|-------------|
-| [coco](coco/SKILL.md) | CoCo — your AI PM brain. Unified interface wrapping skills, commands, and knowledge tools. Invoke /coco to activate. |
-| [ultra-think](ultra-think/SKILL.md) | Deep, multi-dimensional analysis and problem solving. Activates systematic reasoning across technical, business, user, and system perspectives. Generates multip |
-
-## Pm (1)
-
-| Skill | Description |
-|-------|-------------|
-| [ai-product](ai-product/SKILL.md) | Expert in shipping production-grade AI-powered features — LLM integration patterns, RAG architecture, prompt engineering that scales, AI UX that users trust, sa |
-
-## Unspecified (61)
+## Engineering (20)
 
 | Skill | Description |
 |-------|-------------|
 | [agent-lightning](agent-lightning/SKILL.md) | Train and optimize AI agents using Microsoft's Agent Lightning framework with reinforcement learning. Use when setting up agent training, instrumenting agents w |
-| [ai-marketing-videos](ai-marketing-videos/SKILL.md) | Create AI marketing videos for ads, promos, product launches, and brand content. Models: Veo, Seedance, Wan, FLUX for visuals, Kokoro for voiceover. Types: prod |
 | [api-design-principles](api-design-principles/SKILL.md) | Master REST and GraphQL API design principles to build intuitive, scalable, and maintainable APIs that delight developers. Use when designing new APIs, reviewin |
-| [pmstudio-arb](arb-review/SKILL.md) | Generate an Architecture Review Board (ARB) presentation in Coco Inc's standard 11-slide format. Use when someone asks to "create an ARB deck", "architecture re |
-| [axiom-liquid-glass](axiom-liquid-glass/SKILL.md) | Apple Liquid Glass design system — comprehensive design philosophy, implementation guide, and technical API reference from WWDC 2025. Covers design principles ( |
-| [brainstorming](brainstorming/SKILL.md) | You MUST use this before any creative work - creating features, building components, adding functionality, or modifying behavior. Explores user intent, requirem |
+| [arch-index](arch-index/SKILL.md) | Build and validate .arch/index.json — a committed map from each architectural component of this repository to the real directories and files that implement it,  |
 | [browser-automation](browser-automation/SKILL.md) | Browser automation for AI agents. Two providers — agent-browser (local CLI with Playwright) and agentic-browser (cloud via inference.sh). Both use the same @e r |
-| [pmstudio-changelog](change-log/SKILL.md) | Create or update a structured change log for a product or platform. Use when someone asks to "create a change log", "log this change", "what changed", "update t |
-| [cli-anything](cli-anything/SKILL.md) | Wrap any command-line tool into a JSON-emitting agent skill. Use when you want to make a CLI reliably callable and parseable by an AI agent — introspect its --h |
-| [clone-website](clone-website/SKILL.md) | Clone any website into a pixel-perfect single-file HTML prototype. Extracts design tokens, assets, CSS computed styles, interaction patterns, and content via Pl |
-| [coco-ads](coco-ads/SKILL.md) | Turn the project you just shipped into a short, polished, shareable launch video (an "ad") using HyperFrames. Use when someone says "/coco-ads", "make a launch  |
-| [coco-cli](coco-cli/SKILL.md) | Install, update, version-check, or uninstall the Coco open-source AI workflow framework via its CLI (@coco-research/coco-cli, run with npx). Use when setting up |
-| [coco-loop](coco-loop/SKILL.md) | Start a safe, governed autonomous loop from a plain-language goal. Use when the user says /coco-loop, "run an autonomous loop", "keep my build green for N hours |
+| [c4-architecture](c4-architecture/SKILL.md) | Generate architecture documentation using C4 model Mermaid diagrams. Use when asked to create architecture diagrams, document system architecture, visualize sof |
 | [code-verification](code-verification/SKILL.md) | Post-implementation verification system that catches AI-introduced bugs. Covers 7 categories — TDZ errors, import mismatches, reference integrity, dead code, Re |
-| [design-taste-frontend](design-taste-frontend/SKILL.md) | Anti-slop frontend skill for landing pages, portfolios, and redesigns. The agent reads the brief, infers the right design direction, and ships interfaces that d |
-| [dispatching-parallel-agents](dispatching-parallel-agents/SKILL.md) | Use when facing 2+ independent tasks that can be worked on without shared state or sequential dependencies |
-| [pmstudio-sync](doc-sync/SKILL.md) | Use when a project has linked documentation artifacts (PRDs, presentations, meeting notes, architecture maps) that must stay synchronized. Detects which source  |
-| [pmstudio-dr](dr-plan/SKILL.md) | Generate a Disaster Recovery plan with RTO/RPO targets. Use when someone asks to "create a DR plan", "disaster recovery", "business continuity", or "RTO RPO". D |
-| [executing-plans](executing-plans/SKILL.md) | Use when you have a written implementation plan to execute in a separate session with review checkpoints |
 | [expo-api-routes](expo-api-routes/SKILL.md) | Guidelines for creating API routes in Expo Router with EAS Hosting |
-| [find-skills](find-skills/SKILL.md) | Helps users discover and install agent skills when they ask questions like "how do I do X", "find a skill for X", "is there a skill that can...", or express int |
 | [finishing-a-development-branch](finishing-a-development-branch/SKILL.md) | Use when implementation is complete, all tests pass, and you need to decide how to integrate the work - guides completion of development work by presenting stru |
-| [frontend-design](frontend-design/SKILL.md) | Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts,  |
-| [humanizer](humanizer/SKILL.md) | Remove signs of AI-generated writing from text. Use when editing or reviewing text to make it sound more natural and human-written. Based on Wikipedia's compreh |
-| [pmstudio-irp](irp/SKILL.md) | Generate an Incident Response Plan (IRP) with severity classification, escalation procedures, and communication templates. Use when someone asks to "create an i |
-| [journey-map](journey-map/SKILL.md) | Loads full context for a React Flow (@xyflow/react) user journey mapping project. Use when working on, extending, debugging, or building features for the journe |
-| [karpathy-guidelines](karpathy-guidelines/SKILL.md) | Behavioral guidelines to reduce common LLM coding mistakes. Use when writing, reviewing, or refactoring code to avoid overcomplication, make surgical changes, s |
+| [generate-tests](generate-tests/SKILL.md) | Generate complete test coverage for any file, component, or module. Covers unit tests, integration tests, edge cases, error handling, and mocking — adapted to w |
 | [meta:media](media-memory/SKILL.md) | Multimodal memory — ingest, embed, and search media (images, video, audio, files) with Gemini Embedding 2 + ChromaDB |
-| [pmstudio-meeting-notes](meeting-notes/SKILL.md) | Generate structured meeting notes from transcripts or pasted text. Use when someone says "meeting notes", "process this transcript", "summarize this call", "not |
-| [pmstudio-nfr](nfr-tracker/SKILL.md) | Detailed completeness audit of all project documents. Use when someone asks "are we ready for production", "audit our docs", "readiness check", "nfr tracker", o |
 | [openai-agents](openai-agents/SKILL.md) | Build AI applications with OpenAI Agents SDK - text agents, voice agents, multi-agent handoffs, tools with Zod schemas, guardrails, and streaming. Prevents 11 d |
 | [openai-api](openai-api/SKILL.md) | Build with OpenAI stateless APIs - Chat Completions (GPT-5.2, o3), Realtime voice, Batch API (50% savings), Embeddings, DALL-E 3, Whisper, and TTS. Prevents 16  |
 | [OpenAI Apps MCP](openai-apps-mcp/SKILL.md) | Build ChatGPT apps with MCP servers on Cloudflare Workers. Extend ChatGPT with custom tools and interactive widgets (HTML/JS UI).  Use when: developing ChatGPT  |
 | [openai-whisper](openai-whisper/SKILL.md) | Speech-to-text transcription via OpenAI Whisper. Supports two modes — Local CLI (no API key, runs on-device) and Cloud API (fast, scalable, requires OPENAI_API_ |
+| [receiving-code-review](receiving-code-review/SKILL.md) | Use when receiving code review feedback, before implementing suggestions, especially if feedback seems unclear or technically questionable - requires technical  |
+| [requesting-code-review](requesting-code-review/SKILL.md) | Use when completing tasks, implementing major features, or before merging to verify work meets requirements |
+| [test-driven-development](test-driven-development/SKILL.md) | Use when implementing any feature or bugfix, before writing implementation code |
+| [using-git-worktrees](using-git-worktrees/SKILL.md) | Use when starting feature work that needs isolation from current workspace or before executing implementation plans - creates isolated git worktrees with smart  |
+| [vercel-react-best-practices](vercel-react-best-practices/SKILL.md) | React and Next.js performance optimization guidelines from Vercel Engineering. This skill should be used when writing, reviewing, or refactoring React/Next.js c |
+| [voice-ai](voice-ai/SKILL.md) | Voice AI architecture and implementation guide. Covers two architectures: speech-to-speech (OpenAI Realtime API, lowest latency) and pipeline (STT->LLM->TTS, mo |
+
+## Foundational (13)
+
+| Skill | Description |
+|-------|-------------|
+| [brainstorming](brainstorming/SKILL.md) | You MUST use this before any creative work - creating features, building components, adding functionality, or modifying behavior. Explores user intent, requirem |
+| [coco](coco/SKILL.md) | CoCo — your AI PM brain. Unified interface wrapping skills, commands, and knowledge tools. Invoke /coco to activate. |
+| [dispatching-parallel-agents](dispatching-parallel-agents/SKILL.md) | Use when facing 2+ independent tasks that can be worked on without shared state or sequential dependencies |
+| [executing-plans](executing-plans/SKILL.md) | Use when you have a written implementation plan to execute in a separate session with review checkpoints |
+| [humanizer](humanizer/SKILL.md) | Remove signs of AI-generated writing from text. Use when editing or reviewing text to make it sound more natural and human-written. Based on Wikipedia's compreh |
+| [karpathy-guidelines](karpathy-guidelines/SKILL.md) | Behavioral guidelines to reduce common LLM coding mistakes. Use when writing, reviewing, or refactoring code to avoid overcomplication, make surgical changes, s |
+| [subagent-driven-development](subagent-driven-development/SKILL.md) | Use when executing implementation plans with independent tasks in the current session |
+| [systematic-debugging](systematic-debugging/SKILL.md) | Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes |
+| [ultra-think](ultra-think/SKILL.md) | Deep, multi-dimensional analysis and problem solving. Activates systematic reasoning across technical, business, user, and system perspectives. Generates multip |
+| [using-superpowers](using-superpowers/SKILL.md) | Use when starting any conversation - establishes how to find and use skills, requiring Skill tool invocation before ANY response including clarifying questions |
+| [verification-before-completion](verification-before-completion/SKILL.md) | Use when about to claim work is complete, fixed, or passing, before committing or creating PRs - requires running verification commands and confirming output be |
+| [workflow-routing](workflow-routing/SKILL.md) | Use at the start of any task to route between Superpowers skills and GSD commands based on project state, task scope, and context signals. Fires before other sk |
+| [writing-plans](writing-plans/SKILL.md) | Use when you have a spec or requirements for a multi-step task, before touching code |
+
+## Meta (6)
+
+| Skill | Description |
+|-------|-------------|
+| [cli-anything](cli-anything/SKILL.md) | Wrap any command-line tool into a JSON-emitting agent skill. Use when you want to make a CLI reliably callable and parseable by an AI agent — introspect its --h |
+| [coco-cli](coco-cli/SKILL.md) | Install, update, version-check, or uninstall the Coco open-source AI workflow framework via its CLI (@coco-research/coco-cli, run with npx). Use when setting up |
+| [coco-loop](coco-loop/SKILL.md) | Start a safe, governed autonomous loop from a plain-language goal. Use when the user says /coco-loop, "run an autonomous loop", "keep my build green for N hours |
+| [find-skills](find-skills/SKILL.md) | Helps users discover and install agent skills when they ask questions like "how do I do X", "find a skill for X", "is there a skill that can...", or express int |
+| [skill-creator](skill-creator/SKILL.md) | Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends Claude's capabil |
+| [writing-skills](writing-skills/SKILL.md) | Use when creating new skills, editing existing skills, or verifying skills work before deployment |
+
+## Ops (5)
+
+| Skill | Description |
+|-------|-------------|
+| [pmstudio-arb](arb-review/SKILL.md) | Generate an Architecture Review Board (ARB) presentation in Coco Inc's standard 11-slide format. Use when someone asks to "create an ARB deck", "architecture re |
+| [pmstudio-dr](dr-plan/SKILL.md) | Generate a Disaster Recovery plan with RTO/RPO targets. Use when someone asks to "create a DR plan", "disaster recovery", "business continuity", or "RTO RPO". D |
+| [pmstudio-irp](irp/SKILL.md) | Generate an Incident Response Plan (IRP) with severity classification, escalation procedures, and communication templates. Use when someone asks to "create an i |
+| [pmstudio-nfr](nfr-tracker/SKILL.md) | Detailed completeness audit of all project documents. Use when someone asks "are we ready for production", "audit our docs", "readiness check", "nfr tracker", o |
+| [pmstudio-recovery](recovery-plan/SKILL.md) | Generate detailed service restoration runbooks with step-by-step procedures. Use when someone asks to "create recovery procedures", "restoration runbook", "reco |
+
+## PM (10)
+
+| Skill | Description |
+|-------|-------------|
+| [ai-product](ai-product/SKILL.md) | Expert in shipping production-grade AI-powered features — LLM integration patterns, RAG architecture, prompt engineering that scales, AI UX that users trust, sa |
+| [pmstudio-changelog](change-log/SKILL.md) | Create or update a structured change log for a product or platform. Use when someone asks to "create a change log", "log this change", "what changed", "update t |
+| [pmstudio-sync](doc-sync/SKILL.md) | Use when a project has linked documentation artifacts (PRDs, presentations, meeting notes, architecture maps) that must stay synchronized. Detects which source  |
+| [pmstudio-meeting-notes](meeting-notes/SKILL.md) | Generate structured meeting notes from transcripts or pasted text. Use when someone says "meeting notes", "process this transcript", "summarize this call", "not |
 | [pmstudio](pmstudio/SKILL.md) | PM Studio command center. Use for a quick overview of available commands and document inventory. Use when someone says "pmstudio", "show commands", "what can I  |
 | [prd-generator](prd-generator/SKILL.md) | Generate comprehensive Product Requirements Documents (PRDs) for product managers. Use this skill when users ask to "create a PRD", "write product requirements" |
 | [PRD Mastery: Context-Aware, Expert-Driven, and Token-Efficient Refinement](prd-mastery/SKILL.md) | A skill that blends the wisdom of top industry experts, ensures token-efficient PRDs, and organizes outputs in a clear folder structure. |
 | [pmstudio-init](project-docs/SKILL.md) | Use when starting a new project, onboarding to an existing product, or setting up a documentation ecosystem for any initiative. Scaffolds the standard document  |
-| [receiving-code-review](receiving-code-review/SKILL.md) | Use when receiving code review feedback, before implementing suggestions, especially if feedback seems unclear or technically questionable - requires technical  |
-| [pmstudio-recovery](recovery-plan/SKILL.md) | Generate detailed service restoration runbooks with step-by-step procedures. Use when someone asks to "create recovery procedures", "restoration runbook", "reco |
-| [redesign-existing-projects](redesign-existing-projects/SKILL.md) | Upgrades existing websites and apps to premium quality. Audits current design, identifies generic AI patterns, and applies high-end design standards without bre |
-| [requesting-code-review](requesting-code-review/SKILL.md) | Use when completing tasks, implementing major features, or before merging to verify work meets requirements |
-| [scroll-world](scroll-world/SKILL.md) | Build an immersive scroll-scrubbed "fly through the world" landing page for any industry or brand using Higgsfield. As the visitor scrolls, a pre-rendered camer |
-| [skill-creator](skill-creator/SKILL.md) | Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends Claude's capabil |
 | [pmstudio-comms](stakeholder-comms/SKILL.md) | Generate templated stakeholder communications from project context. Use when someone asks to "write a go-live email", "create a status update", "onboard someone |
-| [subagent-driven-development](subagent-driven-development/SKILL.md) | Use when executing implementation plans with independent tasks in the current session |
-| [swiftui-liquid-glass](swiftui-liquid-glass/SKILL.md) | Implement, review, or improve SwiftUI features using the iOS 26+ Liquid Glass API. Use when asked to adopt Liquid Glass in new SwiftUI UI, refactor an existing  |
-| [systematic-debugging](systematic-debugging/SKILL.md) | Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes |
 | [task-prd-creator](task-prd-creator/SKILL.md) | Use this skill when users request new features, enhancements, bug fixes, or any work that needs planning. Creates structured task files and PRDs (Product Requir |
-| [test-driven-development](test-driven-development/SKILL.md) | Use when implementing any feature or bugfix, before writing implementation code |
-| [ui-ux-pro-max](ui-ux-pro-max/SKILL.md) | UI/UX design intelligence. 50 styles, 21 palettes, 50 font pairings, 20 charts, 9 stacks (React, Next.js, Vue, Svelte, SwiftUI, React Native, Flutter, Tailwind, |
-| [using-git-worktrees](using-git-worktrees/SKILL.md) | Use when starting feature work that needs isolation from current workspace or before executing implementation plans - creates isolated git worktrees with smart  |
-| [using-superpowers](using-superpowers/SKILL.md) | Use when starting any conversation - establishes how to find and use skills, requiring Skill tool invocation before ANY response including clarifying questions |
-| [vercel-react-best-practices](vercel-react-best-practices/SKILL.md) | React and Next.js performance optimization guidelines from Vercel Engineering. This skill should be used when writing, reviewing, or refactoring React/Next.js c |
-| [verification-before-completion](verification-before-completion/SKILL.md) | Use when about to claim work is complete, fixed, or passing, before committing or creating PRs - requires running verification commands and confirming output be |
-| [visual-explainer](visual-explainer/SKILL.md) | Generate self-contained HTML visual explanations for systems, code changes, plans, data, and technical concepts. Use for diagrams, architecture overviews, diff  |
-| [voice-ai](voice-ai/SKILL.md) | Voice AI architecture and implementation guide. Covers two architectures: speech-to-speech (OpenAI Realtime API, lowest latency) and pipeline (STT->LLM->TTS, mo |
-| [web-design-guidelines](web-design-guidelines/SKILL.md) | Review UI code for Web Interface Guidelines compliance. Use when asked to "review my UI", "check accessibility", "audit design", "review UX", or "check my site  |
-| [workflow-routing](workflow-routing/SKILL.md) | Use at the start of any task to route between Superpowers skills and GSD commands based on project state, task scope, and context signals. Fires before other sk |
-| [writing-plans](writing-plans/SKILL.md) | Use when you have a spec or requirements for a multi-step task, before touching code |
-| [writing-skills](writing-skills/SKILL.md) | Use when creating new skills, editing existing skills, or verifying skills work before deployment |
 
 ## Bundle: brain (6 skills)
 

--- a/skills/agent-lightning/SKILL.md
+++ b/skills/agent-lightning/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: agent-lightning
 description: Train and optimize AI agents using Microsoft's Agent Lightning framework with reinforcement learning. Use when setting up agent training, instrumenting agents with tracing, configuring LightningStore, implementing reward functions, or optimizing prompts with RL/APO algorithms.
+domain: engineering
 ---
 
 # Agent Lightning

--- a/skills/ai-marketing-videos/SKILL.md
+++ b/skills/ai-marketing-videos/SKILL.md
@@ -9,6 +9,7 @@ description: |
   product video, explainer video, ad creative, video ad, facebook ad video,
   youtube ad, instagram ad, tiktok ad, promotional video, launch video
 allowed-tools: Bash(infsh *)
+domain: design
 ---
 
 # AI Marketing Videos

--- a/skills/api-design-principles/SKILL.md
+++ b/skills/api-design-principles/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: api-design-principles
 description: Master REST and GraphQL API design principles to build intuitive, scalable, and maintainable APIs that delight developers. Use when designing new APIs, reviewing API specifications, or establishing API design standards.
+domain: engineering
 ---
 
 # API Design Principles

--- a/skills/arb-review/SKILL.md
+++ b/skills/arb-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: pmstudio-arb
 description: Generate an Architecture Review Board (ARB) presentation in Coco Inc's standard 11-slide format. Use when someone asks to "create an ARB deck", "architecture review presentation", "prepare for architecture review board", "ARB slides", or needs to present a product/platform architecture for sign-off. Reads PRD, architecture maps, and project memory to pre-fill technical content. Produces a self-contained HTML slide deck.
+domain: ops
 ---
 
 # ARB Review — Architecture Review Board Presentation

--- a/skills/axiom-liquid-glass/SKILL.md
+++ b/skills/axiom-liquid-glass/SKILL.md
@@ -5,6 +5,7 @@ user-invocable: true
 skill_type: discipline
 version: 1.2.0
 apple_platforms: iOS 26+, iPadOS 26+, macOS Tahoe+, visionOS 3+
+domain: design
 ---
 
 # Liquid Glass — Apple's Design System

--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: brainstorming
 description: "You MUST use this before any creative work - creating features, building components, adding functionality, or modifying behavior. Explores user intent, requirements and design before implementation."
+domain: foundational
 ---
 
 # Brainstorming Ideas Into Designs

--- a/skills/browser-automation/SKILL.md
+++ b/skills/browser-automation/SKILL.md
@@ -2,6 +2,7 @@
 name: browser-automation
 description: Browser automation for AI agents. Two providers — agent-browser (local CLI with Playwright) and agentic-browser (cloud via inference.sh). Both use the same @e ref-based workflow for navigating pages, filling forms, clicking buttons, taking screenshots, extracting data, and automating browser tasks.
 allowed-tools: Bash(agent-browser:*), Bash(infsh *)
+domain: engineering
 ---
 
 # Browser Automation

--- a/skills/change-log/SKILL.md
+++ b/skills/change-log/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: pmstudio-changelog
 description: Create or update a structured change log for a product or platform. Use when someone asks to "create a change log", "log this change", "what changed", "update the change log", "release notes", or "changelog". Reads project memory (CLAUDE.local.md Recent Changes) and meeting notes to build chronological change records. Supports init (backfill from memory), update (append new entries), and release (summarize for a version).
+domain: pm
 ---
 
 # Change Log — Running Product Change Record

--- a/skills/cli-anything/SKILL.md
+++ b/skills/cli-anything/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: cli-anything
 description: Wrap any command-line tool into a JSON-emitting agent skill. Use when you want to make a CLI reliably callable and parseable by an AI agent — introspect its --help, define a structured-output (--json) contract and a stable error contract, then generate a SKILL.md wrapper with verified examples. Triggers on "wrap this CLI", "make X agent-usable", "generate a skill for this command", "turn a tool into an agent skill".
+domain: meta
 ---
 
 <!-- Methodology adapted from HKUDS/CLI-Anything (https://github.com/HKUDS/CLI-Anything) — Apache-2.0. -->

--- a/skills/clone-website/SKILL.md
+++ b/skills/clone-website/SKILL.md
@@ -3,6 +3,7 @@ name: clone-website
 description: Clone any website into a pixel-perfect single-file HTML prototype. Extracts design tokens, assets, CSS computed styles, interaction patterns, and content via Playwright. Outputs a self-contained HTML file with real data injection. Use when the user wants to clone, replicate, reverse-engineer, or create a pixel-perfect copy of any website or web app. Provide one or more target URLs as arguments.
 argument-hint: "<url1> [<url2> ...]"
 user-invocable: true
+domain: design
 ---
 
 # Clone Website --- Single-File HTML Prototype Builder

--- a/skills/coco-ads/SKILL.md
+++ b/skills/coco-ads/SKILL.md
@@ -3,6 +3,7 @@ name: coco-ads
 description: Turn the project you just shipped into a short, polished, shareable launch video (an "ad") using HyperFrames. Use when someone says "/coco-ads", "make a launch video", "brag about this", "turn this into a promo", "make an ad for this", or wants to share what they built. Reads the project code directly — no live URL or screenshots needed. Renders locally.
 argument-hint: "[--tone <preset|freeform>] [--format landscape|vertical|square] [--duration <s>] [--no-music] [--title <name>]"
 user-invocable: true
+domain: design
 ---
 
 # /coco-ads — launch videos from your repo

--- a/skills/coco-cli/SKILL.md
+++ b/skills/coco-cli/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: coco-cli
 description: Install, update, version-check, or uninstall the Coco open-source AI workflow framework via its CLI (@coco-research/coco-cli, run with npx). Use when setting up Coco on a machine, pulling the latest into an existing clone, checking the installed version, or removing it. Triggers on "install coco", "update coco", "set up coco", "coco cli", "uninstall coco".
+domain: meta
 ---
 
 <!-- Wrapper generated with the cli-anything skill. Methodology: HKUDS/CLI-Anything (https://github.com/HKUDS/CLI-Anything) — Apache-2.0. -->

--- a/skills/coco-loop/SKILL.md
+++ b/skills/coco-loop/SKILL.md
@@ -7,6 +7,7 @@ description: >
   proposes fixes and never commits on its own. Turns a vague goal into a readable
   charter the user confirms, then arms and runs the loop propose-only under the
   coco-loops governance framework.
+domain: meta
 ---
 
 # coco-loop

--- a/skills/code-verification/SKILL.md
+++ b/skills/code-verification/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: code-verification
 description: Post-implementation verification system that catches AI-introduced bugs. Covers 7 categories — TDZ errors, import mismatches, reference integrity, dead code, React state/effects, mock isolation, and CSS integrity. Run after every code change, after writing tests, or before marking a task complete. Triggers on "verify", "check code quality", "run verification", "audit code", "quality gate", "pre-commit check".
+domain: engineering
 ---
 
 # Code Verification Skill

--- a/skills/design-taste-frontend/SKILL.md
+++ b/skills/design-taste-frontend/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: design-taste-frontend
 description: Anti-slop frontend skill for landing pages, portfolios, and redesigns. The agent reads the brief, infers the right design direction, and ships interfaces that do not look templated. Real design systems when applicable, audit-first on redesigns, strict pre-flight check.
+domain: design
 ---
 
 <!-- Vendored from Leonxlnx/taste-skill (https://github.com/Leonxlnx/taste-skill) — MIT License, (c) 2026 Leonxlnx. -->

--- a/skills/dispatching-parallel-agents/SKILL.md
+++ b/skills/dispatching-parallel-agents/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: dispatching-parallel-agents
 description: Use when facing 2+ independent tasks that can be worked on without shared state or sequential dependencies
+domain: foundational
 ---
 
 # Dispatching Parallel Agents

--- a/skills/doc-sync/SKILL.md
+++ b/skills/doc-sync/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: pmstudio-sync
 description: Use when a project has linked documentation artifacts (PRDs, presentations, meeting notes, architecture maps) that must stay synchronized. Detects which source files changed, identifies downstream documents needing updates, reads new content, and proposes specific edits with diffs before applying. Also use when a .sync-report.md exists in the project or user says "process sync report".
+domain: pm
 ---
 
 # Doc Sync — Cascading Document Updater

--- a/skills/dr-plan/SKILL.md
+++ b/skills/dr-plan/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: pmstudio-dr
 description: Generate a Disaster Recovery plan with RTO/RPO targets. Use when someone asks to "create a DR plan", "disaster recovery", "business continuity", or "RTO RPO". Do NOT use for step-by-step restoration runbooks — use /pmstudio-recovery instead. Designed for SaaS platform products where Coco Inc is the customer — focuses on service continuity, data recovery, and vendor dependency management rather than infrastructure rebuild.
+domain: ops
 ---
 
 # DR Plan — Disaster Recovery Plan

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: executing-plans
 description: Use when you have a written implementation plan to execute in a separate session with review checkpoints
+domain: foundational
 ---
 
 # Executing Plans

--- a/skills/expo-api-routes/SKILL.md
+++ b/skills/expo-api-routes/SKILL.md
@@ -3,6 +3,7 @@ name: expo-api-routes
 description: Guidelines for creating API routes in Expo Router with EAS Hosting
 version: 1.0.0
 license: MIT
+domain: engineering
 ---
 
 ## When to Use API Routes

--- a/skills/find-skills/SKILL.md
+++ b/skills/find-skills/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: find-skills
 description: Helps users discover and install agent skills when they ask questions like "how do I do X", "find a skill for X", "is there a skill that can...", or express interest in extending capabilities. This skill should be used when the user is looking for functionality that might exist as an installable skill.
+domain: meta
 ---
 
 # Find Skills

--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: finishing-a-development-branch
 description: Use when implementation is complete, all tests pass, and you need to decide how to integrate the work - guides completion of development work by presenting structured options for merge, PR, or cleanup
+domain: engineering
 ---
 
 # Finishing a Development Branch

--- a/skills/frontend-design/SKILL.md
+++ b/skills/frontend-design/SKILL.md
@@ -2,6 +2,7 @@
 name: frontend-design
 description: Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.
 license: Complete terms in LICENSE.txt
+domain: design
 ---
 
 This skill guides creation of distinctive, production-grade frontend interfaces that avoid generic "AI slop" aesthetics. Implement real working code with exceptional attention to aesthetic details and creative choices.

--- a/skills/humanizer/SKILL.md
+++ b/skills/humanizer/SKILL.md
@@ -17,6 +17,7 @@ allowed-tools:
   - Grep
   - Glob
   - AskUserQuestion
+domain: foundational
 ---
 
 # Humanizer: Remove AI Writing Patterns

--- a/skills/irp/SKILL.md
+++ b/skills/irp/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: pmstudio-irp
 description: Generate an Incident Response Plan (IRP) with severity classification, escalation procedures, and communication templates. Use when someone asks to "create an incident response plan", "IRP", "incident procedures", "escalation matrix", "incident playbook", or needs to document how to handle incidents for a product/platform. Reads PRD, stakeholder directory, and project memory to build product-specific response procedures. Complementary to DR plan (DR = restore service; IRP = manage the incident while it's happening).
+domain: ops
 ---
 
 # IRP — Incident Response Plan

--- a/skills/journey-map/SKILL.md
+++ b/skills/journey-map/SKILL.md
@@ -7,6 +7,7 @@ description: >
   "work on journey map", "build user journey", "react flow journey project",
   "journey-map app", or any request to add features like swimlanes,
   emotion curves, persona nodes, touchpoints, or pain point markers.
+domain: design
 ---
 
 # Journey Map Project

--- a/skills/karpathy-guidelines/SKILL.md
+++ b/skills/karpathy-guidelines/SKILL.md
@@ -2,6 +2,7 @@
 name: karpathy-guidelines
 description: Behavioral guidelines to reduce common LLM coding mistakes. Use when writing, reviewing, or refactoring code to avoid overcomplication, make surgical changes, surface assumptions, and define verifiable success criteria.
 license: MIT
+domain: foundational
 ---
 
 # Karpathy Guidelines

--- a/skills/media-memory/SKILL.md
+++ b/skills/media-memory/SKILL.md
@@ -11,6 +11,7 @@ trigger: |
   ALSO proactively query when:
   - User discusses a topic and a past media asset might be relevant
   - User references "that screenshot", "the diagram from last week", etc.
+domain: engineering
 ---
 
 # /media-memory — Multimodal Memory System

--- a/skills/meeting-notes/SKILL.md
+++ b/skills/meeting-notes/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: pmstudio-meeting-notes
 description: Generate structured meeting notes from transcripts or pasted text. Use when someone says "meeting notes", "process this transcript", "summarize this call", "notes from today's meeting", or pastes/references a meeting transcript. Auto-enriches attendees from stakeholder directory, routes output to correct project subfolder, flags downstream artifact impacts (PRD, deck, architecture), and proposes CLAUDE.local.md updates. Produces date-first Markdown files.
+domain: pm
 ---
 
 # Meeting Notes — Transcript-to-Artifact Generator

--- a/skills/nfr-tracker/SKILL.md
+++ b/skills/nfr-tracker/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: pmstudio-nfr
 description: Detailed completeness audit of all project documents. Use when someone asks "are we ready for production", "audit our docs", "readiness check", "nfr tracker", or "what's missing". Do NOT use for a quick command listing — use /pmstudio instead. Scans every document for section-level completeness, reports staleness, and gives prioritized gap-closure recommendations.
+domain: ops
 ---
 
 # NFR Tracker — Operational Readiness Auditor

--- a/skills/openai-agents/SKILL.md
+++ b/skills/openai-agents/SKILL.md
@@ -5,6 +5,7 @@ description: |
 
   Use when: building agents with tools, voice agents with WebRTC, multi-agent workflows, or troubleshooting MaxTurnsExceededError, tool call failures, reasoning defaults, JSON output leaks.
 user-invocable: true
+domain: engineering
 ---
 
 # OpenAI Agents SDK

--- a/skills/openai-api/SKILL.md
+++ b/skills/openai-api/SKILL.md
@@ -5,6 +5,7 @@ description: |
 
   Use when: implementing GPT-5 chat, streaming, function calling, embeddings for RAG, or troubleshooting rate limits (429), API errors, TypeScript issues, model name errors.
 user-invocable: true
+domain: engineering
 ---
 
 # OpenAI API - Complete Guide

--- a/skills/openai-apps-mcp/SKILL.md
+++ b/skills/openai-apps-mcp/SKILL.md
@@ -6,6 +6,7 @@ description: |
   Use when: developing ChatGPT extensions, implementing MCP servers, or troubleshooting CORS, widget 404s, MIME types, ASSETS binding errors, Next.js integration issues, or edge platform limitations.
 user-invocable: true
 allowed-tools: [Read, Write, Edit, Bash, Glob, Grep]
+domain: engineering
 ---
 
 # Building OpenAI Apps with Stateless MCP Servers

--- a/skills/openai-whisper/SKILL.md
+++ b/skills/openai-whisper/SKILL.md
@@ -2,6 +2,7 @@
 name: openai-whisper
 description: Speech-to-text transcription via OpenAI Whisper. Supports two modes — Local CLI (no API key, runs on-device) and Cloud API (fast, scalable, requires OPENAI_API_KEY). Use when the user needs to transcribe audio files, translate speech, or convert audio to text.
 homepage: https://openai.com/research/whisper
+domain: engineering
 ---
 
 # OpenAI Whisper — Speech-to-Text

--- a/skills/pmstudio/SKILL.md
+++ b/skills/pmstudio/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: pmstudio
 description: PM Studio command center. Use for a quick overview of available commands and document inventory. Use when someone says "pmstudio", "show commands", "what can I generate", or "project status". Do NOT use for detailed completeness audits — use /pmstudio-nfr instead. Shows document coverage dashboard and recommends which /pmstudio-* command to run next.
+domain: pm
 ---
 
 # PM Studio — Command Center

--- a/skills/prd-generator/SKILL.md
+++ b/skills/prd-generator/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: prd-generator
 description: Generate comprehensive Product Requirements Documents (PRDs) for product managers. Use this skill when users ask to "create a PRD", "write product requirements", "document a feature", or need help structuring product specifications.
+domain: pm
 ---
 
 # PRD Generator

--- a/skills/prd-mastery/SKILL.md
+++ b/skills/prd-mastery/SKILL.md
@@ -4,6 +4,7 @@ description: "A skill that blends the wisdom of top industry experts, ensures to
 version: "1.0"
 author: "Callum Bir"
 keywords: ["PRD", "product requirements", "business analysis", "product management", "documentation", "Cagan", "Torres", "Biddle"]
+domain: pm
 ---
 
 # PRD Mastery Skills

--- a/skills/project-docs/SKILL.md
+++ b/skills/project-docs/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: pmstudio-init
 description: Use when starting a new project, onboarding to an existing product, or setting up a documentation ecosystem for any initiative. Scaffolds the standard document set, folder structure, project memory, and doc-sync config. Works for software products, consulting engagements, platform implementations, and governance programs.
+domain: pm
 ---
 
 # Project Docs — Standard Document Ecosystem

--- a/skills/receiving-code-review/SKILL.md
+++ b/skills/receiving-code-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: receiving-code-review
 description: Use when receiving code review feedback, before implementing suggestions, especially if feedback seems unclear or technically questionable - requires technical rigor and verification, not performative agreement or blind implementation
+domain: engineering
 ---
 
 # Code Review Reception

--- a/skills/recovery-plan/SKILL.md
+++ b/skills/recovery-plan/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: pmstudio-recovery
 description: Generate detailed service restoration runbooks with step-by-step procedures. Use when someone asks to "create recovery procedures", "restoration runbook", "recovery steps", "how to restore service", or needs tactical step-by-step procedures for recovering from disaster scenarios. This is the execution companion to the DR plan — DR defines what and when, recovery-plan defines exactly how. Requires a DR plan to exist (will prompt to run /pmstudio-dr first if missing).
+domain: ops
 ---
 
 # Recovery Plan — Service Restoration Runbooks

--- a/skills/redesign-existing-projects/SKILL.md
+++ b/skills/redesign-existing-projects/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: redesign-existing-projects
 description: Upgrades existing websites and apps to premium quality. Audits current design, identifies generic AI patterns, and applies high-end design standards without breaking functionality. Works with any CSS framework or vanilla CSS.
+domain: design
 ---
 
 <!-- Vendored from Leonxlnx/taste-skill (https://github.com/Leonxlnx/taste-skill) — MIT License, (c) 2026 Leonxlnx. -->

--- a/skills/requesting-code-review/SKILL.md
+++ b/skills/requesting-code-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: requesting-code-review
 description: Use when completing tasks, implementing major features, or before merging to verify work meets requirements
+domain: engineering
 ---
 
 # Requesting Code Review

--- a/skills/scroll-world/SKILL.md
+++ b/skills/scroll-world/SKILL.md
@@ -14,6 +14,7 @@ description: >
   "browse-through-the-industry" hero, a scroll cinematic, a diorama landing, or to
   turn a business into a scrollable world.
 allowed-tools: Bash, Read, Write, Edit, AskUserQuestion, Skill
+domain: design
 ---
 
 # scroll-world

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -2,6 +2,7 @@
 name: skill-creator
 description: Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends Claude's capabilities with specialized knowledge, workflows, or tool integrations.
 license: Complete terms in LICENSE.txt
+domain: meta
 ---
 
 # Skill Creator

--- a/skills/stakeholder-comms/SKILL.md
+++ b/skills/stakeholder-comms/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: pmstudio-comms
 description: Generate templated stakeholder communications from project context. Use when someone asks to "write a go-live email", "create a status update", "onboard someone", "write an announcement", "steerco update", "incident summary", "change notification", or any stakeholder communication task. Reads project memory, stakeholder directory, PRD, and meeting notes to pre-fill real names, dates, and context. Produces ready-to-send Markdown.
+domain: pm
 ---
 
 # Stakeholder Comms — Templated Communications Generator

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: subagent-driven-development
 description: Use when executing implementation plans with independent tasks in the current session
+domain: foundational
 ---
 
 # Subagent-Driven Development

--- a/skills/swiftui-liquid-glass/SKILL.md
+++ b/skills/swiftui-liquid-glass/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: swiftui-liquid-glass
 description: Implement, review, or improve SwiftUI features using the iOS 26+ Liquid Glass API. Use when asked to adopt Liquid Glass in new SwiftUI UI, refactor an existing feature to Liquid Glass, or review Liquid Glass usage for correctness, performance, and design alignment.
+domain: design
 ---
 
 # SwiftUI Liquid Glass

--- a/skills/systematic-debugging/SKILL.md
+++ b/skills/systematic-debugging/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: systematic-debugging
 description: Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes
+domain: foundational
 ---
 
 # Systematic Debugging

--- a/skills/task-prd-creator/SKILL.md
+++ b/skills/task-prd-creator/SKILL.md
@@ -10,6 +10,7 @@ tags:
   - documentation
   - project-management
 auto_activate: true
+domain: pm
 ---
 
 # Task & PRD Creator

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: test-driven-development
 description: Use when implementing any feature or bugfix, before writing implementation code
+domain: engineering
 ---
 
 # Test-Driven Development (TDD)

--- a/skills/ui-ux-pro-max/SKILL.md
+++ b/skills/ui-ux-pro-max/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ui-ux-pro-max
 description: "UI/UX design intelligence. 50 styles, 21 palettes, 50 font pairings, 20 charts, 9 stacks (React, Next.js, Vue, Svelte, SwiftUI, React Native, Flutter, Tailwind, shadcn/ui). Actions: plan, build, create, design, implement, review, fix, improve, optimize, enhance, refactor, check UI/UX code. Projects: website, landing page, dashboard, admin panel, e-commerce, SaaS, portfolio, blog, mobile app, .html, .tsx, .vue, .svelte. Elements: button, modal, navbar, sidebar, card, table, form, chart. Styles: glassmorphism, claymorphism, minimalism, brutalism, neumorphism, bento grid, dark mode, responsive, skeuomorphism, flat design. Topics: color palette, accessibility, animation, layout, typography, font pairing, spacing, hover, shadow, gradient. Integrations: shadcn/ui MCP for component search and examples."
+domain: design
 ---
 
 # UI/UX Pro Max - Design Intelligence

--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: using-git-worktrees
 description: Use when starting feature work that needs isolation from current workspace or before executing implementation plans - creates isolated git worktrees with smart directory selection and safety verification
+domain: engineering
 ---
 
 # Using Git Worktrees

--- a/skills/using-superpowers/SKILL.md
+++ b/skills/using-superpowers/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: using-superpowers
 description: Use when starting any conversation - establishes how to find and use skills, requiring Skill tool invocation before ANY response including clarifying questions
+domain: foundational
 ---
 
 **Announce at start:** "Using Superpowers skill activated."

--- a/skills/vercel-react-best-practices/SKILL.md
+++ b/skills/vercel-react-best-practices/SKILL.md
@@ -5,6 +5,7 @@ license: MIT
 metadata:
   author: vercel
   version: "1.0.0"
+domain: engineering
 ---
 
 # Vercel React Best Practices

--- a/skills/verification-before-completion/SKILL.md
+++ b/skills/verification-before-completion/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: verification-before-completion
 description: Use when about to claim work is complete, fixed, or passing, before committing or creating PRs - requires running verification commands and confirming output before making any success claims; evidence before assertions always
+domain: foundational
 ---
 
 # Verification Before Completion

--- a/skills/visual-explainer/SKILL.md
+++ b/skills/visual-explainer/SKILL.md
@@ -6,6 +6,7 @@ compatibility: Requires a browser to view generated HTML files. Optional surf-cl
 metadata:
   author: nicobailon
   version: "0.8.1"
+domain: design
 ---
 
 # Visual Explainer

--- a/skills/voice-ai/SKILL.md
+++ b/skills/voice-ai/SKILL.md
@@ -2,6 +2,7 @@
 name: voice-ai
 description: "Voice AI architecture and implementation guide. Covers two architectures: speech-to-speech (OpenAI Realtime API, lowest latency) and pipeline (STT->LLM->TTS, more control). Includes provider-specific patterns for OpenAI Realtime, Vapi, Deepgram, ElevenLabs, and LiveKit. Use when building voice agents, voice-enabled apps, or real-time conversational AI."
 source: vibeship-spawner-skills (Apache 2.0)
+domain: engineering
 ---
 
 # Voice AI — Architecture & Implementation

--- a/skills/web-design-guidelines/SKILL.md
+++ b/skills/web-design-guidelines/SKILL.md
@@ -5,6 +5,7 @@ metadata:
   author: vercel
   version: "1.0.0"
   argument-hint: <file-or-pattern>
+domain: design
 ---
 
 # Web Interface Guidelines

--- a/skills/workflow-routing/SKILL.md
+++ b/skills/workflow-routing/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: workflow-routing
 description: Use at the start of any task to route between Superpowers skills and GSD commands based on project state, task scope, and context signals. Fires before other skills when both systems are installed.
+domain: foundational
 ---
 
 # Workflow Routing: Superpowers + GSD

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: writing-plans
 description: Use when you have a spec or requirements for a multi-step task, before touching code
+domain: foundational
 ---
 
 # Writing Plans

--- a/skills/writing-skills/SKILL.md
+++ b/skills/writing-skills/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: writing-skills
 description: Use when creating new skills, editing existing skills, or verifying skills work before deployment
+domain: meta
 ---
 
 # Writing Skills


### PR DESCRIPTION
## Why

`docs/architecture.md` has defined six domains for a long time. `CONTRIBUTING.md:47` and `docs/guides/migration.md:194` both declare the `domain` frontmatter field **required**. Three adapter manifests declare all six. The GitHub issue template asks contributors to supply one.

**Seven of 68 core skills actually carried it.** A field documented as required, at 10% coverage — which is exactly why `skills/INDEX.md` grouped 61 skills under a meaningless "Unspecified" heading after #84 stopped hiding them.

## What changed

All 61 remaining core skills now declare a domain, assigned from **what each skill does** rather than from its name:

| Domain | Count | Examples |
|---|---:|---|
| `engineering` | 20 | `test-driven-development`, `api-design-principles`, `openai-api`, `voice-ai` |
| `design` | 14 | `frontend-design`, `ui-ux-pro-max`, `axiom-liquid-glass`, `journey-map` |
| `foundational` | 13 | `brainstorming`, `systematic-debugging`, `writing-plans`, `using-superpowers` |
| `pm` | 10 | `prd-generator`, `pmstudio`, `meeting-notes`, `stakeholder-comms` |
| `meta` | 6 | `skill-creator`, `writing-skills`, `find-skills`, `coco-cli` |
| `ops` | 5 | `dr-plan`, `irp`, `recovery-plan`, `arb-review`, `nfr-tracker` |
| **Total** | **68** | |

**Two assignments follow `architecture.md`'s own wording rather than intuition.** `arb-review` and `nfr-tracker` are `ops`, because that entry reads *"Operations / risk / compliance (DR, IRP, ARB, NFR)"* and names both explicitly — even though both generate PM-style documents and a name-based guess would have filed them under `pm`.

## Two smaller fixes that came with it

**`domain_label()` in the generator.** Headings were built with `str.title()`, which renders the `pm` slug as "Pm". It is an initialism, and it appears in a user-facing heading in `skills/INDEX.md` and in `docs/by-domain/pm.md`, so the six slugs now have explicit display names.

**`docs/architecture.md` listed three things domains are "used to" do.** One is now true and is kept — generating `docs/by-domain/<domain>.md` and grouping `skills/INDEX.md`, both produced by `scripts/build-index.py`. The other two never existed:

- there is no `coco list` subcommand (`bin/` contains only `coco.js` and `coco-bootstrap.sh`)
- `install.sh` accepts no `--domains` flag (grep returns nothing across `install.sh` and all five adapters)

The document now says so plainly. Building either is straightforward now that every skill declares a domain, but describing unbuilt features as though they ship is the same defect class as the phantom `--systems team`, so the promise goes rather than being left dangling.

## Before / after

```
before:  ## Unspecified (61)      <- the field CONTRIBUTING calls required
after:   ## Design (14)
         ## Engineering (20)
         ## Foundational (13)
         ## Meta (6)
         ## Ops (5)
         ## PM (10)
```

## Verification

| Check | Result |
|---|---|
| Core skills parsing as YAML with a valid slug | **68 / 68** |
| Invalid or missing domain values | **0** |
| `Unspecified` group in `skills/INDEX.md` | gone |
| `docs/by-domain/` views generated | all **6** |
| Generator output across two consecutive runs | byte-identical |
| Frontmatter lint (CI logic) | 165 checked, all valid |
| `bash tests/check-command-refs.sh` | PASS |
| `bash tests/check-evidence-gate.sh` | PASS |
| `bash tests/smoke.sh` | 18 passed, 0 failed |
| `arch-index` fixtures | pass |
| All four adapter dry-runs | exit 0 |
| `build-index.py` | 179 skills |

## Note on the bundles

Only the 68 **core** skills are assigned. The 111 bundle skills group by bundle instead, which is how `skills/INDEX.md` presents them and is the more useful axis for an opt-in bundle. Assigning them a domain as well is possible later but adds nothing today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)