### PR TITLE
feat(m0): add M0 cross-tool agent memory as an opt-in bundle

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -21,9 +21,19 @@
 
 ## By system bundle
 
-- [GSD](../systems/gsd/) — project orchestration (68 skills)
+Installable with `install.sh --systems <name>`:
+
+- [GSD](../systems/gsd/) — project orchestration (68 skills, 24 agents)
+- [HyperFrames](../systems/hyperframes/) — video and motion suite (20 skills)
+- [Superintelligence](../systems/superintelligence/) — 389-persona expert board (9 team skills; generates 242 commands at install)
 - [Brain](../systems/brain/) — local knowledge tracker (6 skills)
-- [Team](../systems/team/) — multi-agent pipelines
+- [M0](../systems/m0/) — cross-tool agent memory (4 skills)
+- [Cognee](../systems/cognee/) — knowledge-graph memory (3 skills)
+
+See [systems/INDEX.md](../systems/INDEX.md) for the generated bundle table with live counts.
+
+`/team` is **not** a bundle — it is core, and its commands are installed by a plain
+`bash install.sh`. See [systems/team/](../systems/team/) for the design notes.
 
 ## By IDE adapter
 

--- a/skills/INDEX.md
+++ b/skills/INDEX.md
@@ -2,7 +2,7 @@
 
 Auto-generated. Run `python3 scripts/build-index.py` to refresh.
 
-**Total: 179 skills** — 68 core, 111 across 6 bundles.
+**Total: 183 skills** — 68 core, 115 across 7 bundles.
 
 ## Design (14)
 
@@ -228,6 +228,15 @@ Auto-generated. Run `python3 scripts/build-index.py` to refresh.
 | [slideshow](../systems/hyperframes/skills/slideshow/SKILL.md) | Author a HyperFrames slideshow — a presentation, pitch deck, or interactive deck with discrete slides, fragment reveals, branching, hotspot navigation, and buil |
 | [talking-head-recut](../systems/hyperframes/skills/talking-head-recut/SKILL.md) | Package an existing talking-head / interview / podcast video with timed, designed GRAPHIC OVERLAY cards — kinetic titles, lower-thirds, data callouts, quotes, s |
 | [website-to-video](../systems/hyperframes/skills/website-to-video/SKILL.md) | Capture a general website/URL and turn it into a video OF the site — tour, showcase, or social clip built from captured screenshots and the site's own brand ass |
+
+## Bundle: m0 (4 skills)
+
+| Skill | Description |
+|-------|-------------|
+| [m0](../systems/m0/skills/m0/SKILL.md) | Cross-tool agent memory control plane. Start, stop, and check the M0 operational-thread server; find the store; drain deferred writes; wire the MCP tools and se |
+| [m0-handoff](../systems/m0/skills/m0-handoff/SKILL.md) | Session handoff and resume for M0. Write a compact_checkpoint before a session ends or context is compacted, and resume from the latest one at the start of a se |
+| [m0-recall](../systems/m0/skills/m0-recall/SKILL.md) | Read the recent M0 operational thread for a project, newest first, to pick up work started in this or another tool. Answers 'where were we' and 'what is next' b |
+| [m0-remember](../systems/m0/skills/m0-remember/SKILL.md) | Write one entry to the M0 operational thread so the next session, in this tool or any other, can continue the work. Records a completed step, a decision, a veri |
 
 ## Bundle: superintelligence (9 skills)
 

--- a/systems/INDEX.md
+++ b/systems/INDEX.md
@@ -10,6 +10,7 @@ Bundles under `systems/` are opt-in via `install.sh --systems <name>`. Directori
 | cognee | `systems/cognee/` | 3 | 0 | 0 | 4 |
 | gsd | `systems/gsd/` | 68 | 24 | 0 | 93 |
 | hyperframes | `systems/hyperframes/` | 20 | 0 | 0 | 928 |
+| m0 | `systems/m0/` | 4 | 0 | 0 | 9 |
 | superintelligence | `systems/superintelligence/` | 9 | 0 | 0 | 1159 |
 | team | `systems/team/` | 0 | 0 | 0 | 2 |
 | claude-code | `adapters/claude-code/` | 0 | 0 | 0 | 3 |

--- a/systems/m0/README.md
+++ b/systems/m0/README.md
@@ -1,0 +1,200 @@
+# M0 — Cross-Tool Agent Memory
+
+A shared *operational thread* for agents: one small local store that records what
+was done, what was verified, and what happens next, so a session starting cold in
+one tool can pick up work left by another.
+
+M0 is Coco's own memory bundle. It ships a working server, an MCP server, and a
+published wire contract ([`SPEC.md`](SPEC.md)). It is deliberately small: one
+SQLite table, two endpoints, Python standard library only, no network calls, no
+telemetry. It sits alongside the [cognee](#m0-or-cognee) bundle, which solves a
+larger problem in a larger way.
+
+---
+
+## Install
+
+```bash
+bash install.sh --systems m0
+```
+
+Or together with other bundles:
+
+```bash
+bash install.sh --adapter claude-code --systems brain,m0
+```
+
+That wires four skills into your IDE. Nothing runs until you start the server.
+
+### Start the server
+
+```bash
+python3 ~/.claude/skills/m0/scripts/m0_server.py serve
+# m0 1.0.0 listening on http://127.0.0.1:8787
+```
+
+There are no dependencies to install. `python3` (3.9+) and its bundled `sqlite3`
+are the whole requirement.
+
+### Wire the MCP tools (optional)
+
+```bash
+claude mcp add coco-m0 -- python3 ~/.claude/skills/m0/scripts/m0_mcp.py
+```
+
+The MCP server exposes `m0_remember` and `m0_recall`. It prefers the HTTP server
+and falls back to the local store directly when nothing is listening, so the
+tools work whether or not you keep a server running.
+
+## Skills
+
+| Skill | What it does |
+|-------|-------------|
+| `/m0` | Status, start/stop, store location, drain, MCP wiring, hook recipes |
+| `/m0-remember` | Write one entry to the thread — a step, a decision, a verification |
+| `/m0-recall` | Read the recent thread for a project, newest first |
+| `/m0-handoff` | Write a handoff before a session ends; resume from one at the start |
+
+## The whole protocol
+
+Two operations. One table. That is all there is.
+
+```bash
+# write
+curl -s -X POST http://127.0.0.1:8787/api/brain/checkpoint \
+  -H 'Content-Type: application/json' \
+  -d '{"project":"acme-web","kind":"step_done",
+       "text":"Fixed the token refresh race.",
+       "next_step":"Add a regression test for concurrent refresh.",
+       "last_verified":"pytest tests/auth -q: 31 passed",
+       "meta_json":{"pr":42}}'
+# {"id":"9a71de71…","ts":"2026-08-01T13:31:26.536Z","ok":true,"deferred":false}
+
+# read
+curl -s 'http://127.0.0.1:8787/api/brain/thread?project=acme-web&limit=5'
+```
+
+Entries carry a `kind`: `step_done` (a fact or decision, the default),
+`compact_checkpoint` (a session handoff), `session_end`, `lane_dispatched`,
+`lane_result`, `ambient_signal`.
+
+Four guarantees, all specified in [`SPEC.md`](SPEC.md) and all covered by the
+smoke test:
+
+- **Idempotent.** `id` is a content hash. The same write twice leaves one row and
+  returns the same response, so retries and re-fired hooks are harmless.
+- **Never loses a write.** If the store is briefly locked, the entry is spooled to
+  a sidecar file and the response says `deferred: true`; the spool drains on next
+  start. This is what makes it safe to call from a shutdown hook.
+- **Bounded.** Every database call carries a short, configurable busy timeout
+  (10s by default). A caller can always tell "busy" from "hung".
+- **Local-only.** SQLite on disk, loopback bind, no outbound calls, no telemetry.
+
+### Where your data lives
+
+`$XDG_DATA_HOME/coco-m0/thread.db`, i.e. `~/.local/share/coco-m0/thread.db` on a
+default setup. Override with `M0_DB`. Sidecars sit in `sidecars/` next to it.
+It is a plain SQLite file: inspect it with `sqlite3`, back it up with `cp`, delete
+it to forget everything. Uninstalling is removing the symlinked skills and that
+file.
+
+## Verify it
+
+```bash
+bash systems/m0/tests/m0-smoke.sh
+```
+
+27 assertions in a throwaway directory on an ephemeral port: round trip,
+idempotency (including the same metadata re-encoded as a string), the deferred
+write under a genuinely locked store, the drain on restart, and the MCP tools
+over stdio. It touches no existing store. Point `M0_BASE_URL` at another
+implementation to check it against the spec.
+
+## M0 or cognee
+
+Both bundles give agents memory that outlives a session. They are not the same
+size of thing, and the honest summary is that cognee can do much more.
+
+**cognee is a mature knowledge-graph memory platform** (Apache-2.0, developed
+independently of Coco; the `systems/cognee/` bundle wires the upstream project in).
+It
+builds a real graph with embeddings over your content: semantic search, graph
+traversal, cross-dataset entity linking, ingestion pipelines for documents and
+code, a choice of vector and graph backends. If you want to ask "what do we know
+about X" and get an answer assembled from everything you have ever fed it,
+cognee is the right tool and M0 is not a substitute.
+
+**M0 is a session-continuity log.** It answers one question — "where were we, and
+what is next" — and answers it in a few milliseconds from a file with no server
+dependencies beyond `python3`.
+
+| | M0 | cognee |
+|---|---|---|
+| Problem solved | Cross-tool session continuity | General long-term knowledge memory |
+| Storage | One SQLite table | Knowledge graph + vector store (+ relational) |
+| Retrieval | Recent entries by project and kind | Semantic, graph traversal, lexical, hybrid |
+| Dependencies | Python standard library | Python package plus graph/vector backends |
+| Runtime | ~640 lines of stdlib Python, one process — or none | A server and its backing stores |
+| Entity extraction | None | Automatic, LLM-assisted |
+| Embeddings / LLM calls | None | Yes, by design |
+| Network | Loopback only, no outbound calls | Model and backend endpoints as configured |
+| Wire contract | Published, `m0/1`, reimplementable | The project's own API |
+| Reads across projects | Yes, flat by `project` key | Yes, as graph queries across datasets |
+
+### What M0 does not do
+
+Stated plainly, so you can rule it out quickly:
+
+- **No semantic search.** Retrieval is by project, kind and recency. There is no
+  embedding, no ranking, no similarity. "Show me the last 20 entries" is the query
+  model. Nothing else.
+- **No entity or relationship extraction.** M0 stores the prose you give it. It
+  does not discover that two entries mention the same person or module, and there
+  is no graph to traverse.
+- **No summarisation, compression or consolidation.** The thread grows
+  monotonically. Nothing merges old entries or builds higher-level summaries; if
+  you want that, write a `compact_checkpoint` yourself.
+- **No ingestion.** It does not read your documents, mail, transcripts or
+  repository. Every entry arrives because something called the write endpoint.
+- **No multi-user story.** `owner_user_id` and `visibility` exist as columns and
+  are stamped on every row, but the reference server enforces nothing and has no
+  authentication. It binds to loopback and trusts every caller.
+- **No automatic capture.** Nothing writes for you until you wire a hook or an
+  agent decides to call `m0_remember`. The `/m0` skill has hook recipes; installing
+  them is your choice.
+- **No conflict resolution or sync.** One local file. No replication, no merge, no
+  remote. Two machines are two threads.
+
+### Choosing
+
+- Pick **M0** if you want session continuity across tools today, with nothing to
+  operate and nothing leaving the machine; or if you need a memory contract you
+  can implement in another language.
+- Pick **cognee** if you want a searchable knowledge base with entity linking and
+  semantic retrieval, and you are willing to run and feed it.
+- Run **both** if that fits: M0 for "where were we", cognee for "what do we know".
+  They share no state and do not interfere.
+
+## Layout
+
+```
+systems/m0/
+├── README.md                       this file
+├── SPEC.md                         the wire contract (m0/1)
+├── skills/
+│   ├── m0/
+│   │   ├── SKILL.md                control plane
+│   │   └── scripts/
+│   │       ├── m0_server.py        reference server + CLI (stdlib only)
+│   │       └── m0_mcp.py           MCP server, two tools (stdlib only)
+│   ├── m0-remember/SKILL.md        write path
+│   ├── m0-recall/SKILL.md          read path
+│   └── m0-handoff/SKILL.md         handoff / resume flow
+└── tests/m0-smoke.sh               27 assertions against a live server
+```
+
+## License
+
+MIT, matching the Coco core. Written from the `m0/1` specification in this
+directory; no third-party code is vendored, and nothing here is derived from any
+other implementation.

--- a/systems/m0/SPEC.md
+++ b/systems/m0/SPEC.md
@@ -1,0 +1,321 @@
+# M0 protocol specification
+
+**Spec version:** `m0/1`
+**Status:** stable
+**License:** MIT
+
+M0 is a minimal protocol for a shared *operational thread*: the running record of
+what an agent did, what it verified, and what should happen next. Any number of
+tools — different CLIs, editors, hooks, daemons — write to one store and read the
+same thread back, so a session that starts cold can pick up where another left off.
+
+This document is the contract. It is written so that a second implementation can
+be built from it without reference to any particular codebase, in any language,
+and remain wire-compatible. The reference implementation that ships with this
+bundle (`skills/m0/scripts/m0_server.py`, Python standard library only) is one
+conforming server, not the definition.
+
+The keywords MUST, MUST NOT, SHOULD and MAY are used in the usual sense.
+
+---
+
+## 1. Data model
+
+A conforming store holds exactly one logical relation, `operational_thread`, with
+these fields. The order is normative because the content hash depends on it.
+
+| # | Field | Type | Null | Meaning |
+|---|-------|------|------|---------|
+| 1 | `id` | text | no | Primary key. The content hash defined in §2. |
+| 2 | `project` | text | no | Project key that scopes the thread. Any stable string; a repository or directory name is typical. |
+| 3 | `session_id` | text | yes | Identifier of the writing session, when the writer knows one. |
+| 4 | `source_tool` | text | yes | Which tool wrote the entry (`claude-code`, `cursor`, `mcp`, a hook name, …). Provenance for cross-tool reading. |
+| 5 | `role` | text | yes | Who the entry speaks for. `assistant` by default; `user` or `system` are permitted. |
+| 6 | `kind` | text | no | One of the values in §3. |
+| 7 | `ts` | text | no | Write time, UTC ISO-8601 with a literal trailing `Z`, e.g. `2026-08-01T13:31:26.536Z`. Millisecond precision is RECOMMENDED. |
+| 8 | `branch` | text | yes | Version-control branch at write time, when meaningful. |
+| 9 | `head_sha` | text | yes | Version-control HEAD at write time, when meaningful. |
+| 10 | `next_step` | text | yes | The single next action a fresh session should take. |
+| 11 | `last_verified` | text | yes | What was actually verified, and how. Distinguishes a checked claim from an assumed one. |
+| 12 | `text` | text | no | The entry itself, in prose. MUST be non-empty. |
+| 13 | `meta_json` | text | yes | Structured metadata, stored as a canonical JSON string (§4). |
+| 14 | `owner_user_id` | text | yes | Owner of the row. Defaults to a single local identity; present so a multi-tenant store can enforce ownership without a schema change. |
+| 15 | `visibility` | text | yes | `private` (default), or any value a deployment defines. Present for the same reason as `owner_user_id`. |
+
+A store SHOULD index `(project, ts DESC)` and `(project, kind, ts DESC)`.
+
+Nothing else is required. There is no separate session table, no embedding, no
+graph. That is the point: the thread is append-only prose plus a handful of
+context columns, which is what makes the protocol implementable in an afternoon.
+
+## 2. Identity: the content hash
+
+`id` is the lowercase hex SHA-256 of the entry's content-bearing fields:
+
+1. Take fields 2–15 above **in table order, skipping `ts`** — that is:
+   `project`, `session_id`, `source_tool`, `role`, `kind`, `branch`, `head_sha`,
+   `next_step`, `last_verified`, `text`, `meta_json`, `owner_user_id`,
+   `visibility`.
+   Note that the traversal order is the table order, so `kind` precedes `branch`.
+2. Replace every null with the empty string. Apply the defaults from §5 *before*
+   hashing, so a defaulted field and an explicitly supplied identical value hash
+   the same.
+3. Join with a single NUL byte (`U+0000`) as separator.
+4. UTF-8 encode, SHA-256, lowercase hex, all 64 characters.
+
+Reference implementation:
+
+```python
+HASHED = ("project", "session_id", "source_tool", "role", "kind", "branch",
+          "head_sha", "next_step", "last_verified", "text", "meta_json",
+          "owner_user_id", "visibility")
+
+def content_id(row):
+    joined = "\x00".join((row.get(f) or "") for f in HASHED)
+    return hashlib.sha256(joined.encode("utf-8")).hexdigest()
+```
+
+`ts` is excluded because it is a clock reading, not content. Two writes of the
+same content at different times are the same entry; that is what makes a retry,
+a re-fired hook, or a replayed log harmless.
+
+## 3. `kind` values
+
+Exactly six values are defined. A server MUST reject an unknown `kind` rather
+than storing it, so that a typo fails loudly instead of creating a category no
+reader knows to look for.
+
+| `kind` | Use it for |
+|--------|-----------|
+| `step_done` | A completed step, a fact, or a decision. The default. |
+| `compact_checkpoint` | A session handoff: enough state that a fresh session can continue. Written before context is dropped or a session ends. |
+| `session_end` | A session closing. Typically written by a shutdown hook. |
+| `lane_dispatched` | Work delegated to a subagent, worker or parallel lane. |
+| `lane_result` | The outcome of delegated work. |
+| `ambient_signal` | Context observed passively rather than reported by the agent. |
+
+## 4. `meta_json` normalisation
+
+`meta_json` is stored as a canonical JSON string: keys sorted, no insignificant
+whitespace (`json.dumps(obj, sort_keys=True, separators=(",", ":"))`). Canonical
+form is required so that logically identical metadata hashes identically.
+
+A conforming server MUST accept all of the following for the write field, and
+normalise before hashing:
+
+| Input | Stored as |
+|-------|-----------|
+| JSON object or array | canonicalised form of that value |
+| String that parses as a JSON object or array | canonicalised form of the parsed value |
+| String that parses as a JSON scalar | `{"value": <scalar>}` |
+| Number or boolean | `{"value": <scalar>}` |
+| Any other string | `{"note": "<the string>"}` |
+| `null`, absent, or empty string | null |
+
+The last row is deliberate. A metadata parameter that rejects input it could
+have stored is worse than a lenient one: callers stop using it, and the metadata
+never gets written at all. **This rule exists because of a real defect.** In an
+MCP tool, declaring this parameter as `{"type": "string"}` makes it unusable —
+clients parse a JSON-looking string argument into an object before the tool is
+invoked, so the value that arrives never matches the declared type and every
+valid call is rejected. Declare it as `{"type": "object"}` and accept strings
+defensively, as §7 requires.
+
+Servers MUST accept `meta` as an alias for `meta_json` on write.
+
+## 5. Write — `POST /api/brain/checkpoint`
+
+Request body: a JSON object.
+
+| Field | Required | Default |
+|-------|----------|---------|
+| `project` | yes | — (a server MAY substitute an environment default) |
+| `text` | yes | — MUST be non-empty after trimming |
+| `kind` | no | `step_done` |
+| `next_step` | no | null |
+| `last_verified` | no | null |
+| `meta_json` (or `meta`) | no | null |
+| `session_id` | no | environment default, else null |
+
+A conforming server MUST also accept these optional passthrough fields, which map
+onto the remaining columns: `source_tool`, `role`, `branch`, `head_sha`,
+`owner_user_id`, `visibility`, `ts`. Clients that record version-control context
+(the handoff flow does) need them, and a server that silently dropped them would
+lose data it was handed.
+
+Defaults applied before hashing: `role` → `assistant`, `owner_user_id` → a local
+identity (`local` in the reference server), `visibility` → `private`,
+`ts` → now. A server MAY source `session_id`, `source_tool`, `owner_user_id` and
+`visibility` from its environment when absent from the body.
+
+Response, HTTP 200:
+
+```json
+{"id": "<64 hex chars>", "ts": "<stored ts>", "ok": true, "deferred": false}
+```
+
+- `id` — the content hash (§2).
+- `ts` — the timestamp **as stored**. On a repeat write this is the original
+  timestamp, not the current time (§6.1).
+- `ok` — `true` when the write is durable *or* spooled. A write that is neither
+  MUST NOT report `ok: true`.
+- `deferred` — `true` when the entry went to the sidecar spool instead of the
+  store (§6.2).
+
+Errors: HTTP 400 with `{"ok": false, "error": "<message>"}` for a missing
+`project`, an empty `text`, an unknown `kind`, an unparseable body, or a
+non-integer `limit`. HTTP 404 for an unknown route, 500 for an unexpected fault.
+A server MUST NOT return HTTP 200 with `ok: false`.
+
+## 6. Guarantees
+
+### 6.1 Idempotent
+
+The write is an upsert on `id`. Writing the same content twice MUST leave exactly
+one row and MUST return the same `id`. First write wins: a repeat MUST NOT
+overwrite the stored `ts` or any other stored field. Consequently two identical
+writes return byte-identical responses, which is the cheapest way for a caller
+to tell a retry from a new entry.
+
+### 6.2 Never loses a write
+
+Callers include shutdown and compaction hooks: paths that run once, at a bad
+moment, and cannot retry. So a write that cannot reach the store MUST NOT be
+dropped.
+
+When the store rejects the insert because it is busy or locked, the server MUST:
+
+1. Serialise the fully normalised entry (all 15 fields, `id` and `ts` included)
+   to a sidecar file, written atomically — temporary file in the same directory,
+   `fsync`, then rename over the target.
+2. Return HTTP 200 with `deferred: true` and `ok: true`.
+
+The sidecar file MUST be a single JSON object whose keys are the field names of
+§1. The file name is unconstrained; `<ts>-<id prefix>.json` sorts usefully.
+
+A conforming server MUST drain the spool on start: for each file, insert the
+entry (idempotently, per §6.1) and delete the file on success. If the store is
+still busy, the remaining files MUST stay spooled for a later attempt. A file
+that is not valid JSON, or lacks an `id`, MUST be moved aside rather than
+retried forever. A server MAY also expose an explicit drain (the reference
+server has `POST /api/brain/sidecars/drain` and a `drain` CLI subcommand).
+
+### 6.3 Bounded
+
+Every store call MUST carry an explicit busy timeout, and it MUST be short
+enough that a caller can tell "busy" from "hung". A default in the region of
+10 seconds is RECOMMENDED and MUST be configurable. Long timeouts — a minute or
+more — are non-conforming: from the caller's side, a two-minute wait inside a
+shutdown hook is indistinguishable from a hang, and the deferred path in §6.2
+exists precisely so that waiting is never necessary.
+
+### 6.4 Local-only by default
+
+A conforming server MUST default to a loopback bind, MUST NOT make outbound
+network calls in the course of serving these endpoints, and MUST NOT emit
+telemetry. A non-loopback bind SHOULD warn, since the protocol defines no
+authentication.
+
+### 6.5 Resilient read
+
+A read MUST still succeed while the store is busy. A server SHOULD return the
+union of the stored rows and the pending sidecar entries, marking the pending
+ones (the reference server sets `"pending": true`), so that a deferred write is
+readable immediately rather than after the next drain. If the stored rows cannot
+be read at all, the server SHOULD return what it has and report the reason in
+`degraded`.
+
+## 7. Read — `GET /api/brain/thread`
+
+Query parameters:
+
+| Parameter | Required | Default | Meaning |
+|-----------|----------|---------|---------|
+| `project` | no | all projects | Scope to one project. |
+| `limit` | no | 20 | Maximum entries. A server SHOULD cap this (500 in the reference server). |
+| `kind` | no | all kinds | Filter to one `kind`. An unknown value MUST be rejected. |
+
+Response, HTTP 200: entries ordered by `ts` descending — **newest first** — with
+`id` descending as a tiebreak.
+
+```json
+{
+  "project": "acme-web",
+  "kind": null,
+  "limit": 20,
+  "count": 1,
+  "pending_sidecars": 0,
+  "degraded": null,
+  "entries": [
+    {
+      "id": "9a71de71…",
+      "project": "acme-web",
+      "session_id": "sess-001",
+      "source_tool": "claude-code",
+      "role": "assistant",
+      "kind": "compact_checkpoint",
+      "ts": "2026-08-01T13:31:26.536Z",
+      "branch": "feat/auth",
+      "head_sha": "deadbee",
+      "next_step": "Wire the new middleware into the admin router.",
+      "last_verified": "pytest tests/ -q: 214 passed",
+      "text": "Refactored the auth middleware and got the full suite green.",
+      "meta_json": "{\"pr\":42,\"tests\":\"green\"}",
+      "owner_user_id": "local",
+      "visibility": "private"
+    }
+  ]
+}
+```
+
+Every entry MUST carry all 15 fields of §1. `count`, `entries` and newest-first
+ordering are required; `pending_sidecars` and `degraded` are RECOMMENDED.
+Additional keys are permitted, so clients MUST ignore fields they do not know.
+
+## 8. MCP surface
+
+A conforming MCP server exposes at least two tools over JSON-RPC 2.0 on stdio:
+
+- **`m0_remember`** — wraps §5. Required input: `text`. Optional: `project`,
+  `kind` (enumerated), `next_step`, `last_verified`, `session_id`, `branch`,
+  `head_sha`, and `meta`.
+- **`m0_recall`** — wraps §7. Optional input: `project`, `limit`, `kind`.
+
+`meta` MUST be declared as `{"type": "object"}`, for the reason given in §4.
+Tool-execution failures MUST be returned as a result with `isError: true`, not
+as a JSON-RPC protocol error, so the client can show the agent what went wrong.
+
+## 9. Optional endpoints
+
+A server MAY implement these. Clients MUST NOT depend on them.
+
+- `GET /api/health` → `{"ok", "version", "spec", "db", "rows", "pending_sidecars", "degraded", "local_only", …}`
+- `POST /api/brain/sidecars/drain` → `{"drained", "skipped", "quarantined"}`
+
+## 10. Conformance checklist
+
+An implementation conforms to `m0/1` when all of the following hold:
+
+- [ ] `operational_thread` carries all 15 fields of §1 with the stated nullability.
+- [ ] `id` matches the §2 hash for the same input, byte for byte.
+- [ ] The six `kind` values of §3 are accepted; anything else is rejected.
+- [ ] `meta_json` normalises per §4, including the object/string/free-text cases.
+- [ ] `POST /api/brain/checkpoint` accepts §5's required, optional and passthrough fields and returns the four documented response keys.
+- [ ] A repeat write returns the same `id` and `ts` and leaves one row (§6.1).
+- [ ] A busy store yields `deferred: true` plus an atomically written sidecar, and the spool drains on start (§6.2).
+- [ ] Every store call has a configurable, short busy timeout (§6.3).
+- [ ] Loopback bind by default, no outbound calls, no telemetry (§6.4).
+- [ ] Reads succeed while the store is busy (§6.5).
+- [ ] `GET /api/brain/thread` returns newest-first entries with all 15 fields (§7).
+- [ ] The MCP `meta` parameter is typed `object` (§8).
+
+`systems/m0/tests/m0-smoke.sh` exercises every item on that list against a live
+server, in a throwaway directory. Run it against your own implementation by
+pointing `M0_BASE_URL` at it.
+
+## 11. Versioning
+
+The spec version is `m0/1`. Additive fields and additional endpoints are minor
+changes and do not bump it. Anything that changes the hash input, the meaning of
+a `kind`, or a response key that clients read bumps it to `m0/2`. A server
+SHOULD report its spec version from `GET /api/health`.

--- a/systems/m0/skills/m0-handoff/SKILL.md
+++ b/systems/m0/skills/m0-handoff/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: m0-handoff
+description: "Session handoff and resume for M0. Write a compact_checkpoint before a session ends or context is compacted, and resume from the latest one at the start of a session in any tool. Turns a cold start into a continuation. Triggers on: 'm0 handoff', 'hand off', 'session handoff', 'save session state', 'resume where we left off', 'pick up where we left off', 'before I compact', 'end of session', 'continue in Cursor', 'continue in Claude Code'."
+---
+
+# /m0-handoff — Hand Off and Resume
+
+Two halves of one flow, both against the M0 operational thread:
+
+- **Hand off** — write a `compact_checkpoint` that a session with no other context
+  could act on.
+- **Resume** — read the latest one and continue, in this tool or another.
+
+This is what M0 exists for. Everything else in the bundle supports it.
+
+## Quick Reference
+
+```bash
+M0="${M0_BASE_URL:-http://127.0.0.1:8787}"
+M0S="$HOME/.claude/skills/m0/scripts"
+PROJECT="${M0_PROJECT:-$(basename "$PWD")}"
+
+# Hand off
+curl -s -X POST "$M0/api/brain/checkpoint" -H 'Content-Type: application/json' -d "$(python3 - <<'PY'
+import json, os, subprocess
+def git(*a):
+    try: return subprocess.check_output(("git",)+a, text=True, stderr=subprocess.DEVNULL).strip()
+    except Exception: return None
+print(json.dumps({
+  "project": os.environ.get("M0_PROJECT") or os.path.basename(os.getcwd()),
+  "kind": "compact_checkpoint",
+  "source_tool": "claude-code",
+  "branch": git("rev-parse", "--abbrev-ref", "HEAD"),
+  "head_sha": git("rev-parse", "--short", "HEAD"),
+  "text": "<what state the work is in>",
+  "next_step": "<the single next action>",
+  "last_verified": "<command and its actual result>",
+  "meta_json": {"open_questions": ["<anything unresolved>"]},
+}))
+PY
+)"
+
+# Resume
+curl -s "$M0/api/brain/thread?project=$PROJECT&kind=compact_checkpoint&limit=1" | python3 -m json.tool
+```
+
+Serverless equivalents, same store:
+
+```bash
+python3 "$M0S/m0_server.py" write --project "$PROJECT" --kind compact_checkpoint \
+  --text "…" --next-step "…" --last-verified "…" \
+  --branch "$(git rev-parse --abbrev-ref HEAD 2>/dev/null)" \
+  --head-sha "$(git rev-parse --short HEAD 2>/dev/null)"
+
+python3 "$M0S/m0_server.py" read --project "$PROJECT" --kind compact_checkpoint --limit 1
+```
+
+## Handing off
+
+Write one before the context window is compacted, before a session ends, and
+before switching tools. Do not wait to be asked.
+
+1. **Resolve the project key** — `$M0_PROJECT`, else the repository or directory name.
+   The same value the earlier entries used; check with `/m0-recall` if unsure.
+2. **Write the four things** that a stranger needs:
+
+   | Field | What belongs there |
+   |-------|--------------------|
+   | `text` | Where the work stands. What is done, what is half-done, what is broken. Prose, no jargon from this conversation. |
+   | `next_step` | The single next action, concrete enough to start on. One action, not a plan. |
+   | `last_verified` | The command that was run and what it actually printed. Empty if nothing was verified. |
+   | `meta_json` | Anything structured worth keeping: `{"open_questions": [...], "files": [...], "pr": 42}`. |
+
+3. **Include `branch` and `head_sha`.** Without them a reader cannot tell whether
+   the checkpoint describes the tree in front of them.
+4. **Set `source_tool`** to the tool you are running in, so the next reader knows
+   where the work happened.
+5. **Confirm the response.** `deferred: true` means the store was busy and the entry
+   is spooled to a sidecar file: real, readable, and landing on the next drain, but
+   say so rather than reporting a clean write.
+
+### What a good handoff looks like
+
+```json
+{
+  "kind": "compact_checkpoint",
+  "text": "Auth middleware refactor is done and green. The admin router still uses the old wrapper, so admin requests bypass the new nonce check.",
+  "next_step": "Replace the old wrapper in routers/admin.py with require_session, then re-run tests/admin.",
+  "last_verified": "pytest tests/auth tests/api -q: 214 passed, 0 failed",
+  "branch": "feat/auth",
+  "head_sha": "9f2c1ab",
+  "meta_json": {"open_questions": ["Should legacy tokens keep working past the cutover?"]}
+}
+```
+
+The failure mode to avoid is a checkpoint that only makes sense to the session
+that wrote it: "continued the refactor, tests mostly fine, next step as
+discussed". Assume the reader has nothing but this row.
+
+## Resuming
+
+1. **Fetch the latest checkpoint** for the project (`kind=compact_checkpoint`,
+   `limit=1`). If there is none, fall back to the full thread via `/m0-recall`.
+2. **Reconcile it with reality before acting.** The checkpoint is a claim from an
+   earlier moment:
+
+   ```bash
+   git rev-parse --abbrev-ref HEAD; git rev-parse --short HEAD; git status --short
+   ```
+
+   Same branch and sha means the description probably still holds. Different, or a
+   dirty tree, means the world moved — read the newer entries too, and re-run
+   whatever `last_verified` claims if you are about to build on it.
+3. **Tell the user what you found**, in three lines: where the work stands, what
+   was last verified, what the recorded next step is. Then say what you will do.
+4. **Ask before acting on a stale next step.** If the recorded next step no longer
+   fits the tree, say so and propose the alternative rather than following it
+   mechanically.
+5. **Write the next entry as you go**, with `/m0-remember`, so the thread does not
+   go quiet again until the following handoff.
+
+## Crossing tools
+
+The thread is one local store, keyed by project, with `source_tool` on every row.
+So "finish this in the other editor" is just: hand off here, resume there.
+
+- Use the **same project key** in both tools. `M0_PROJECT` in each tool's
+  environment is the reliable way; a mismatch produces two threads that each look
+  empty.
+- Set **`source_tool` honestly** in both, so a reader can tell which tool made a
+  claim.
+- Nothing syncs between machines. One machine, one thread.
+
+## Automating the handoff
+
+A session-end hook makes a handoff unconditional rather than remembered — see
+`/m0 hooks` for the recipe. It writes a `session_end` entry with the branch and
+sha even if the agent forgot to write a checkpoint, and because a shutdown hook
+runs at a bad moment, this is precisely the case the deferred-write path was built
+for: a locked store spools the entry instead of dropping it.
+
+A hook cannot know what the work state was, only that the session ended. It is a
+floor, not a substitute for an explicit `compact_checkpoint`.

--- a/systems/m0/skills/m0-recall/SKILL.md
+++ b/systems/m0/skills/m0-recall/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: m0-recall
+description: "Read the recent M0 operational thread for a project, newest first, to pick up work started in this or another tool. Answers 'where were we' and 'what is next' before asking the user to repeat context. Local SQLite, no embeddings, no network. Triggers on: 'm0 recall', 'where were we', 'what did we do last time', 'catch me up', 'resume context', 'read the thread', 'what is next'."
+---
+
+# /m0-recall — Read the Operational Thread
+
+The read path for M0. Returns the most recent entries for a project, newest
+first, with the `next_step` and `last_verified` that were recorded when they were
+still true.
+
+Retrieval is by project, kind and recency — there is no semantic search. That is
+the whole query model, and it is why this returns in milliseconds.
+
+## Quick Reference
+
+```bash
+M0="${M0_BASE_URL:-http://127.0.0.1:8787}"
+M0S="$HOME/.claude/skills/m0/scripts"
+
+# The recent thread for a project
+curl -s "$M0/api/brain/thread?project=acme-web&limit=10" | python3 -m json.tool
+
+# Just the handoffs
+curl -s "$M0/api/brain/thread?project=acme-web&kind=compact_checkpoint&limit=3"
+
+# Without a server (same store)
+python3 "$M0S/m0_server.py" read --project acme-web --limit 10
+```
+
+If the MCP tools are wired (`/m0 mcp`), call `m0_recall` directly — it returns the
+same data already formatted for reading.
+
+## Parameters
+
+| Parameter | Default | Notes |
+|-----------|---------|-------|
+| `project` | all projects | Omit only when you genuinely want every project. |
+| `limit` | 20 | Capped at 500. |
+| `kind` | all kinds | `step_done`, `compact_checkpoint`, `session_end`, `lane_dispatched`, `lane_result`, `ambient_signal`. An unknown value is rejected. |
+
+## Procedure
+
+1. **Resolve the project key** the same way the write path does: `$M0_PROJECT`, else
+   the repository or directory name.
+2. **Start broad, then narrow.** `limit=10` with no `kind` filter shows what has
+   been happening. If the thread is long, `kind=compact_checkpoint` gives the
+   handoffs, which is usually the fastest way to orient.
+3. **Read the newest entry first.** It carries the freshest `next_step`. Older
+   `next_step` values have usually been superseded — do not act on a stale one.
+4. **Summarise for the user in three lines:** where the work stands, what was last
+   verified, and what the recorded next step is. Then say what you intend to do.
+5. **Check `source_tool` and `branch`** on the entries you rely on. An entry written
+   by another tool on another branch may not describe the tree you are looking at.
+6. **Verify before building on a claim.** `last_verified` records what someone said
+   they checked, at some earlier point. If it matters now, re-run it.
+
+## Reading the response
+
+```json
+{
+  "project": "acme-web",
+  "count": 2,
+  "pending_sidecars": 0,
+  "degraded": null,
+  "entries": [ { "ts": "…", "kind": "step_done", "text": "…", "next_step": "…" } ]
+}
+```
+
+| Signal | What it means |
+|--------|---------------|
+| `count: 0` | Nothing recorded for that project. Check the project key before concluding the thread is empty — a typo reads as "no memory". |
+| `"pending": true` on an entry | It is still in the sidecar spool, not yet in the store. Real, and readable, but not durable until the next drain. |
+| `pending_sidecars > 0` | Some writes are spooled. Run `python3 "$M0S/m0_server.py" drain`. |
+| `degraded` set | The store could not be read — another process holds the lock — so the entries shown may be only the spooled ones. Say so; do not present a partial thread as complete. |
+
+## When to call this
+
+- **At the start of a session**, before asking the user what you were doing.
+- **When picking up work started in another tool** — the thread is shared, so a
+  session in one editor can read what another wrote.
+- **After a context compaction**, to recover the operational state rather than
+  re-reading the whole history.
+- **Before re-doing anything expensive.** The thread often already records the
+  result, and whether it was verified.
+
+## Limits, stated plainly
+
+- No semantic search, no ranking, no similarity. Recency and `kind`, nothing else.
+- No entity or relationship extraction, so there is no "everything about X" query.
+- No summarisation. A long thread is long; `compact_checkpoint` entries are the
+  compression, and only because someone wrote them.
+- Only what was explicitly written is there. Nothing is captured automatically
+  unless a hook was installed (`/m0 hooks`).
+
+For semantic retrieval over a knowledge graph, the cognee bundle is the right
+tool — see the comparison in `systems/m0/README.md`.

--- a/systems/m0/skills/m0-remember/SKILL.md
+++ b/systems/m0/skills/m0-remember/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: m0-remember
+description: "Write one entry to the M0 operational thread so the next session, in this tool or any other, can continue the work. Records a completed step, a decision, a verification result, or a dispatched lane. Idempotent and local-only. Triggers on: 'remember this', 'm0 remember', 'save to memory', 'log this decision', 'record what we did', 'note for next session', 'write a checkpoint'."
+---
+
+# /m0-remember — Write to the Operational Thread
+
+The write path for M0. One call appends one entry to the shared thread for a
+project. Writing the same content twice creates one row, so this is safe to call
+after every step and safe to retry.
+
+## Quick Reference
+
+```bash
+M0="${M0_BASE_URL:-http://127.0.0.1:8787}"
+M0S="$HOME/.claude/skills/m0/scripts"
+
+# Over HTTP
+curl -s -X POST "$M0/api/brain/checkpoint" \
+  -H 'Content-Type: application/json' \
+  -d '{"project":"acme-web","kind":"step_done",
+       "text":"Fixed the token refresh race in the auth middleware.",
+       "next_step":"Add a regression test for two concurrent refreshes.",
+       "last_verified":"pytest tests/auth -q: 31 passed",
+       "source_tool":"claude-code","meta_json":{"pr":42}}'
+# {"id":"9a71de71…","ts":"2026-08-01T13:31:26.536Z","ok":true,"deferred":false}
+
+# Without a server (same store, same guarantees)
+python3 "$M0S/m0_server.py" write \
+  --project acme-web --kind step_done \
+  --text "Fixed the token refresh race in the auth middleware." \
+  --next-step "Add a regression test for two concurrent refreshes." \
+  --last-verified "pytest tests/auth -q: 31 passed" \
+  --source-tool claude-code --meta '{"pr":42}'
+```
+
+If the MCP tools are wired (`/m0 mcp`), call `m0_remember` directly instead — same
+endpoint, fewer moving parts, and `meta` takes a real JSON object.
+
+## Fields
+
+| Field | Required | What to put in it |
+|-------|----------|-------------------|
+| `project` | yes | The project key. Use one stable value per project — the repository or directory name is the usual choice. Getting this wrong splits the thread. |
+| `text` | yes | What happened, in one or two plain sentences. Written for a reader with no other context. |
+| `kind` | no | Defaults to `step_done`. See the table below. |
+| `next_step` | no | The single next action. Concrete enough to act on without re-deriving it. |
+| `last_verified` | no | What was actually checked, and how. A command and its result, not an impression. |
+| `meta_json` | no | Structured metadata as a JSON object, e.g. `{"pr":42,"tests":"green"}`. |
+| `session_id` | no | Session identifier, when known. |
+| `source_tool` | no | Which tool is writing. Fill it in — it is what makes the thread legible across tools. |
+| `branch`, `head_sha` | no | Version-control position. Worth including whenever the entry is about code. |
+
+Kinds:
+
+| `kind` | Use it for |
+|--------|-----------|
+| `step_done` | A completed step, a fact, or a decision. The default. |
+| `compact_checkpoint` | A session handoff — see `/m0-handoff`. |
+| `session_end` | A session closing, usually from a hook. |
+| `lane_dispatched` | Work handed to a subagent or parallel lane. |
+| `lane_result` | The outcome of that work. |
+| `ambient_signal` | Context observed rather than reported. |
+
+An unknown `kind` is rejected with HTTP 400, deliberately: a typo would create a
+category no reader looks in.
+
+## Procedure
+
+1. **Resolve the project key.** Use `$M0_PROJECT` if set, otherwise the repository
+   or directory name. Reuse whatever earlier entries used — check with
+   `/m0-recall` if unsure. Do not invent a variant.
+2. **Write one entry per meaningful thing.** A step that landed, a decision with
+   its reason, a verification result. Not a running commentary.
+3. **Include version-control context** when the entry is about code:
+
+   ```bash
+   BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)"
+   SHA="$(git rev-parse --short HEAD 2>/dev/null)"
+   ```
+4. **Be honest in `last_verified`.** Put the command and its actual result there.
+   If nothing was verified, leave it empty. A false verification claim in a
+   memory store outlives the session that made it and misleads every later reader.
+5. **Check the response.** `{"ok":true,"deferred":false}` means it is durable.
+   `"deferred":true` means the store was busy and the entry is spooled to a
+   sidecar file — it is not lost and lands on the next drain or server start. Say
+   so rather than reporting a clean write.
+
+## Good and bad entries
+
+```
+text:          "Fixed the token refresh race in the auth middleware: the retry
+                path double-incremented the nonce."
+next_step:     "Add a regression test for two concurrent refreshes."
+last_verified: "pytest tests/auth -q: 31 passed"
+```
+
+```
+text:          "Made some progress on auth."          # nothing to act on
+next_step:     "Continue."                            # not a next step
+last_verified: "Tests should pass now."               # a claim, not a check
+```
+
+## Notes
+
+- **Idempotent.** `id` is a SHA-256 of the content fields, `ts` excluded. Re-writing
+  identical content returns the identical response and leaves one row. Retry
+  freely.
+- **Metadata is lenient.** An object, a JSON string, or free text all work: a JSON
+  string is parsed and canonicalised, anything else is stored as `{"note": "…"}`.
+  It never rejects what it could have kept.
+- **Local-only.** SQLite on disk, loopback server, no outbound calls, no telemetry.
+- **Reading back:** `/m0-recall`. **Handoffs:** `/m0-handoff`. **Plumbing:** `/m0`.

--- a/systems/m0/skills/m0/SKILL.md
+++ b/systems/m0/skills/m0/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: m0
+description: "Cross-tool agent memory control plane. Start, stop, and check the M0 operational-thread server; find the store; drain deferred writes; wire the MCP tools and session hooks. Local SQLite, no dependencies, no network. Triggers on: 'm0', 'm0 status', 'start m0', 'cross-tool memory', 'operational thread', 'agent memory server', 'where is my memory stored'."
+---
+
+# /m0 — Cross-Tool Agent Memory
+
+M0 keeps one local *operational thread* per project: what was done, what was
+verified, what is next. Any tool can write to it and read it back, so a session
+that starts cold can continue work another tool began.
+
+Two operations, one SQLite table, standard library only. The wire contract is in
+`systems/m0/SPEC.md`; the write path is `/m0-remember`, the read path is
+`/m0-recall`, and the session handoff flow is `/m0-handoff`.
+
+## Quick Reference
+
+```bash
+M0S="$HOME/.claude/skills/m0/scripts"          # installed location
+M0="${M0_BASE_URL:-http://127.0.0.1:8787}"     # server base URL
+
+# Is it up, and where does it store?
+curl -s "$M0/api/health" | python3 -m json.tool
+
+# Start it (foreground)
+python3 "$M0S/m0_server.py" serve
+
+# Start it in the background, logging to the store directory
+nohup python3 "$M0S/m0_server.py" serve > "$HOME/.local/share/coco-m0/server.log" 2>&1 &
+
+# Write and read without any server at all
+python3 "$M0S/m0_server.py" write --project my-project --text "Did the thing."
+python3 "$M0S/m0_server.py" read  --project my-project --limit 5
+
+# Land any writes that were deferred while the store was busy
+python3 "$M0S/m0_server.py" drain
+```
+
+If the scripts are not at `$HOME/.claude/skills/m0/scripts`, the bundle was
+installed elsewhere: run `bash install.sh --systems m0` from the Coco checkout,
+or use the in-repo path `systems/m0/skills/m0/scripts`.
+
+## Sub-commands
+
+### /m0 status — is memory working, and where does it live
+
+```bash
+M0="${M0_BASE_URL:-http://127.0.0.1:8787}"
+if curl -fsS "$M0/api/health" >/dev/null 2>&1; then
+    curl -s "$M0/api/health" | python3 -m json.tool
+else
+    echo "No M0 server at $M0."
+    echo "Direct store access still works:"
+    python3 "$HOME/.claude/skills/m0/scripts/m0_server.py" health
+fi
+```
+
+Report to the user, in this order:
+
+1. **Server** — running at `<url>`, or not running (and that this is fine; the CLI
+   and the MCP tools both fall back to the store directly).
+2. **Store** — the `db` path and the `rows` count. This is the whole dataset.
+3. **Pending** — if `pending_sidecars` is above zero, some writes are spooled but
+   not yet landed. Run `drain`.
+4. **Degraded** — if `degraded` is set, another process holds the write lock.
+   Reads still work; writes will defer rather than fail.
+
+### /m0 start — run the server
+
+Ask which the user wants:
+
+- **Foreground** for a quick session: `python3 "$M0S/m0_server.py" serve`
+- **Background** for daily use: the `nohup` line above.
+- **Nothing** — the CLI and MCP tools work against the store directly. A server
+  is only needed when several tools should share one process, or when something
+  can only speak HTTP.
+
+Useful flags and variables:
+
+| Setting | Effect |
+|---------|--------|
+| `--port` / `M0_PORT` | Listen port (default 8787) |
+| `--host` / `M0_HOST` | Bind address (default `127.0.0.1`; anything else warns, there is no auth) |
+| `--db` / `M0_DB` | Store path (default `$XDG_DATA_HOME/coco-m0/thread.db`) |
+| `--busy-timeout-ms` / `M0_BUSY_TIMEOUT_MS` | Per-call SQLite busy timeout (default 10000) |
+| `M0_PROJECT` | Default project when a caller omits one |
+| `M0_SOURCE_TOOL` | Stamped on writes, so you can tell which tool wrote what |
+
+Never set `M0_BUSY_TIMEOUT_MS` to a large value. A long wait inside a shutdown
+hook is indistinguishable from a hang; the deferred-write path exists so waiting
+is never necessary.
+
+### /m0 mcp — wire the two tools
+
+```bash
+claude mcp add coco-m0 -- python3 "$HOME/.claude/skills/m0/scripts/m0_mcp.py"
+claude mcp list          # confirm it is registered
+```
+
+That exposes `m0_remember` and `m0_recall` as tools the agent can call directly,
+which is the lowest-friction way to make memory habitual. For editors that read a
+project `.mcp.json`, the equivalent entry is:
+
+```json
+{
+  "mcpServers": {
+    "coco-m0": {
+      "command": "python3",
+      "args": ["<absolute path>/skills/m0/scripts/m0_mcp.py"],
+      "env": { "M0_PROJECT": "<this project>" }
+    }
+  }
+}
+```
+
+The MCP server prefers the HTTP server and falls back to the store directly when
+nothing is listening, so either mode works. Each result reports which path served
+it under `via`.
+
+### /m0 hooks — capture without being asked
+
+Automatic capture is opt-in. These are recipes for the user to install; **do not
+edit the user's settings files without asking first.** Show the snippet, explain
+what it does, and let them decide.
+
+Session end, so a closing session always leaves a trace:
+
+```bash
+python3 "$HOME/.claude/skills/m0/scripts/m0_server.py" write \
+  --project "$(basename "$PWD")" --kind session_end \
+  --source-tool claude-code \
+  --branch "$(git rev-parse --abbrev-ref HEAD 2>/dev/null)" \
+  --head-sha "$(git rev-parse --short HEAD 2>/dev/null)" \
+  --text "Session ended."
+```
+
+This is exactly the case the deferred-write path was built for: if the store is
+locked at that moment, the entry is spooled to a sidecar file and lands on the
+next start rather than being lost.
+
+Session start, to inject the thread into a fresh session:
+
+```bash
+python3 "$HOME/.claude/skills/m0/scripts/m0_server.py" read \
+  --project "$(basename "$PWD")" --limit 10
+```
+
+### /m0 drain — land deferred writes
+
+```bash
+python3 "$HOME/.claude/skills/m0/scripts/m0_server.py" drain
+# {"drained": 1, "skipped": 0, "quarantined": 0}
+```
+
+- `drained` — entries moved from the spool into the store.
+- `skipped` — the store was still busy; they stay spooled for next time.
+- `quarantined` — files that were not valid entries, renamed `*.json.bad` so they
+  stop blocking the queue. Inspect them; they are plain JSON.
+
+A server drains automatically on start, so this is only needed when running
+serverless or after an unusual amount of write contention.
+
+### /m0 verify — prove it works
+
+```bash
+bash systems/m0/tests/m0-smoke.sh
+```
+
+27 assertions in a throwaway directory on an ephemeral port: the round trip,
+idempotency, a deferred write under a genuinely locked store, the drain on
+restart, and the MCP tools over stdio. It touches no existing store. Run it
+before trusting a change to this bundle, and quote the output rather than
+summarising it.
+
+### /m0 privacy — what leaves the machine
+
+Nothing. The store is a SQLite file on local disk, the server binds to loopback,
+there are no outbound calls in the request path and no telemetry. To inspect,
+back up or forget:
+
+```bash
+DB="$(python3 "$HOME/.claude/skills/m0/scripts/m0_server.py" health | python3 -c 'import json,sys;print(json.load(sys.stdin)["db"])')"
+sqlite3 "$DB" "SELECT ts, kind, substr(text,1,60) FROM operational_thread ORDER BY ts DESC LIMIT 10;"
+cp "$DB" ~/m0-backup.db     # back up
+rm "$DB"                    # forget everything
+```
+
+## When to reach for this
+
+- **Use `/m0-recall`** at the start of a session, or when picking up work started
+  elsewhere, before asking the user to repeat context.
+- **Use `/m0-remember`** after a step lands, a decision is made, or something is
+  verified.
+- **Use `/m0-handoff`** before context is compacted or a session ends.
+- **Use `/m0` (this skill)** for the plumbing: server, store, spool, wiring.
+
+M0 answers "where were we and what is next". It does not do semantic search,
+entity extraction or summarisation — see the comparison with the cognee bundle in
+`systems/m0/README.md` before choosing.

--- a/systems/m0/skills/m0/scripts/m0_mcp.py
+++ b/systems/m0/skills/m0/scripts/m0_mcp.py
@@ -1,0 +1,422 @@
+#!/usr/bin/env python3
+"""M0 MCP server - exposes the M0 memory protocol as two tools over stdio.
+
+Tools:
+    m0_remember   write one entry to the operational thread (idempotent)
+    m0_recall     read the most recent entries, newest first
+
+Transport is JSON-RPC 2.0 over stdin/stdout, one message per line, which is
+what MCP stdio clients speak. Standard library only.
+
+The tools wrap the M0 HTTP endpoints (POST /api/brain/checkpoint and
+GET /api/brain/thread). If no server is listening and M0_MCP_TRANSPORT is
+"auto" (the default), the tools fall back to the local SQLite store directly,
+so memory still works when no daemon is running. Every response reports which
+path served it under "via".
+
+Register with Claude Code:
+    claude mcp add coco-m0 -- python3 <this file>
+
+Environment:
+    M0_BASE_URL         M0 server base URL (default http://127.0.0.1:8787)
+    M0_MCP_TRANSPORT    auto (default) | http | direct
+    M0_PROJECT          default project when a call omits it
+    M0_SOURCE_TOOL      stamped onto writes (default "mcp")
+    M0_HTTP_TIMEOUT     HTTP timeout in seconds (default 15)
+    plus every M0_* variable understood by m0_server.py for the direct path
+
+MIT licensed, part of the Coco M0 bundle.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import m0_server  # noqa: E402  (local module, same directory)
+
+SERVER_NAME = "coco-m0"
+SERVER_VERSION = m0_server.VERSION
+DEFAULT_PROTOCOL = "2025-06-18"
+BASE_URL = os.environ.get("M0_BASE_URL", "http://127.0.0.1:8787").rstrip("/")
+TRANSPORT = os.environ.get("M0_MCP_TRANSPORT", "auto").strip().lower()
+HTTP_TIMEOUT = float(os.environ.get("M0_HTTP_TIMEOUT", "15"))
+
+START_HINT = (
+    "No M0 server is listening at "
+    + BASE_URL
+    + ". Start one with:  python3 "
+    + str(Path(__file__).resolve().parent / "m0_server.py")
+    + " serve"
+)
+
+# meta accepts a JSON object. It is declared as type "object" on purpose: a
+# client that hands the tool structured metadata gets it through unchanged.
+# Declaring it as a string is the bug this server exists not to have - clients
+# coerce a JSON string argument into a dict before the tool sees it, so a
+# string-typed parameter rejects every valid value and is unusable. Strings are
+# still accepted here for compatibility (see m0_server.Store.canonical_meta).
+META_SCHEMA = {
+    "type": "object",
+    "description": (
+        "Optional structured metadata, as a JSON object (not a JSON string). "
+        "Example: {\"pr\": 42, \"tests\": \"green\"}. A JSON-encoded string is "
+        "also accepted and parsed; any other string is stored as "
+        "{\"note\": \"...\"} rather than rejected."
+    ),
+    "additionalProperties": True,
+}
+
+TOOLS = [
+    {
+        "name": "m0_remember",
+        "description": (
+            "Write one entry to the M0 operational thread so the next session - in "
+            "this tool or any other - can pick the work up. Use it after finishing a "
+            "step, making a decision, or before a session ends. Idempotent: writing "
+            "the same content twice creates one row."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "description": "What happened, in one or two plain sentences.",
+                },
+                "project": {
+                    "type": "string",
+                    "description": "Project key. Defaults to $M0_PROJECT, then the current directory name.",
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": list(m0_server.KINDS),
+                    "default": m0_server.DEFAULT_KIND,
+                    "description": (
+                        "step_done for a fact or decision (default); compact_checkpoint "
+                        "for a session handoff; session_end when a session closes; "
+                        "lane_dispatched / lane_result for delegated work; ambient_signal "
+                        "for passively observed context."
+                    ),
+                },
+                "next_step": {
+                    "type": "string",
+                    "description": "The single next action a fresh session should take.",
+                },
+                "last_verified": {
+                    "type": "string",
+                    "description": "What was actually verified, and how (not what was assumed).",
+                },
+                "session_id": {"type": "string", "description": "Session identifier, if known."},
+                "branch": {"type": "string", "description": "Git branch, if relevant."},
+                "head_sha": {"type": "string", "description": "Git HEAD sha, if relevant."},
+                "meta": META_SCHEMA,
+            },
+            "required": ["text"],
+        },
+    },
+    {
+        "name": "m0_recall",
+        "description": (
+            "Read the most recent M0 operational-thread entries for a project, newest "
+            "first. Call this at the start of a session, or when picking up work started "
+            "in another tool, before asking the user to repeat context."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "project": {
+                    "type": "string",
+                    "description": "Project key. Defaults to $M0_PROJECT, then the current directory name.",
+                },
+                "limit": {
+                    "type": "integer",
+                    "default": m0_server.DEFAULT_LIMIT,
+                    "minimum": 1,
+                    "maximum": m0_server.MAX_LIMIT,
+                    "description": "How many entries to return (newest first).",
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": list(m0_server.KINDS),
+                    "description": "Optional filter. Omit for the whole thread.",
+                },
+            },
+        },
+    },
+]
+
+
+# ------------------------------------------------------------------ transports
+
+
+def _http(method: str, path: str, payload: dict | None = None,
+          query: dict | None = None) -> dict:
+    url = BASE_URL + path
+    if query:
+        clean = {k: v for k, v in query.items() if v not in (None, "")}
+        if clean:
+            url += "?" + urllib.parse.urlencode(clean)
+    data = None
+    headers = {"Accept": "application/json"}
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    request = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", "replace")
+        try:
+            parsed = json.loads(body)
+        except json.JSONDecodeError:
+            parsed = {"ok": False, "error": body.strip() or str(exc)}
+        parsed.setdefault("ok", False)
+        parsed["http_status"] = exc.code
+        return parsed
+
+
+_store = None
+
+
+def store() -> m0_server.Store:
+    global _store
+    if _store is None:
+        _store = m0_server.Store()
+    return _store
+
+
+def call_write(payload: dict) -> dict:
+    if TRANSPORT != "direct":
+        try:
+            result = _http("POST", "/api/brain/checkpoint", payload=payload)
+            result["via"] = "http"
+            return result
+        except (urllib.error.URLError, OSError) as exc:
+            if TRANSPORT == "http":
+                return {"ok": False, "error": f"{START_HINT} ({exc})", "via": "http"}
+    result = store().write(payload)
+    result["via"] = "direct"
+    return result
+
+
+def call_read(project: str | None, limit: int, kind: str | None) -> dict:
+    query = {"project": project, "limit": limit, "kind": kind}
+    if TRANSPORT != "direct":
+        try:
+            result = _http("GET", "/api/brain/thread", query=query)
+            result["via"] = "http"
+            return result
+        except (urllib.error.URLError, OSError) as exc:
+            if TRANSPORT == "http":
+                return {"ok": False, "error": f"{START_HINT} ({exc})", "via": "http"}
+    result = store().read(project=project, limit=limit, kind=kind)
+    result["via"] = "direct"
+    return result
+
+
+# ----------------------------------------------------------------- tool bodies
+
+
+def default_project(given) -> str:
+    for candidate in (given, os.environ.get("M0_PROJECT"), Path.cwd().name):
+        if candidate and str(candidate).strip():
+            return str(candidate).strip()
+    return "default"
+
+
+def normalize_meta(args: dict):
+    """Accept meta or meta_json, as an object or a string. Never reject."""
+    raw = args.get("meta")
+    if raw is None:
+        raw = args.get("meta_json")
+    return m0_server.Store.canonical_meta(raw)
+
+
+def tool_remember(args: dict) -> tuple[str, dict]:
+    text = args.get("text")
+    if not text or not str(text).strip():
+        raise ValueError("'text' is required and must be non-empty")
+    payload = {
+        "project": default_project(args.get("project")),
+        "text": str(text).strip(),
+        "kind": args.get("kind") or m0_server.DEFAULT_KIND,
+        "next_step": args.get("next_step"),
+        "last_verified": args.get("last_verified"),
+        "session_id": args.get("session_id"),
+        "source_tool": args.get("source_tool") or os.environ.get("M0_SOURCE_TOOL") or "mcp",
+        "branch": args.get("branch"),
+        "head_sha": args.get("head_sha"),
+        "meta_json": normalize_meta(args),
+    }
+    result = call_write({k: v for k, v in payload.items() if v is not None})
+    if not result.get("ok"):
+        raise ValueError(result.get("error") or "write failed")
+    lines = [
+        f"Remembered in project '{payload['project']}' as {payload['kind']}.",
+        f"  id  {result.get('id')}",
+        f"  ts  {result.get('ts')}",
+        f"  via {result.get('via')}"
+        + ("  (deferred to sidecar - the store was busy; it lands on next drain)"
+           if result.get("deferred") else ""),
+    ]
+    return "\n".join(lines), result
+
+
+def tool_recall(args: dict) -> tuple[str, dict]:
+    project = default_project(args.get("project"))
+    try:
+        limit = int(args.get("limit") or m0_server.DEFAULT_LIMIT)
+    except (TypeError, ValueError):
+        raise ValueError(f"'limit' must be an integer, got {args.get('limit')!r}")
+    kind = args.get("kind") or None
+    result = call_read(project, limit, kind)
+    if result.get("ok") is False:
+        raise ValueError(result.get("error") or "read failed")
+
+    entries = result.get("entries") or []
+    header = f"M0 thread for '{project}'"
+    if kind:
+        header += f" (kind={kind})"
+    header += f" - {len(entries)} entr{'y' if len(entries) == 1 else 'ies'}, newest first"
+    if result.get("degraded"):
+        header += f"  [degraded: {result['degraded']}]"
+    lines = [header, ""]
+    if not entries:
+        lines.append("(nothing recorded yet - write with m0_remember)")
+    for entry in entries:
+        stamp = entry.get("ts") or "?"
+        marks = []
+        if entry.get("source_tool"):
+            marks.append(entry["source_tool"])
+        if entry.get("branch"):
+            marks.append(entry["branch"])
+        if entry.get("pending"):
+            marks.append("pending")
+        suffix = f"  [{' | '.join(marks)}]" if marks else ""
+        lines.append(f"- {stamp}  ({entry.get('kind')}){suffix}")
+        lines.append(f"    {entry.get('text')}")
+        if entry.get("next_step"):
+            lines.append(f"    next: {entry['next_step']}")
+        if entry.get("last_verified"):
+            lines.append(f"    verified: {entry['last_verified']}")
+        if entry.get("meta_json"):
+            lines.append(f"    meta: {entry['meta_json']}")
+    return "\n".join(lines), result
+
+
+HANDLERS = {"m0_remember": tool_remember, "m0_recall": tool_recall}
+
+
+# ------------------------------------------------------------------ jsonrpc io
+
+
+def send(message: dict) -> None:
+    sys.stdout.write(json.dumps(message, ensure_ascii=False) + "\n")
+    sys.stdout.flush()
+
+
+def reply(request_id, result: dict) -> None:
+    send({"jsonrpc": "2.0", "id": request_id, "result": result})
+
+
+def fail(request_id, code: int, message: str) -> None:
+    send({"jsonrpc": "2.0", "id": request_id, "error": {"code": code, "message": message}})
+
+
+def handle(message: dict) -> None:
+    method = message.get("method")
+    request_id = message.get("id")
+    params = message.get("params") or {}
+    is_notification = "id" not in message
+
+    if method == "initialize":
+        requested = str(params.get("protocolVersion") or "")
+        version = requested if len(requested) == 10 and requested.count("-") == 2 else DEFAULT_PROTOCOL
+        reply(request_id, {
+            "protocolVersion": version,
+            "capabilities": {"tools": {"listChanged": False}},
+            "serverInfo": {"name": SERVER_NAME, "version": SERVER_VERSION},
+            "instructions": (
+                "Call m0_recall at the start of a session to pick up the operational "
+                "thread, and m0_remember after each meaningful step so the next session "
+                "or tool can continue without re-reading the whole history."
+            ),
+        })
+        return
+
+    if method in ("notifications/initialized", "initialized", "notifications/cancelled"):
+        return
+
+    if method == "ping":
+        reply(request_id, {})
+        return
+
+    if method == "tools/list":
+        reply(request_id, {"tools": TOOLS})
+        return
+
+    if method in ("resources/list", "prompts/list"):
+        reply(request_id, {"resources": []} if method.startswith("resources") else {"prompts": []})
+        return
+
+    if method == "tools/call":
+        name = params.get("name")
+        args = params.get("arguments") or {}
+        handler = HANDLERS.get(name)
+        if handler is None:
+            reply(request_id, {
+                "content": [{"type": "text", "text": f"Unknown tool: {name}"}],
+                "isError": True,
+            })
+            return
+        try:
+            text, structured = handler(args if isinstance(args, dict) else {})
+        except Exception as exc:  # tool errors travel in the result, per MCP
+            reply(request_id, {
+                "content": [{"type": "text", "text": f"{type(exc).__name__}: {exc}"}],
+                "isError": True,
+            })
+            return
+        reply(request_id, {
+            "content": [{"type": "text", "text": text}],
+            "structuredContent": structured,
+            "isError": False,
+        })
+        return
+
+    if is_notification:
+        return
+    fail(request_id, -32601, f"Method not found: {method}")
+
+
+def main() -> int:
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError as exc:
+            fail(None, -32700, f"Parse error: {exc}")
+            continue
+        if not isinstance(message, dict):
+            fail(None, -32600, "Invalid Request: expected a JSON object")
+            continue
+        try:
+            handle(message)
+        except Exception as exc:  # pragma: no cover - last-resort guard
+            if "id" in message:
+                fail(message.get("id"), -32603, f"Internal error: {type(exc).__name__}: {exc}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/systems/m0/skills/m0/scripts/m0_server.py
+++ b/systems/m0/skills/m0/scripts/m0_server.py
@@ -1,0 +1,642 @@
+#!/usr/bin/env python3
+"""M0 reference server - cross-tool operational-thread memory on SQLite.
+
+Implements the M0 wire contract (see systems/m0/SPEC.md):
+
+    POST /api/brain/checkpoint    write one thread entry (idempotent)
+    GET  /api/brain/thread        read recent entries, newest first
+    GET  /api/health              liveness and store stats (extension)
+
+Standard library only. Binds to loopback by default, makes no outbound
+network calls, and emits no telemetry. Every database call carries an
+explicit, short busy timeout; a write that still cannot land is persisted
+to a sidecar file and reported as deferred, so a write is never lost.
+
+Usage:
+    python3 m0_server.py serve [--host 127.0.0.1] [--port 8787] [--db PATH]
+    python3 m0_server.py drain [--db PATH]
+    python3 m0_server.py write --project P --text T [--kind K] [...]
+    python3 m0_server.py read  [--project P] [--limit N] [--kind K]
+    python3 m0_server.py health
+
+Environment:
+    M0_DB               store path (default $XDG_DATA_HOME/coco-m0/thread.db)
+    M0_SIDECAR_DIR      sidecar spool (default <db dir>/sidecars)
+    M0_BUSY_TIMEOUT_MS  per-call SQLite busy timeout in ms (default 10000)
+    M0_HOST, M0_PORT    serve defaults (127.0.0.1, 8787)
+    M0_PROJECT          default project for the CLI
+    M0_SESSION_ID       default session_id for writes
+    M0_SOURCE_TOOL      default source_tool for writes
+    M0_OWNER            default owner_user_id for writes (default "local")
+    M0_VISIBILITY       default visibility for writes (default "private")
+
+MIT licensed, part of the Coco M0 bundle.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+VERSION = "1.0.0"
+SPEC_VERSION = "m0/1"
+
+# Column order is normative: the content hash is computed over these fields,
+# minus "id" and "ts", joined in exactly this order. See SPEC.md.
+FIELDS = (
+    "id",
+    "project",
+    "session_id",
+    "source_tool",
+    "role",
+    "kind",
+    "ts",
+    "branch",
+    "head_sha",
+    "next_step",
+    "last_verified",
+    "text",
+    "meta_json",
+    "owner_user_id",
+    "visibility",
+)
+
+HASHED_FIELDS = tuple(f for f in FIELDS if f not in ("id", "ts"))
+
+KINDS = (
+    "step_done",
+    "compact_checkpoint",
+    "session_end",
+    "lane_dispatched",
+    "lane_result",
+    "ambient_signal",
+)
+
+DEFAULT_KIND = "step_done"
+DEFAULT_LIMIT = 20
+MAX_LIMIT = 500
+DEFAULT_BUSY_TIMEOUT_MS = 10_000
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS operational_thread (
+    id            TEXT PRIMARY KEY,
+    project       TEXT NOT NULL,
+    session_id    TEXT,
+    source_tool   TEXT,
+    role          TEXT,
+    kind          TEXT NOT NULL,
+    ts            TEXT NOT NULL,
+    branch        TEXT,
+    head_sha      TEXT,
+    next_step     TEXT,
+    last_verified TEXT,
+    text          TEXT NOT NULL,
+    meta_json     TEXT,
+    owner_user_id TEXT,
+    visibility    TEXT
+);
+CREATE INDEX IF NOT EXISTS ix_ot_project_ts   ON operational_thread(project, ts DESC);
+CREATE INDEX IF NOT EXISTS ix_ot_project_kind ON operational_thread(project, kind, ts DESC);
+"""
+
+
+class M0Error(Exception):
+    """A client-visible request error."""
+
+    def __init__(self, message: str, status: int = 400) -> None:
+        super().__init__(message)
+        self.status = status
+
+
+# ---------------------------------------------------------------- paths / time
+
+
+def default_db_path() -> Path:
+    env = os.environ.get("M0_DB")
+    if env:
+        return Path(env).expanduser()
+    base = os.environ.get("XDG_DATA_HOME") or "~/.local/share"
+    return Path(base).expanduser() / "coco-m0" / "thread.db"
+
+
+def sidecar_dir_for(db_path: Path) -> Path:
+    env = os.environ.get("M0_SIDECAR_DIR")
+    if env:
+        return Path(env).expanduser()
+    return db_path.parent / "sidecars"
+
+
+def busy_timeout_ms() -> int:
+    raw = os.environ.get("M0_BUSY_TIMEOUT_MS", str(DEFAULT_BUSY_TIMEOUT_MS))
+    try:
+        value = int(float(raw))
+    except ValueError:
+        return DEFAULT_BUSY_TIMEOUT_MS
+    return max(1, value)
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+# ------------------------------------------------------------------ store core
+
+
+class Store:
+    """SQLite-backed operational thread with a sidecar spool."""
+
+    def __init__(self, db_path: Path | None = None, sidecars: Path | None = None,
+                 timeout_ms: int | None = None) -> None:
+        self.db_path = Path(db_path).expanduser() if db_path else default_db_path()
+        self.sidecars = Path(sidecars).expanduser() if sidecars else sidecar_dir_for(self.db_path)
+        self.timeout_ms = timeout_ms or busy_timeout_ms()
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self.sidecars.mkdir(parents=True, exist_ok=True)
+        self._init_schema()
+
+    # -- connections -------------------------------------------------------
+
+    def connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(
+            str(self.db_path),
+            timeout=self.timeout_ms / 1000.0,
+            isolation_level=None,
+        )
+        conn.row_factory = sqlite3.Row
+        conn.execute(f"PRAGMA busy_timeout = {self.timeout_ms}")
+        return conn
+
+    def _init_schema(self) -> None:
+        conn = self.connect()
+        try:
+            try:
+                conn.execute("PRAGMA journal_mode = WAL")
+            except sqlite3.OperationalError:
+                pass  # a concurrent writer holds the file; WAL is an optimisation
+            conn.executescript(SCHEMA)
+        finally:
+            conn.close()
+
+    # -- normalisation -----------------------------------------------------
+
+    @staticmethod
+    def canonical_meta(value) -> str | None:
+        """Accept an object, an array, or a string. Never reject.
+
+        A JSON-encoded string is parsed and re-serialised canonically, so the
+        same metadata always hashes identically. A string that is not JSON is
+        preserved as {"note": <string>} rather than raising, because a metadata
+        parameter that rejects valid input is worse than a lenient one.
+        """
+        if value is None:
+            return None
+        if isinstance(value, (dict, list)):
+            return json.dumps(value, sort_keys=True, separators=(",", ":"))
+        if isinstance(value, (int, float, bool)):
+            return json.dumps({"value": value}, sort_keys=True, separators=(",", ":"))
+        text = str(value).strip()
+        if not text:
+            return None
+        try:
+            parsed = json.loads(text)
+        except (json.JSONDecodeError, ValueError):
+            return json.dumps({"note": str(value)}, sort_keys=True, separators=(",", ":"))
+        if isinstance(parsed, (dict, list)):
+            return json.dumps(parsed, sort_keys=True, separators=(",", ":"))
+        return json.dumps({"value": parsed}, sort_keys=True, separators=(",", ":"))
+
+    @staticmethod
+    def content_id(row: dict) -> str:
+        joined = "\x00".join((row.get(f) or "") for f in HASHED_FIELDS)
+        return hashlib.sha256(joined.encode("utf-8")).hexdigest()
+
+    def normalize(self, payload: dict) -> dict:
+        if not isinstance(payload, dict):
+            raise M0Error("body must be a JSON object")
+
+        project = str(payload.get("project") or os.environ.get("M0_PROJECT") or "").strip()
+        if not project:
+            raise M0Error("'project' is required")
+
+        text = payload.get("text")
+        if text is None or not str(text).strip():
+            raise M0Error("'text' is required and must be non-empty")
+
+        kind = str(payload.get("kind") or DEFAULT_KIND).strip()
+        if kind not in KINDS:
+            raise M0Error(f"unknown kind '{kind}' (expected one of: {', '.join(KINDS)})")
+
+        # meta_json / meta are aliases; either may be an object or a string.
+        meta_raw = payload.get("meta_json")
+        if meta_raw is None:
+            meta_raw = payload.get("meta")
+
+        row = {
+            "project": project,
+            "session_id": _opt(payload.get("session_id"), os.environ.get("M0_SESSION_ID")),
+            "source_tool": _opt(payload.get("source_tool"), os.environ.get("M0_SOURCE_TOOL")),
+            "role": _opt(payload.get("role"), "assistant"),
+            "kind": kind,
+            "ts": _opt(payload.get("ts")) or utc_now(),
+            "branch": _opt(payload.get("branch")),
+            "head_sha": _opt(payload.get("head_sha")),
+            "next_step": _opt(payload.get("next_step")),
+            "last_verified": _opt(payload.get("last_verified")),
+            "text": str(text).strip(),
+            "meta_json": self.canonical_meta(meta_raw),
+            "owner_user_id": _opt(payload.get("owner_user_id"), os.environ.get("M0_OWNER"), "local"),
+            "visibility": _opt(payload.get("visibility"), os.environ.get("M0_VISIBILITY"), "private"),
+        }
+        row["id"] = self.content_id(row)
+        return row
+
+    # -- writes ------------------------------------------------------------
+
+    def write(self, payload: dict) -> dict:
+        """Idempotent write. Falls back to a sidecar file if the store is busy."""
+        row = self.normalize(payload)
+        try:
+            stored_ts = self._insert(row)
+            return {"id": row["id"], "ts": stored_ts, "ok": True, "deferred": False}
+        except sqlite3.OperationalError:
+            self._spool(row)
+            return {"id": row["id"], "ts": row["ts"], "ok": True, "deferred": True}
+
+    def _insert(self, row: dict) -> str:
+        """Insert if absent, then return the stored ts (first write wins)."""
+        columns = ", ".join(FIELDS)
+        placeholders = ", ".join("?" for _ in FIELDS)
+        conn = self.connect()
+        try:
+            conn.execute(
+                f"INSERT INTO operational_thread ({columns}) VALUES ({placeholders}) "
+                f"ON CONFLICT(id) DO NOTHING",
+                [row.get(f) for f in FIELDS],
+            )
+            found = conn.execute(
+                "SELECT ts FROM operational_thread WHERE id = ?", (row["id"],)
+            ).fetchone()
+            return found["ts"] if found else row["ts"]
+        finally:
+            conn.close()
+
+    def _spool(self, row: dict) -> Path:
+        """Persist a write we could not land, atomically (tmp + replace)."""
+        self.sidecars.mkdir(parents=True, exist_ok=True)
+        safe_ts = row["ts"].replace(":", "").replace(".", "")
+        target = self.sidecars / f"{safe_ts}-{row['id'][:16]}.json"
+        fd, tmp = tempfile.mkstemp(dir=str(self.sidecars), suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(row, handle, ensure_ascii=False, sort_keys=True)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp, target)
+        except BaseException:
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+            raise
+        return target
+
+    # -- sidecars ----------------------------------------------------------
+
+    def pending_sidecars(self) -> list[dict]:
+        rows = []
+        if not self.sidecars.is_dir():
+            return rows
+        for path in sorted(self.sidecars.glob("*.json")):
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if isinstance(data, dict) and data.get("id"):
+                data["_sidecar"] = path.name
+                rows.append(data)
+        return rows
+
+    def drain(self) -> dict:
+        """Land every spooled write. Called on start and available on demand."""
+        drained = 0
+        skipped = 0
+        quarantined = 0
+        if not self.sidecars.is_dir():
+            return {"drained": 0, "skipped": 0, "quarantined": 0}
+        for path in sorted(self.sidecars.glob("*.json")):
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                path.rename(path.with_suffix(".json.bad"))
+                quarantined += 1
+                continue
+            if not isinstance(data, dict) or not data.get("id"):
+                path.rename(path.with_suffix(".json.bad"))
+                quarantined += 1
+                continue
+            data.pop("_sidecar", None)
+            try:
+                self._insert(data)
+            except sqlite3.OperationalError:
+                skipped += 1
+                break  # store still busy; keep the rest spooled for next time
+            try:
+                path.unlink()
+            except OSError:
+                pass
+            drained += 1
+        return {"drained": drained, "skipped": skipped, "quarantined": quarantined}
+
+    # -- reads -------------------------------------------------------------
+
+    def read(self, project: str | None = None, limit: int = DEFAULT_LIMIT,
+             kind: str | None = None) -> dict:
+        """Most recent entries, newest first. Union of the store and the spool.
+
+        Reads survive a locked store: if SELECT cannot run, spooled entries are
+        still returned and the degraded reason is reported.
+        """
+        limit = max(1, min(int(limit or DEFAULT_LIMIT), MAX_LIMIT))
+        if kind and kind not in KINDS:
+            raise M0Error(f"unknown kind '{kind}' (expected one of: {', '.join(KINDS)})")
+
+        entries: list[dict] = []
+        degraded = None
+        sql = "SELECT * FROM operational_thread"
+        clauses, params = [], []
+        if project:
+            clauses.append("project = ?")
+            params.append(project)
+        if kind:
+            clauses.append("kind = ?")
+            params.append(kind)
+        if clauses:
+            sql += " WHERE " + " AND ".join(clauses)
+        sql += " ORDER BY ts DESC, id DESC LIMIT ?"
+        params.append(limit)
+
+        try:
+            conn = self.connect()
+            try:
+                entries = [dict(r) for r in conn.execute(sql, params).fetchall()]
+            finally:
+                conn.close()
+        except sqlite3.OperationalError as exc:
+            degraded = f"store busy: {exc}"
+
+        seen = {e["id"] for e in entries}
+        pending = 0
+        for row in self.pending_sidecars():
+            if project and row.get("project") != project:
+                continue
+            if kind and row.get("kind") != kind:
+                continue
+            pending += 1
+            if row["id"] in seen:
+                continue
+            entry = {f: row.get(f) for f in FIELDS}
+            entry["pending"] = True
+            entries.append(entry)
+            seen.add(row["id"])
+
+        entries.sort(key=lambda e: (e.get("ts") or "", e.get("id") or ""), reverse=True)
+        entries = entries[:limit]
+        return {
+            "project": project,
+            "kind": kind,
+            "limit": limit,
+            "count": len(entries),
+            "pending_sidecars": pending,
+            "degraded": degraded,
+            "entries": entries,
+        }
+
+    # -- health ------------------------------------------------------------
+
+    def health(self) -> dict:
+        rows = None
+        projects = None
+        degraded = None
+        try:
+            conn = self.connect()
+            try:
+                rows = conn.execute("SELECT COUNT(*) AS n FROM operational_thread").fetchone()["n"]
+                projects = conn.execute(
+                    "SELECT COUNT(DISTINCT project) AS n FROM operational_thread"
+                ).fetchone()["n"]
+            finally:
+                conn.close()
+        except sqlite3.OperationalError as exc:
+            degraded = f"store busy: {exc}"
+        return {
+            "ok": degraded is None,
+            "version": VERSION,
+            "spec": SPEC_VERSION,
+            "db": str(self.db_path),
+            "sidecar_dir": str(self.sidecars),
+            "busy_timeout_ms": self.timeout_ms,
+            "rows": rows,
+            "projects": projects,
+            "pending_sidecars": len(self.pending_sidecars()),
+            "degraded": degraded,
+            "local_only": True,
+        }
+
+
+def _opt(*candidates):
+    """First candidate that is a non-empty string, else None."""
+    for value in candidates:
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return None
+
+
+# ----------------------------------------------------------------- http layer
+
+
+class Handler(BaseHTTPRequestHandler):
+    server_version = f"m0/{VERSION}"
+    protocol_version = "HTTP/1.1"
+    store: Store  # injected on the server instance
+
+    def log_message(self, fmt: str, *args) -> None:  # keep stdout clean
+        sys.stderr.write("m0 %s - %s\n" % (self.address_string(), fmt % args))
+
+    # -- helpers -----------------------------------------------------------
+
+    def _send(self, status: int, payload: dict) -> None:
+        body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _body(self) -> dict:
+        length = int(self.headers.get("Content-Length") or 0)
+        if length <= 0:
+            return {}
+        raw = self.rfile.read(length)
+        try:
+            return json.loads(raw.decode("utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            raise M0Error(f"invalid JSON body: {exc}")
+
+    # -- routes ------------------------------------------------------------
+
+    def do_POST(self) -> None:  # noqa: N802 - http.server API
+        route = urlparse(self.path).path.rstrip("/") or "/"
+        try:
+            if route == "/api/brain/checkpoint":
+                self._send(200, self.server.store.write(self._body()))
+            elif route == "/api/brain/sidecars/drain":
+                self._send(200, self.server.store.drain())
+            else:
+                self._send(404, {"ok": False, "error": f"no route POST {route}"})
+        except M0Error as exc:
+            self._send(exc.status, {"ok": False, "error": str(exc)})
+        except Exception as exc:  # pragma: no cover - last-resort guard
+            self._send(500, {"ok": False, "error": f"{type(exc).__name__}: {exc}"})
+
+    def do_GET(self) -> None:  # noqa: N802 - http.server API
+        parsed = urlparse(self.path)
+        route = parsed.path.rstrip("/") or "/"
+        query = parse_qs(parsed.query)
+
+        def one(name, default=None):
+            values = query.get(name) or []
+            return values[0] if values and values[0] != "" else default
+
+        try:
+            if route == "/api/brain/thread":
+                limit_raw = one("limit", str(DEFAULT_LIMIT))
+                try:
+                    limit = int(limit_raw)
+                except (TypeError, ValueError):
+                    raise M0Error(f"'limit' must be an integer, got '{limit_raw}'")
+                self._send(200, self.server.store.read(
+                    project=one("project"), limit=limit, kind=one("kind")))
+            elif route in ("/api/health", "/health"):
+                self._send(200, self.server.store.health())
+            else:
+                self._send(404, {"ok": False, "error": f"no route GET {route}"})
+        except M0Error as exc:
+            self._send(exc.status, {"ok": False, "error": str(exc)})
+        except Exception as exc:  # pragma: no cover - last-resort guard
+            self._send(500, {"ok": False, "error": f"{type(exc).__name__}: {exc}"})
+
+
+def serve(store: Store, host: str, port: int) -> None:
+    report = store.drain()
+    if report["drained"] or report["quarantined"]:
+        print(f"m0: drained {report['drained']} sidecar write(s), "
+              f"quarantined {report['quarantined']}", flush=True)
+    httpd = ThreadingHTTPServer((host, port), Handler)
+    httpd.daemon_threads = True
+    httpd.store = store
+    if host not in ("127.0.0.1", "localhost", "::1"):
+        print(f"m0: WARNING binding {host} exposes the store beyond this machine; "
+              f"there is no authentication.", flush=True)
+    print(f"m0 {VERSION} listening on http://{host}:{port}", flush=True)
+    print(f"m0 store: {store.db_path}", flush=True)
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        print("m0: stopping", flush=True)
+    finally:
+        httpd.server_close()
+
+
+# ------------------------------------------------------------------------ cli
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="m0_server.py", description=__doc__.split("\n")[0])
+    parser.add_argument("--db", help="store path (default $M0_DB or XDG data dir)")
+    parser.add_argument("--sidecar-dir", help="sidecar spool (default <db dir>/sidecars)")
+    parser.add_argument("--busy-timeout-ms", type=int, help="per-call SQLite busy timeout")
+    sub = parser.add_subparsers(dest="command")
+
+    p_serve = sub.add_parser("serve", help="run the HTTP server")
+    p_serve.add_argument("--host", default=os.environ.get("M0_HOST", "127.0.0.1"))
+    p_serve.add_argument("--port", type=int, default=int(os.environ.get("M0_PORT", "8787")))
+
+    sub.add_parser("drain", help="land spooled writes now")
+    sub.add_parser("health", help="print store health as JSON")
+
+    p_write = sub.add_parser("write", help="write one entry without HTTP")
+    p_write.add_argument("--project", default=os.environ.get("M0_PROJECT"))
+    p_write.add_argument("--text", required=True)
+    p_write.add_argument("--kind", default=DEFAULT_KIND, choices=list(KINDS))
+    p_write.add_argument("--next-step")
+    p_write.add_argument("--last-verified")
+    p_write.add_argument("--session-id")
+    p_write.add_argument("--source-tool")
+    p_write.add_argument("--branch")
+    p_write.add_argument("--head-sha")
+    p_write.add_argument("--meta", help="JSON object, or any string (wrapped as {\"note\": ...})")
+
+    p_read = sub.add_parser("read", help="print recent entries as JSON")
+    p_read.add_argument("--project", default=os.environ.get("M0_PROJECT"))
+    p_read.add_argument("--limit", type=int, default=DEFAULT_LIMIT)
+    p_read.add_argument("--kind", choices=list(KINDS))
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    store = Store(db_path=args.db, sidecars=args.sidecar_dir, timeout_ms=args.busy_timeout_ms)
+    command = args.command or "serve"
+
+    if command == "serve":
+        serve(store, args.host, args.port)
+        return 0
+    if command == "drain":
+        print(json.dumps(store.drain(), indent=2))
+        return 0
+    if command == "health":
+        print(json.dumps(store.health(), indent=2))
+        return 0
+    if command == "write":
+        try:
+            result = store.write({
+                "project": args.project,
+                "text": args.text,
+                "kind": args.kind,
+                "next_step": args.next_step,
+                "last_verified": args.last_verified,
+                "session_id": args.session_id,
+                "source_tool": args.source_tool,
+                "branch": args.branch,
+                "head_sha": args.head_sha,
+                "meta_json": args.meta,
+            })
+        except M0Error as exc:
+            print(json.dumps({"ok": False, "error": str(exc)}), file=sys.stderr)
+            return 2
+        print(json.dumps(result, indent=2))
+        return 0
+    if command == "read":
+        try:
+            print(json.dumps(store.read(args.project, args.limit, args.kind), indent=2))
+        except M0Error as exc:
+            print(json.dumps({"ok": False, "error": str(exc)}), file=sys.stderr)
+            return 2
+        return 0
+
+    print(f"unknown command: {command}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/systems/m0/tests/m0-smoke.sh
+++ b/systems/m0/tests/m0-smoke.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# M0 smoke test - proves the four guarantees in SPEC.md against a real server.
+#
+#   1. round trip      POST /api/brain/checkpoint then GET /api/brain/thread
+#   2. idempotency     the same content written twice leaves exactly one row
+#   3. deferred write  a locked store yields deferred:true plus a sidecar file,
+#                      the read still returns the entry, and the next start drains it
+#   4. MCP tools       initialize / tools/list / tools/call over stdio, with
+#                      structured metadata passed as a JSON object
+#
+# Everything runs in a throwaway temp directory on an ephemeral port. No
+# existing store is touched. Requires bash, python3 and curl - nothing else.
+#
+# Run from anywhere:  bash systems/m0/tests/m0-smoke.sh
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS="$HERE/../skills/m0/scripts"
+SERVER="$SCRIPTS/m0_server.py"
+MCP="$SCRIPTS/m0_mcp.py"
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/m0-smoke.XXXXXX")"
+export M0_DB="$WORK/thread.db"
+export M0_SIDECAR_DIR="$WORK/sidecars"
+export M0_BUSY_TIMEOUT_MS=600
+export M0_PROJECT="smoke-project"
+unset M0_SESSION_ID M0_SOURCE_TOOL M0_OWNER M0_VISIBILITY 2>/dev/null || true
+
+PORT="$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()')"
+export M0_BASE_URL="http://127.0.0.1:$PORT"
+SERVER_PID=""
+LOCK_PID=""
+PASS=0
+FAIL=0
+
+cleanup() {
+  [ -n "$LOCK_PID" ] && kill "$LOCK_PID" 2>/dev/null
+  [ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null
+  wait 2>/dev/null
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+check() { # check <label> <condition-description> <0|1 result>
+  if [ "$2" = "0" ]; then
+    printf '  PASS  %s\n' "$1"; PASS=$((PASS + 1))
+  else
+    printf '  FAIL  %s\n' "$1"; FAIL=$((FAIL + 1))
+  fi
+}
+
+jq_get() { python3 -c "import json,sys;d=json.load(sys.stdin);print(d.get('$1',''))"; }
+
+start_server() {
+  python3 "$SERVER" serve --port "$PORT" >"$WORK/server.log" 2>&1 &
+  SERVER_PID=$!
+  for _ in $(seq 1 60); do
+    if curl -fsS "$M0_BASE_URL/api/health" >/dev/null 2>&1; then return 0; fi
+    sleep 0.1
+  done
+  echo "server did not come up; log:"; cat "$WORK/server.log"; return 1
+}
+
+stop_server() {
+  [ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null
+  wait "$SERVER_PID" 2>/dev/null
+  SERVER_PID=""
+}
+
+row_count() { # row_count [where-clause]
+  python3 - "$M0_DB" "${1:-1=1}" <<'PY'
+import sqlite3, sys
+conn = sqlite3.connect(sys.argv[1], timeout=5)
+print(conn.execute(f"SELECT COUNT(*) FROM operational_thread WHERE {sys.argv[2]}").fetchone()[0])
+PY
+}
+
+echo "M0 smoke test"
+echo "  store: $M0_DB"
+echo "  port:  $PORT"
+echo
+
+# ---------------------------------------------------------------- 1. round trip
+echo "1. round trip"
+start_server || exit 1
+HEALTH="$(curl -fsS "$M0_BASE_URL/api/health")"
+[ "$(printf '%s' "$HEALTH" | jq_get ok)" = "True" ]; check "health reports ok" "$?"
+
+BODY='{"project":"smoke-project","kind":"compact_checkpoint",
+ "text":"Smoke test wrote a checkpoint.",
+ "next_step":"Read it back.","last_verified":"m0-smoke.sh step 1",
+ "session_id":"smoke-1","source_tool":"smoke","branch":"main","head_sha":"abc1234",
+ "meta_json":{"suite":"smoke","step":1}}'
+W1="$(curl -fsS -X POST "$M0_BASE_URL/api/brain/checkpoint" -H 'Content-Type: application/json' -d "$BODY")"
+ID1="$(printf '%s' "$W1" | jq_get id)"
+TS1="$(printf '%s' "$W1" | jq_get ts)"
+[ -n "$ID1" ]; check "write returns an id" "$?"
+[ "$(printf '%s' "$W1" | jq_get deferred)" = "False" ]; check "write is not deferred" "$?"
+[ "$(printf '%s' "$W1" | jq_get ok)" = "True" ]; check "write reports ok" "$?"
+
+READ="$(curl -fsS "$M0_BASE_URL/api/brain/thread?project=smoke-project&limit=10")"
+printf '%s' "$READ" | grep -Fq "$ID1"; check "read returns the entry" "$?"
+printf '%s' "$READ" | grep -Fq '\"suite\":\"smoke\"'; check "metadata survives the round trip" "$?"
+KIND_READ="$(curl -fsS "$M0_BASE_URL/api/brain/thread?project=smoke-project&kind=session_end")"
+[ "$(printf '%s' "$KIND_READ" | jq_get count)" = "0" ]; check "kind filter excludes other kinds" "$?"
+echo
+
+# --------------------------------------------------------------- 2. idempotency
+echo "2. idempotency"
+W2="$(curl -fsS -X POST "$M0_BASE_URL/api/brain/checkpoint" -H 'Content-Type: application/json' -d "$BODY")"
+[ "$(printf '%s' "$W2" | jq_get id)" = "$ID1" ]; check "re-write returns the same id" "$?"
+[ "$(printf '%s' "$W2" | jq_get ts)" = "$TS1" ]; check "re-write preserves the original ts" "$?"
+[ "$(row_count "id='$ID1'")" = "1" ]; check "exactly one row exists for that id" "$?"
+
+# Same metadata, re-encoded as a JSON string with the keys in another order.
+BODY_STR='{"project":"smoke-project","kind":"compact_checkpoint",
+ "text":"Smoke test wrote a checkpoint.",
+ "next_step":"Read it back.","last_verified":"m0-smoke.sh step 1",
+ "session_id":"smoke-1","source_tool":"smoke","branch":"main","head_sha":"abc1234",
+ "meta_json":"{\"step\":1,\"suite\":\"smoke\"}"}'
+W3="$(curl -fsS -X POST "$M0_BASE_URL/api/brain/checkpoint" -H 'Content-Type: application/json' -d "$BODY_STR")"
+[ "$(printf '%s' "$W3" | jq_get id)" = "$ID1" ]; check "string-encoded metadata hashes identically" "$?"
+[ "$(row_count "id='$ID1'")" = "1" ]; check "still exactly one row" "$?"
+echo
+
+# ------------------------------------------------------------ 3. deferred write
+echo "3. deferred write under a locked store"
+python3 - "$M0_DB" "$WORK/lock.state" <<'PY' >"$WORK/lock.log" 2>&1 &
+import os, sqlite3, sys, time
+db, state = sys.argv[1], sys.argv[2]
+conn = sqlite3.connect(db, timeout=5, isolation_level=None)
+conn.execute("BEGIN EXCLUSIVE")
+open(state, "w").write("locked")
+while os.path.exists(state):
+    time.sleep(0.1)
+conn.execute("ROLLBACK")
+PY
+LOCK_PID=$!
+for _ in $(seq 1 60); do [ -f "$WORK/lock.state" ] && break; sleep 0.1; done
+[ -f "$WORK/lock.state" ]; check "store is exclusively locked by another writer" "$?"
+
+DEF_BODY='{"project":"smoke-project","kind":"session_end",
+ "text":"Wrote while the store was locked.","next_step":"Drain on next start."}'
+W4="$(curl -fsS -X POST "$M0_BASE_URL/api/brain/checkpoint" -H 'Content-Type: application/json' -d "$DEF_BODY")"
+ID4="$(printf '%s' "$W4" | jq_get id)"
+[ "$(printf '%s' "$W4" | jq_get deferred)" = "True" ]; check "response reports deferred:true" "$?"
+[ "$(printf '%s' "$W4" | jq_get ok)" = "True" ]; check "response still reports ok:true" "$?"
+[ "$(ls -1 "$M0_SIDECAR_DIR"/*.json 2>/dev/null | wc -l | tr -d ' ')" = "1" ]; check "one sidecar file was spooled" "$?"
+[ "$(row_count "id='$ID4'")" = "0" ]; check "the row is not in the store yet" "$?"
+LOCKED_READ="$(curl -fsS "$M0_BASE_URL/api/brain/thread?project=smoke-project&limit=10")"
+printf '%s' "$LOCKED_READ" | grep -Fq "$ID4"; check "read still returns the deferred entry" "$?"
+
+rm -f "$WORK/lock.state"
+wait "$LOCK_PID" 2>/dev/null; LOCK_PID=""
+stop_server
+start_server || exit 1
+grep -q "drained 1 sidecar write" "$WORK/server.log"; check "next start reports the drain" "$?"
+[ "$(ls -1 "$M0_SIDECAR_DIR"/*.json 2>/dev/null | wc -l | tr -d ' ')" = "0" ]; check "the spool is empty" "$?"
+[ "$(row_count "id='$ID4'")" = "1" ]; check "the deferred write landed in the store" "$?"
+echo
+
+# ------------------------------------------------------------------- 4. MCP
+echo "4. MCP tools over stdio"
+MCP_OUT="$(printf '%s\n' \
+ '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{}}}' \
+ '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
+ '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \
+ '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"m0_remember","arguments":{"text":"MCP wrote this.","kind":"step_done","meta":{"via":"mcp","nested":{"ok":true}}}}}' \
+ '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"m0_recall","arguments":{"limit":5}}}' \
+ | python3 "$MCP" 2>"$WORK/mcp.err")"
+
+printf '%s' "$MCP_OUT" | grep -Fq '"serverInfo"'; check "initialize returns serverInfo" "$?"
+printf '%s' "$MCP_OUT" | grep -Fq '"m0_remember"'; check "tools/list advertises m0_remember" "$?"
+printf '%s' "$MCP_OUT" | grep -Fq '"m0_recall"'; check "tools/list advertises m0_recall" "$?"
+printf '%s' "$MCP_OUT" | python3 -c "
+import json, sys
+by_id = {m.get('id'): m for m in (json.loads(l) for l in sys.stdin if l.strip())}
+tools = {t['name']: t for t in by_id[2]['result']['tools']}
+meta = tools['m0_remember']['inputSchema']['properties']['meta']
+sys.exit(0 if meta.get('type') == 'object' else 1)
+"
+check "the meta parameter is typed object, not string" "$?"
+printf '%s' "$MCP_OUT" | grep -Fq '"isError": false'; check "tools/call succeeds" "$?"
+printf '%s' "$MCP_OUT" | grep -Fq '\"nested\":{\"ok\":true}'; check "nested metadata object round-trips" "$?"
+echo
+
+echo "----"
+echo "PASS $PASS   FAIL $FAIL"
+[ "$FAIL" -eq 0 ] || exit 1
+echo "m0 smoke: all guarantees verified."


### PR DESCRIPTION
## What M0 is

M0 answers one question well: **"where were we, what was verified, what is next."** It reads and writes a local operational thread so a session can be resumed from a different tool — Claude Code to Cursor and back — from a file, in milliseconds, with no daemon required.

Four skills, opt-in via `install.sh --systems m0`:

| Skill | Role |
|---|---|
| `m0` | control plane |
| `m0-remember` | write path |
| `m0-recall` | read path |
| `m0-handoff` | resume / handoff flow |

Plus a reference server and an MCP server — **Python standard library only, zero dependencies** — and `SPEC.md`, which is complete enough to reimplement the wire contract from without reading the code.

## Why the guarantees matter more than the feature

These are tested, not asserted:

- **Content-hash idempotency.** Re-posting an identical body returns the identical id *and* timestamp, so a caller can distinguish a retry from a new entry for free. That makes hooks and retries safe.
- **Sidecar spool on a locked store.** A write that cannot land is spooled atomically and reported `deferred: true` rather than lost, then drained on next start. This is exactly where naive memory writes get dropped: inside a shutdown hook.
- **Bounded timeouts.** Short by default and configurable. A two-minute timeout is indistinguishable from a hang, and `SPEC.md` says so explicitly rather than leaving it to taste.
- **Reads survive a locked store.** The read path unions the table with pending sidecars, so a concurrent bulk writer cannot black out recall.
- **Genuinely local.** SQLite on disk, loopback bind, no outbound calls, no telemetry. Delete the file and it has forgotten everything.

## What it does not do

`systems/m0/README.md` carries this as a side-by-side table so a reader can rule M0 out in about thirty seconds. There is no semantic search, no embeddings, no entity or relationship extraction, no graph to traverse, no summarisation or consolidation, no document ingestion, no automatic capture unless you install a hook, no authentication or real multi-tenancy, and no sync — one machine, one thread.

**Whenever the question is "what do we know about X" rather than "where were we", the bundled Cognee is the better choice, and the README says so directly.** Two memory bundles that overlapped without admitting it would be worse than one.

## Extraction note

This was extracted onto a fresh branch rather than rebased: the original work sat **35 commits behind** `main`. The change is purely additive apart from one documentation list.

## Also fixed here

`docs/INDEX.md` listed only GSD, Brain and Team under "By system bundle". It omitted **HyperFrames, Superintelligence and Cognee** — all of which install — and listed **Team, which is core rather than a bundle**. It now lists the six real bundles with skill counts and points at the generated `systems/INDEX.md` for live figures.

## Verification

Every check run and its output read.

| Check | Result |
|---|---|
| `bash systems/m0/tests/m0-smoke.sh` | **PASS 27, FAIL 0** against a live server |
| `python3 scripts/build-index.py` | 183 skills — matches `find` over the whole tree |
| `skills/INDEX.md` | gains a `## Bundle: m0 (4 skills)` heading |
| `systems/INDEX.md` | gains a row: `m0 · systems/m0/ · 4 skills` |
| Bundle gating, per skill | all 4 linked **with** `--systems m0`, **0** without |
| `bash tests/check-command-refs.sh` | PASS |
| `bash tests/check-evidence-gate.sh` | PASS |
| `bash tests/smoke.sh` | 18 passed, 0 failed |
| `arch-index` fixtures | pass |
| All four adapter dry-runs | exit 0 |

**No installer change was needed** — `link_system()` already globs `systems/<name>/skills/*/`, which I confirmed by reading it rather than assuming.

## Honest caveats

Two things stated rather than buried. The Python `3.9+` floor is reasoned from the APIs used, not tested, because this machine has only 3.14. And `owner_user_id` / `visibility` are columns with defaults rather than enforcement — `SPEC.md` and the README both say so explicitly instead of implying a security property that is not there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)