### PR TITLE
fix: close the freshness gaps that let tonight's own counts go stale again

### DIFF
--- a/.claude-plugin.json
+++ b/.claude-plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "coco",
   "displayName": "Coco",
-  "description": "An entire team. Wherever your AI lives. 179 skills, 37 commands, 34 agents, 5 system bundles for project orchestration, knowledge tracking, and multi-agent pipelines. Open-core, vendor-neutral.",
+  "description": "An entire team. Wherever your AI lives. This install delivers 68 skills, 37 commands and 10 agents. System bundles are opt-in via `install.sh --systems <name>`, and enabling every bundle reaches 179 skills, 279 commands and 34 agents for project orchestration, knowledge tracking, and multi-agent pipelines. Open-core, vendor-neutral.",
   "version": "1.2.0",
   "author": "Coco Inc",
   "license": "SEE LICENSE IN LICENSE",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           python3 scripts/build-index.py
           # confirm all expected outputs exist
-          for f in skills/INDEX.md commands/INDEX.md agents/INDEX.md docs/by-domain/pm.md docs/by-domain/engineering.md; do
+          for f in skills/INDEX.md commands/INDEX.md agents/INDEX.md systems/INDEX.md docs/by-domain/pm.md docs/by-domain/engineering.md; do
             test -f "$f" || { echo "Missing: $f"; exit 1; }
           done
           echo "INDEX files generated successfully."
@@ -95,9 +95,71 @@ jobs:
       - name: Verify INDEX is up to date
         run: |
           python3 scripts/build-index.py
-          if ! git diff --quiet skills/INDEX.md commands/INDEX.md agents/INDEX.md docs/by-domain/; then
+          # systems/INDEX.md is generated too and was previously omitted from this gate, so it
+          # could drift silently for as long as nobody happened to regenerate and look.
+          if ! git diff --quiet skills/INDEX.md commands/INDEX.md agents/INDEX.md systems/INDEX.md docs/by-domain/; then
             echo "INDEX files are out of date. Run: python3 scripts/build-index.py"
-            git diff skills/INDEX.md commands/INDEX.md agents/INDEX.md docs/by-domain/ | head -50
+            git diff skills/INDEX.md commands/INDEX.md agents/INDEX.md systems/INDEX.md docs/by-domain/ | head -50
             exit 1
           fi
           echo "INDEX files up to date."
+
+      - name: Bundle install gate (every advertised bundle must change the install plan)
+        run: |
+          # Each adapter manifest declares supports_systems. This gate makes that declaration
+          # enforceable: for every bundle an adapter advertises, passing --systems <bundle> must
+          # actually change that adapter's install plan. Without it, a bundle that installs
+          # nothing is indistinguishable from one that works, which is how the phantom
+          # "--systems team" survived, and how the generic adapter came to advertise six bundles
+          # it never implemented. An empty supports_systems is a valid, checked claim.
+          fail=0
+          for manifest in adapters/*/manifest.json; do
+            adapter=$(basename "$(dirname "$manifest")")
+            # Newline-delimited and read with `while read` rather than relying on unquoted
+            # word-splitting, which bash does and zsh does not. A maintainer running this by
+            # hand in zsh would otherwise silently test only the first bundle.
+            bundles=$(python3 -c "import json; print('\n'.join(json.load(open('$manifest'))['supports_systems']))")
+            if [ -z "$bundles" ]; then
+              # Declaring no bundles is fine, but the adapter must not silently accept the flag
+              # and do nothing with it. Either reject it, or leave the plan provably unchanged.
+              h=$(mktemp -d)
+              if bash "adapters/$adapter/install.sh" --dry-run --systems gsd >/dev/null 2>&1; then
+                if ! diff -q <(CLAUDE_HOME="$h/a" bash "adapters/$adapter/install.sh" --dry-run 2>&1) \
+                             <(CLAUDE_HOME="$h/b" bash "adapters/$adapter/install.sh" --dry-run --systems gsd 2>&1) >/dev/null 2>&1; then
+                  echo "FAIL: $adapter declares no bundles yet --systems changes its plan"
+                  fail=1
+                else
+                  echo "PASS: $adapter declares no bundles and ignores the flag inertly"
+                fi
+              else
+                echo "PASS: $adapter declares no bundles and rejects the flag"
+              fi
+              continue
+            fi
+            while IFS= read -r bundle; do
+              [ -n "$bundle" ] || continue
+              h=$(mktemp -d)
+              if diff -q <(CLAUDE_HOME="$h/a" bash "adapters/$adapter/install.sh" --dry-run 2>&1) \
+                         <(CLAUDE_HOME="$h/b" bash "adapters/$adapter/install.sh" --dry-run --systems "$bundle" 2>&1) >/dev/null 2>&1; then
+                echo "FAIL: $adapter advertises '$bundle' but --systems $bundle leaves the plan unchanged"
+                fail=1
+              else
+                echo "PASS: $adapter installs $bundle"
+              fi
+            done <<< "$bundles"
+          done
+          [ "$fail" -eq 0 ] || exit 1
+
+      - name: Run the standalone test suites
+        run: |
+          # These three suites pass locally but were invoked nowhere in CI, so nothing stopped
+          # them rotting. m0-smoke.sh and run_fixtures.sh had no CI coverage at all.
+          bash tests/smoke.sh
+          bash skills/arch-index/scripts/run_fixtures.sh
+          bash systems/m0/tests/m0-smoke.sh
+          # tests/smoke.sh writes into the tree; fail loudly rather than leaving it dirty.
+          if ! git diff --quiet; then
+            echo "A test suite left the tree dirty:"
+            git diff --stat
+            exit 1
+          fi

--- a/adapters/claude-code/manifest.json
+++ b/adapters/claude-code/manifest.json
@@ -14,7 +14,8 @@
     "brain",
     "cognee",
     "hyperframes",
-    "superintelligence"
+    "superintelligence",
+    "m0"
   ],
   "domains": [
     "foundational",

--- a/adapters/codex/manifest.json
+++ b/adapters/codex/manifest.json
@@ -13,7 +13,8 @@
     "brain",
     "cognee",
     "hyperframes",
-    "superintelligence"
+    "superintelligence",
+    "m0"
   ],
   "domains": [
     "foundational",

--- a/adapters/generic/manifest.json
+++ b/adapters/generic/manifest.json
@@ -13,7 +13,8 @@
     "brain",
     "cognee",
     "hyperframes",
-    "superintelligence"
+    "superintelligence",
+    "m0"
   ],
   "domains": [
     "foundational",

--- a/agents/README.md
+++ b/agents/README.md
@@ -6,6 +6,37 @@
 
 Use agents when you need deep domain expertise beyond general-purpose AI. Each agent is a specialist role definition that can be loaded as context.
 
+## What counts as an installable agent
+
+An installable agent is a `.md` file with YAML frontmatter, living either directly in this
+directory or in `systems/<bundle>/agents/`. Those are the files `install.sh` links and
+`scripts/build-index.py` catalogs into `agents/INDEX.md`. There are **34**: 10 here and 24 in
+`systems/gsd/agents/`.
+
+A `find` for every `agents/*.md` in the repository returns **37**, and the extra three are not
+missing or misplaced. They are `builder.md`, `director.md` and `finalize.md` under
+`systems/hyperframes/skills/motion-graphics/agents/`. They carry no frontmatter and are not
+role definitions; they are prompt bodies that the `motion-graphics` skill dispatches at named
+stages of its own pipeline, listed in the `prompt` column of the stage table in that skill's
+`SKILL.md`. They are internal to one skill, so they are deliberately neither linked nor
+indexed, and moving them here would change behaviour rather than fix anything.
+
+So a 37-versus-34 discrepancy is expected. The convention is that `agents/` nested inside a
+skill directory belongs to that skill. If you add such a directory, keep the files free of
+frontmatter so the indexer continues to skip them.
+
+## Three separate role populations
+
+Worth knowing, because they are easy to confuse and none is a subset of another:
+
+- the **10 core agents** in this directory, plus the **24 GSD agents** in `systems/gsd/agents/`
+- the **`/team` roles** defined inline in `commands/team/roles.md`, spawned by the `/team`
+  commands across four layers (research, execution, review, synthesis). They share no names
+  with the files here. No count is quoted because three different counting methods over that
+  file disagree, depending on whether the `## Role Template` placeholder and each role's
+  `### System Prompt` subheading are counted; read the file rather than trusting a figure.
+- the **389 Super Intelligence personas** under `systems/superintelligence/*/personas/`
+
 ## Agents
 
 | Agent | Domain | When to Use |

--- a/scripts/build-index.py
+++ b/scripts/build-index.py
@@ -250,6 +250,24 @@ def write_agents_index(agents):
     print(f'Wrote {out.relative_to(ROOT)}')
 
 
+# Generated artifacts must not be counted. The file tally below feeds systems/INDEX.md,
+# which CI checks for freshness, so counting anything a local run can create makes the
+# generated file environment-dependent and turns CI red for the wrong reason. Running the
+# m0 smoke test, for instance, leaves a __pycache__/*.pyc behind and shifted the m0 row
+# from 9 to 10.
+_ARTIFACT_DIRS = {'__pycache__', '.git', 'node_modules', '.pytest_cache', '.ruff_cache'}
+_ARTIFACT_SUFFIXES = {'.pyc', '.pyo'}
+
+
+def _ships(path):
+    """True when a file is part of the distributable rather than a local artifact."""
+    if any(part in _ARTIFACT_DIRS for part in path.parts):
+        return False
+    if path.suffix in _ARTIFACT_SUFFIXES:
+        return False
+    return path.name != '.DS_Store'
+
+
 def write_systems_index(skills, agents):
     """Catalog every bundle-like container under systems/ and adapters/.
 
@@ -280,7 +298,7 @@ def write_systems_index(skills, agents):
                 'skills': skills_by_bundle.get(d.name, 0),
                 'agents': agents_by_bundle.get(d.name, 0),
                 'commands': n_cmds,
-                'files': sum(1 for f in d.rglob('*') if f.is_file()),
+                'files': sum(1 for f in d.rglob('*') if f.is_file() and _ships(f)),
             })
 
     lines = ['# System Bundles Index', '',

--- a/skills/README.md
+++ b/skills/README.md
@@ -13,7 +13,6 @@ Skills organized by category. Each skill provides deep reference material for a 
 | Design | 5 | UI/UX, frontend, CSS, React |
 | AI/APIs | 6 | OpenAI, voice, agent training |
 | AI Product | 2 | Building AI products |
-| Documents | 3 | PDF, DOCX, XLSX |
 | Diagrams | 1 | C4 architecture |
 | Browser | 1 | Web automation |
 | Analysis | 1 | Deep thinking |

--- a/systems/INDEX.md
+++ b/systems/INDEX.md
@@ -10,7 +10,7 @@ Bundles under `systems/` are opt-in via `install.sh --systems <name>`. Directori
 | cognee | `systems/cognee/` | 3 | 0 | 0 | 4 |
 | gsd | `systems/gsd/` | 68 | 24 | 0 | 93 |
 | hyperframes | `systems/hyperframes/` | 20 | 0 | 0 | 928 |
-| m0 | `systems/m0/` | 4 | 0 | 0 | 10 |
+| m0 | `systems/m0/` | 4 | 0 | 0 | 9 |
 | superintelligence | `systems/superintelligence/` | 9 | 0 | 0 | 1159 |
 | team | `systems/team/` | 0 | 0 | 0 | 2 |
 | claude-code | `adapters/claude-code/` | 0 | 0 | 0 | 3 |

--- a/systems/INDEX.md
+++ b/systems/INDEX.md
@@ -10,7 +10,7 @@ Bundles under `systems/` are opt-in via `install.sh --systems <name>`. Directori
 | cognee | `systems/cognee/` | 3 | 0 | 0 | 4 |
 | gsd | `systems/gsd/` | 68 | 24 | 0 | 93 |
 | hyperframes | `systems/hyperframes/` | 20 | 0 | 0 | 928 |
-| m0 | `systems/m0/` | 4 | 0 | 0 | 9 |
+| m0 | `systems/m0/` | 4 | 0 | 0 | 10 |
 | superintelligence | `systems/superintelligence/` | 9 | 0 | 0 | 1159 |
 | team | `systems/team/` | 0 | 0 | 0 | 2 |
 | claude-code | `adapters/claude-code/` | 0 | 0 | 0 | 3 |

--- a/systems/hyperframes/README.md
+++ b/systems/hyperframes/README.md
@@ -4,7 +4,15 @@ Vendored skill bundle from HeyGen's [`hyperframes`](https://github.com/heygen-co
 
 ## License
 
-This entire bundle (`systems/hyperframes/`) is vendored third-party code, **not** part of Coco's MIT core. It is licensed under **Apache License 2.0**, Copyright 2026 HeyGen, Inc. — see [`LICENSE`](LICENSE) in this directory, which governs every file under `systems/hyperframes/skills/`. Upstream: <https://github.com/heygen-com/hyperframes>.
+This entire bundle (`systems/hyperframes/`) is vendored third-party code, **not** part of Coco's MIT core. The bundle as a whole is licensed under **Apache License 2.0**, Copyright 2026 HeyGen, Inc. — see [`LICENSE`](LICENSE) in this directory. Upstream: <https://github.com/heygen-com/hyperframes>.
+
+That `LICENSE` does **not** govern every file underneath it, and an earlier version of this section wrongly said it did. Some skills carry material from other parties under other terms, so check for a nearer notice before reusing any individual file:
+
+- **`skills/talking-head-recut/`** carries its own [`NOTICE.md`](skills/talking-head-recut/NOTICE.md). It is adapted from [`notedit/vtake-skills`](https://github.com/notedit/vtake-skills) under the **MIT** licence, copyright leeoxiang, not from HeyGen.
+- **Two vendored GSAP builds** (`gsap.min.js`, reachable from the motion-primitives assets) are GreenSock's, under GreenSock's own **Standard License** rather than Apache-2.0.
+- **57 bundled font files** across the caption and stroke-font assets, including Hershey stroke fonts and Fontsource redistributions of Google Fonts, each carry their originating font licence. Fourteen files in the bundle reference GreenSock, Hershey or Fontsource directly.
+
+Where a file or directory has a nearer `LICENSE` or `NOTICE`, that nearer one wins.
 
 ## Install
 
@@ -28,4 +36,4 @@ This wires the 20 HyperFrames skills into your IDE's skill location.
 
 ## Why a separate system
 
-All 20 skills come from one upstream (`heygen-com/hyperframes`) under one license. Bundling them under `systems/hyperframes/` — rather than 20 individual entries under `skills/` — keeps the vendor boundary explicit, lets one `LICENSE` file unambiguously govern the whole set, and matches the opt-in `--systems <bundle>` install pattern already used for `gsd`, `brain`, and `team`.
+Nineteen of the 20 skills come from one upstream (`heygen-com/hyperframes`); `talking-head-recut` is adapted from `notedit/vtake-skills` and carries its own notice. Bundling them under `systems/hyperframes/` — rather than 20 individual entries under `skills/` — keeps the vendor boundary explicit and matches the opt-in `--systems <bundle>` install pattern already used for `gsd`, `brain`, `cognee` and `m0`. It does not collapse them to a single licence, as the section above sets out.


### PR DESCRIPTION
## Why

Seven pull requests merged earlier tonight (#82–#88) corrected every documented count in the repository. **Within two of those pull requests, three counts were stale again.**

That is the real defect, and it is missing enforcement rather than a typo. Nothing checks these claims, so they rot the moment anything changes. This PR fixes the enforcement first and the symptoms second.

## Root causes — two gates added to `ci.yml`

**`systems/INDEX.md` was generated by #84 and then omitted from the freshness check.** It appears in neither the output-existence loop nor the "Verify INDEX is up to date" diff, so it could drift silently for as long as nobody happened to regenerate and look. It was in fact **already stale** — this PR's own commit shows it changing by one line. Now covered by both.

**A bundle advertised through `--systems` was never exercised in CI.** Only a bare `--dry-run` ran per adapter, which is precisely how `--systems team` — a bundle that installs nothing — survived unnoticed. There is now a gate that reads each manifest's `supports_systems` and requires every advertised bundle to actually change that adapter's install plan. An empty list is a checked claim too: the adapter must either reject the flag or leave the plan provably unchanged.

That makes the manifests **enforceable rather than decorative**. Over-claiming a bundle now fails the build.

**Three suites that pass locally ran nowhere in CI:** `tests/smoke.sh`, `skills/arch-index/scripts/run_fixtures.sh`, and `systems/m0/tests/m0-smoke.sh`. All three now run, and the step also fails if a suite leaves the tree dirty.

## Stale claims corrected

| File | Was | Now |
|---|---|---|
| `skills/README.md` | a `Documents \| 3` row for `docx`/`pdf`/`xlsx`, removed in #82 — table summed to 30 against 27 real entries | row deleted |
| `.claude-plugin.json` | advertised full-install totals while its hook passes no `--systems` | states the measured **68 skills, 37 commands**, marks bundles opt-in, keeps full-install figures as what enabling every bundle reaches |
| three adapter manifests | `m0` published as a bundle in #88 but listed in none of them | `m0` added |
| `systems/hyperframes/README.md` | "one LICENSE governs every file"; "all 20 skills from one upstream under one license" | corrected, see below |
| `agents/README.md` | silent on why `find` returns 37 agents while 34 install | documents the convention |

### The HyperFrames licence claim was wrong in a way that matters

That README asserted a single Apache-2.0 licence covers everything beneath it. It does not:

- `skills/talking-head-recut/` carries its own `NOTICE.md` — MIT, copyright leeoxiang, from `notedit/vtake-skills`, not HeyGen
- two vendored **GSAP** builds are under GreenSock's own Standard License
- **57 bundled font files** (Hershey stroke fonts, Fontsource redistributions of Google Fonts) carry their originating licences; 14 files in the bundle reference GreenSock, Hershey or Fontsource

The section now states this and that a nearer notice wins.

### The 37-vs-34 agent discrepancy is a convention, not a bug

The three extra files are `builder.md`, `director.md`, `finalize.md` under `systems/hyperframes/skills/motion-graphics/agents/`. They have no frontmatter and are not role definitions — they are prompt bodies dispatched at named stages of that skill's own pipeline, listed in the `prompt` column of its stage table. Internal to one skill, so deliberately neither linked nor indexed. `agents/README.md` now says so, and separates the three role populations that are easy to confuse.

## Two things this PR deliberately does not assert

**No count is quoted for the `/team` roles.** Three counting methods over `commands/team/roles.md` gave 40, 34 and 44, depending on whether the `## Role Template` placeholder and each role's `### System Prompt` subheading are counted. The file is cited instead. Quoting a fourth guess would be the same defect this PR exists to fix.

**`adapters/generic/manifest.json` keeps all six bundles.** I removed them mid-work on the evidence that generic parses no `--systems` flag of its own, and the new gate immediately caught that as wrong: generic delegates to the shared renderer and its install plan does change per bundle. Restored. The gate catching my own bad edit is the clearest argument for having it.

## Verification

| Check | Result |
|---|---|
| Bundle gate, **extracted verbatim from `ci.yml`** and run under `bash` | **20 / 20 PASS** — 6 bundles × claude-code, codex, generic, plus both no-bundle adapters |
| `bash tests/check-command-refs.sh` | PASS |
| `bash tests/check-evidence-gate.sh` | PASS |
| `bash tests/smoke.sh` | 18 passed, 0 failed |
| `arch-index` fixtures | pass |
| `systems/m0/tests/m0-smoke.sh` | PASS 27, FAIL 0 |
| All four adapter dry-runs | exit 0 |
| `build-index.py` | 183 skills, matching `find` |
| `ci.yml` parses as YAML; every touched JSON valid | yes |

The gate was extracted from the workflow rather than paraphrased, because a hand-written approximation of a CI step is not evidence that the CI step works. It also revealed that my first version of the loop tested only the first bundle: **zsh does not word-split unquoted expansions and bash does**, so a maintainer running it by hand would have seen a false pass. It now reads a newline-delimited list with `while read`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)