### PR TITLE
feat(npm): rename the package to cocosuperintelligence and publish unscoped

### DIFF
--- a/.github/workflows/publish-npmjs.yml
+++ b/.github/workflows/publish-npmjs.yml
@@ -1,7 +1,7 @@
 name: Publish to npmjs.com
 
-# Publishes @coco-research/coco-cli to the public npmjs.com registry.
-# Frictionless install for users — no auth required: `npm install -g @coco-research/coco-cli`.
+# Publishes cocosuperintelligence to the public npmjs.com registry.
+# Frictionless install for users — no auth required: `npm install -g cocosuperintelligence`.
 #
 # Setup (one-time):
 #   1. Create npm account at https://www.npmjs.com/signup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) · Versioning: 
 
 ## [Unreleased]
 
+### Changed
+
+- **The npm package is now `cocosuperintelligence`, published unscoped.** It was previously named `@coco-research/coco-cli` and had never been published, so no installed version of the old name exists anywhere and nothing downstream breaks. The new name matches the product as the README presents it, and shortens the install to `npx cocosuperintelligence`. Renamed across `package.json`, `bin/coco.js`, `README.md`, `install.sh`, `skills/coco-cli/SKILL.md`, `skills/cli-anything/SKILL.md`, `docs/distribution/npm-github-packages.md` and the publish workflow. `publishConfig.access` was dropped because it only applies to scoped packages; unscoped packages are public by default. Dated entries below that mention the old name are left as written, because they record what was true at the time.
+
 ### Fixed
 
 - **`/team ship` no longer reconciles the architecture index mid-pipeline.** Stage 1 previously ran `/team arch build` or `/team arch drift` whenever the index was absent or behind HEAD, which meant every ship following a few commits silently paid for a full index reconciliation, with agents, before any product work began. Stage 1 now only records the pin alongside HEAD and continues, which costs nothing. Refreshing the index is a separate explicit act, and a stale baseline degrades the conformance gate to `UNVERIFIED`, which is the honest outcome.

--- a/README.md
+++ b/README.md
@@ -538,7 +538,7 @@ echo "@coco-research:registry=https://npm.pkg.github.com" >> ~/.npmrc
 echo "//npm.pkg.github.com/:_authToken=YOUR_TOKEN" >> ~/.npmrc
 
 # Install and launch
-npm install -g @coco-research/coco-cli
+npm install -g cocosuperintelligence
 coco
 ```
 
@@ -614,10 +614,10 @@ git pull --ff-only && bash install.sh
 
 ```bash
 # print version + check for updates
-npx @coco-research/coco-cli version
+npx cocosuperintelligence version
 
 # apply an update
-npx @coco-research/coco-cli update
+npx cocosuperintelligence update
 ```
 
 </td>

--- a/bin/coco.js
+++ b/bin/coco.js
@@ -2,13 +2,13 @@
 // Coco CLI — clones Coco into a target dir and runs the installer.
 //
 // Usage:
-//   npx @coco-research/coco-cli               # clones to ./coco and installs (auto-detect adapter)
-//   npx @coco-research/coco-cli install       # same as above
-//   npx @coco-research/coco-cli install --adapter cursor
-//   npx @coco-research/coco-cli install --systems gsd,brain,m0
-//   npx @coco-research/coco-cli update        # pull latest in existing clone
-//   npx @coco-research/coco-cli uninstall     # remove symlinks + clone
-//   npx @coco-research/coco-cli --help
+//   npx cocosuperintelligence               # clones to ./coco and installs (auto-detect adapter)
+//   npx cocosuperintelligence install       # same as above
+//   npx cocosuperintelligence install --adapter cursor
+//   npx cocosuperintelligence install --systems gsd,brain,m0
+//   npx cocosuperintelligence update        # pull latest in existing clone
+//   npx cocosuperintelligence uninstall     # remove symlinks + clone
+//   npx cocosuperintelligence --help
 
 'use strict';
 
@@ -66,7 +66,7 @@ function fetchLatestVersion(cb) {
 function banner(latest) {
   if (latest && semverGt(latest, PKG_VERSION)) {
     console.log(`\n  ⬆  Coco ${latest} is available (you have ${PKG_VERSION}).`);
-    console.log(`     Update:  npx @coco-research/coco-cli update     (or: git -C <clone> pull --ff-only && bash install.sh)\n`);
+    console.log(`     Update:  npx cocosuperintelligence update     (or: git -C <clone> pull --ff-only && bash install.sh)\n`);
   }
 }
 
@@ -84,7 +84,7 @@ function checkForUpdate(force) {
 }
 
 function cmdVersion() {
-  console.log(`@coco-research/coco-cli v${PKG_VERSION}`);
+  console.log(`cocosuperintelligence v${PKG_VERSION}`);
   checkForUpdate(true);
 }
 
@@ -92,12 +92,12 @@ function help() {
   console.log(`Coco — open-source AI workflow framework
 
 Usage:
-  npx @coco-research/coco-cli                   clone + install (auto-detect)
-  npx @coco-research/coco-cli install [flags]   clone + install with flags
-  npx @coco-research/coco-cli update [dir]      pull latest in existing clone
-  npx @coco-research/coco-cli uninstall [dir]   remove symlinks + clone
-  npx @coco-research/coco-cli version           show version + check for updates
-  npx @coco-research/coco-cli --help            this message
+  npx cocosuperintelligence                   clone + install (auto-detect)
+  npx cocosuperintelligence install [flags]   clone + install with flags
+  npx cocosuperintelligence update [dir]      pull latest in existing clone
+  npx cocosuperintelligence uninstall [dir]   remove symlinks + clone
+  npx cocosuperintelligence version           show version + check for updates
+  npx cocosuperintelligence --help            this message
 
 Update checks contact only github.com (no telemetry); disable with COCO_NO_UPDATE_CHECK=1.
 
@@ -108,11 +108,11 @@ Install flags (passed to install.sh):
   --dry-run                             preview, no writes
 
 Examples:
-  npx @coco-research/coco-cli
-  npx @coco-research/coco-cli install --adapter cursor
-  npx @coco-research/coco-cli install --systems gsd,brain --adapter claude-code
-  npx @coco-research/coco-cli update
-  npx @coco-research/coco-cli uninstall
+  npx cocosuperintelligence
+  npx cocosuperintelligence install --adapter cursor
+  npx cocosuperintelligence install --systems gsd,brain --adapter claude-code
+  npx cocosuperintelligence update
+  npx cocosuperintelligence uninstall
 
 Repo: https://github.com/coco-research/coco
 `);
@@ -167,13 +167,13 @@ function cmdInstall(argv) {
   run('bash', [installScript, ...argv]);
 
   console.log(`\nDone. Coco installed at ${dir}.`);
-  console.log(`Re-run install / update later with:\n  npx @coco-research/coco-cli update`);
+  console.log(`Re-run install / update later with:\n  npx cocosuperintelligence update`);
 }
 
 function cmdUpdate(argv) {
   const dir = argv[0] && !argv[0].startsWith('--') ? argv[0] : DEFAULT_DIR;
   if (!fs.existsSync(path.join(dir, '.git'))) {
-    console.error(`Error: ${dir} is not a Coco clone. Run \`npx @coco-research/coco-cli install\` first.`);
+    console.error(`Error: ${dir} is not a Coco clone. Run \`npx cocosuperintelligence install\` first.`);
     process.exit(1);
   }
   cloneOrUpdate(dir);
@@ -228,7 +228,7 @@ function main() {
       cmdUninstall(rest);
       break;
     default:
-      // any unknown subcommand → pass through to install (e.g., npx @coco-research/coco-cli --adapter cursor)
+      // any unknown subcommand → pass through to install (e.g., npx cocosuperintelligence --adapter cursor)
       cmdInstall(argv);
       checkForUpdate(false);
   }

--- a/docs/by-domain/meta.md
+++ b/docs/by-domain/meta.md
@@ -7,7 +7,7 @@ Auto-generated view. Filtered to `domain: meta` skills.
 | Skill | Description |
 |-------|-------------|
 | [cli-anything](../../skills/cli-anything/SKILL.md) | Wrap any command-line tool into a JSON-emitting agent skill. Use when you want to make a CLI reliably callable and parseable by an AI agent — introspect its --help, define a structured-output (--json) |
-| [coco-cli](../../skills/coco-cli/SKILL.md) | Install, update, version-check, or uninstall the Coco open-source AI workflow framework via its CLI (@coco-research/coco-cli, run with npx). Use when setting up Coco on a machine, pulling the latest i |
+| [coco-cli](../../skills/coco-cli/SKILL.md) | Install, update, version-check, or uninstall the Coco open-source AI workflow framework via its CLI (cocosuperintelligence, run with npx). Use when setting up Coco on a machine, pulling the latest int |
 | [coco-loop](../../skills/coco-loop/SKILL.md) | Start a safe, governed autonomous loop from a plain-language goal. Use when the user says /coco-loop, "run an autonomous loop", "keep my build green for N hours", "work on X autonomously for a while", |
 | [find-skills](../../skills/find-skills/SKILL.md) | Helps users discover and install agent skills when they ask questions like "how do I do X", "find a skill for X", "is there a skill that can...", or express interest in extending capabilities. This sk |
 | [skill-creator](../../skills/skill-creator/SKILL.md) | Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends Claude's capabilities with specialized knowledge, workfl |

--- a/docs/distribution/npm-github-packages.md
+++ b/docs/distribution/npm-github-packages.md
@@ -6,7 +6,7 @@ Reference: https://docs.github.com/en/packages/working-with-a-github-packages-re
 
 | File | Purpose |
 |------|---------|
-| `package.json` | Renamed package to `@coco-research/coco-cli`; added `publishConfig.registry` pointing to `https://npm.pkg.github.com` |
+| `package.json` | Renamed package to `cocosuperintelligence`; added `publishConfig.registry` pointing to `https://npm.pkg.github.com` |
 | `.npmrc` | Tells npm to use GitHub Packages registry for the `@coco-research` scope |
 | `.github/workflows/publish-npm.yml` | CI workflow that publishes on `release: published` (or manual trigger) |
 
@@ -53,7 +53,7 @@ echo "@coco-research:registry=https://npm.pkg.github.com" >> ~/.npmrc
 echo "//npm.pkg.github.com/:_authToken=ghp_yourtoken" >> ~/.npmrc
 
 # Install
-npm install -g @coco-research/coco-cli
+npm install -g cocosuperintelligence
 coco install
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -84,5 +84,5 @@ if [[ -z "$DRY_RUN" ]]; then
   echo
   echo "Coco v$VER installed. Check for updates anytime:"
   echo "  bash \"$REPO_ROOT/scripts/check-update.sh\"      # git clones"
-  echo "  npx @coco-research/coco-cli version                      # npm installs"
+  echo "  npx cocosuperintelligence version                      # npm installs"
 fi

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@coco-research/coco-cli",
+  "name": "cocosuperintelligence",
   "version": "1.2.0",
-  "description": "CoCo Super Intelligence — summon an advisory board of 389 world-class minds inside your AI coding session. A vendor-neutral orchestration layer for Claude Code, Cursor, and Codex: 179 skills, 279 commands, 34 agents, and disk-persistent state. 100% local, no telemetry. Open-core: MIT core, proprietary Super Intelligence.",
+  "description": "CoCo Super Intelligence \u2014 summon an advisory board of 389 world-class minds inside your AI coding session. A vendor-neutral orchestration layer for Claude Code, Cursor, and Codex: 179 skills, 279 commands, 34 agents, and disk-persistent state. 100% local, no telemetry. Open-core: MIT core, proprietary Super Intelligence.",
   "bin": {
     "coco": "./bin/coco.js"
   },
@@ -35,9 +35,6 @@
   },
   "bugs": {
     "url": "https://github.com/coco-research/coco/issues"
-  },
-  "publishConfig": {
-    "access": "public"
   },
   "engines": {
     "node": ">=14"

--- a/skills/INDEX.md
+++ b/skills/INDEX.md
@@ -71,7 +71,7 @@ Auto-generated. Run `python3 scripts/build-index.py` to refresh.
 | Skill | Description |
 |-------|-------------|
 | [cli-anything](cli-anything/SKILL.md) | Wrap any command-line tool into a JSON-emitting agent skill. Use when you want to make a CLI reliably callable and parseable by an AI agent — introspect its --h |
-| [coco-cli](coco-cli/SKILL.md) | Install, update, version-check, or uninstall the Coco open-source AI workflow framework via its CLI (@coco-research/coco-cli, run with npx). Use when setting up |
+| [coco-cli](coco-cli/SKILL.md) | Install, update, version-check, or uninstall the Coco open-source AI workflow framework via its CLI (cocosuperintelligence, run with npx). Use when setting up C |
 | [coco-loop](coco-loop/SKILL.md) | Start a safe, governed autonomous loop from a plain-language goal. Use when the user says /coco-loop, "run an autonomous loop", "keep my build green for N hours |
 | [find-skills](find-skills/SKILL.md) | Helps users discover and install agent skills when they ask questions like "how do I do X", "find a skill for X", "is there a skill that can...", or express int |
 | [skill-creator](skill-creator/SKILL.md) | Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends Claude's capabil |

--- a/skills/cli-anything/SKILL.md
+++ b/skills/cli-anything/SKILL.md
@@ -58,4 +58,4 @@ Standard structure so an agent can discover and drive the tool:
 
 ## Worked example
 
-`skills/coco-cli/SKILL.md` is a wrapper produced with this pattern over the `@coco-research/coco-cli` command — note how it documents the (human-only) output contract honestly rather than inventing a JSON mode the tool lacks.
+`skills/coco-cli/SKILL.md` is a wrapper produced with this pattern over the `cocosuperintelligence` command — note how it documents the (human-only) output contract honestly rather than inventing a JSON mode the tool lacks.

--- a/skills/coco-cli/SKILL.md
+++ b/skills/coco-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: coco-cli
-description: Install, update, version-check, or uninstall the Coco open-source AI workflow framework via its CLI (@coco-research/coco-cli, run with npx). Use when setting up Coco on a machine, pulling the latest into an existing clone, checking the installed version, or removing it. Triggers on "install coco", "update coco", "set up coco", "coco cli", "uninstall coco".
+description: Install, update, version-check, or uninstall the Coco open-source AI workflow framework via its CLI (cocosuperintelligence, run with npx). Use when setting up Coco on a machine, pulling the latest into an existing clone, checking the installed version, or removing it. Triggers on "install coco", "update coco", "set up coco", "coco cli", "uninstall coco".
 domain: meta
 ---
 
@@ -8,18 +8,18 @@ domain: meta
 
 # coco-cli — manage the Coco framework
 
-Thin agent wrapper over `@coco-research/coco-cli` (run via `npx`). Drives the real CLI; does not reimplement it.
+Thin agent wrapper over `cocosuperintelligence` (run via `npx`). Drives the real CLI; does not reimplement it.
 
 ## Commands
 
 | Command | Purpose | Invocation |
 |---|---|---|
-| (default) | clone + install, auto-detecting the adapter | `npx @coco-research/coco-cli` |
-| `install` | clone + install with explicit flags | `npx @coco-research/coco-cli install [flags]` |
-| `update` | pull latest in an existing clone | `npx @coco-research/coco-cli update [dir]` |
-| `uninstall` | remove symlinks + the clone | `npx @coco-research/coco-cli uninstall [dir]` |
-| `version` | print version + check for updates | `npx @coco-research/coco-cli version` |
-| `--help` | print usage | `npx @coco-research/coco-cli --help` |
+| (default) | clone + install, auto-detecting the adapter | `npx cocosuperintelligence` |
+| `install` | clone + install with explicit flags | `npx cocosuperintelligence install [flags]` |
+| `update` | pull latest in an existing clone | `npx cocosuperintelligence update [dir]` |
+| `uninstall` | remove symlinks + the clone | `npx cocosuperintelligence uninstall [dir]` |
+| `version` | print version + check for updates | `npx cocosuperintelligence version` |
+| `--help` | print usage | `npx cocosuperintelligence --help` |
 
 ## Install flags (passed through to install.sh)
 
@@ -29,17 +29,17 @@ Thin agent wrapper over `@coco-research/coco-cli` (run via `npx`). Drives the re
 
 ## Examples
 
-- Install for Cursor: `npx @coco-research/coco-cli install --adapter cursor`
-- Selective systems: `npx @coco-research/coco-cli install --systems gsd,brain --adapter claude-code`
-- Preview without writing: `npx @coco-research/coco-cli install --dry-run`
-- Update an existing clone: `npx @coco-research/coco-cli update`
+- Install for Cursor: `npx cocosuperintelligence install --adapter cursor`
+- Selective systems: `npx cocosuperintelligence install --systems gsd,brain --adapter claude-code`
+- Preview without writing: `npx cocosuperintelligence install --dry-run`
+- Update an existing clone: `npx cocosuperintelligence update`
 
 ## Output contract
 
 This CLI is human-output-oriented; it has **no native `--json` mode**. For agent use:
 
 - Treat **exit code 0 = success**, non-zero = failure.
-- `version` prints `@coco-research/coco-cli vX.Y.Z` plus an update hint — parse the `vX.Y.Z` token.
+- `version` prints `cocosuperintelligence vX.Y.Z` plus an update hint — parse the `vX.Y.Z` token.
 - Capture stdout/stderr and branch on the exit code; do not assume machine-readable JSON.
 
 ## Errors


### PR DESCRIPTION
The package was named `@coco-research/coco-cli` and **had never been published**, so there is no installed copy of the old name anywhere and nothing downstream breaks. The owner's chosen name is `cocosuperintelligence` — it matches how the README presents the product, and it shortens the install:

```bash
npx cocosuperintelligence
```

## Scope of the rename

46 occurrences across 8 files: `package.json`, `bin/coco.js`, `README.md`, `install.sh`, `skills/coco-cli/SKILL.md`, `skills/cli-anything/SKILL.md`, `docs/distribution/npm-github-packages.md`, `.github/workflows/publish-npmjs.yml`. Generated indexes regenerated so the catalog descriptions follow.

`publishConfig.access` was **dropped** rather than updated — it only applies to scoped packages, and an unscoped package is public by default, so keeping it would imply a constraint that doesn't exist.

## Two deliberate non-changes

**The dated `CHANGELOG` entries that mention the old scoped name are left as written.** They record what was true when written; rewriting them would make the record dishonest. A new `[Unreleased]` entry documents the rename instead.

**`skills/coco-cli/` keeps its directory name.** It describes what the skill does — wrap the CLI — and renaming it would churn every generated index and any link pointing at it for no user-visible gain. Its contents now reference the new command.

## Verification

| Check | Result |
|---|---|
| `node bin/coco.js --help` | exit 0; every usage line reads `npx cocosuperintelligence` |
| `package.json` | parses; `name: cocosuperintelligence` |
| `publish-npmjs.yml` | valid YAML |
| `bash tests/check-command-refs.sh` / `check-evidence-gate.sh` | PASS |
| `bash tests/smoke.sh` | 18 passed, 0 failed |
| `npm pack --dry-run` | `cocosuperintelligence-1.2.0.tgz`, 19.3 kB, same 5 files |
| Old name outside CHANGELOG history | zero references |

🤖 Generated with [Claude Code](https://claude.com/claude-code)