### PR TITLE
fix(npm): correct the bin path so the published command actually installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "cocosuperintelligence",
   "version": "1.2.0",
-  "description": "CoCo Super Intelligence \u2014 summon an advisory board of 389 world-class minds inside your AI coding session. A vendor-neutral orchestration layer for Claude Code, Cursor, and Codex: 179 skills, 279 commands, 34 agents, and disk-persistent state. 100% local, no telemetry. Open-core: MIT core, proprietary Super Intelligence.",
+  "description": "CoCo Super Intelligence — summon an advisory board of 389 world-class minds inside your AI coding session. A vendor-neutral orchestration layer for Claude Code, Cursor, and Codex: 179 skills, 279 commands, 34 agents, and disk-persistent state. 100% local, no telemetry. Open-core: MIT core, proprietary Super Intelligence.",
   "bin": {
-    "coco": "./bin/coco.js"
+    "coco": "bin/coco.js"
   },
   "files": [
     "bin/",


### PR DESCRIPTION
Two defects, **both introduced by my rename in #92** (`63068d78`), caught when the owner attempted the first publish.

## 1. The `bin` path would have shipped a package with no command

```
npm warn publish "bin[coco]" script name bin/coco.js was invalid and removed
```

The target was `"./bin/coco.js"`. npm rejects a leading `./` in a bin path, auto-corrects it, and warns that the entry **was removed**. Publishing while relying on that auto-correction is not acceptable when the warning says the entry is gone — `npx cocosuperintelligence` could have resolved to nothing. Now `"bin/coco.js"`, which npm accepts unmodified.

## 2. A mangled em dash

The description carried a literal `—` escape. My rename script wrote `package.json` with `json.dumps` at its default `ensure_ascii=True`. It parses back to the same string so nothing was broken, but it is an artefact rather than intent, and `npm pkg fix` flagged it.

## Verified by installing the real artefact

Not by reading the dry-run, because the dry-run is what hid this in the first place:

| Check | Result |
|---|---|
| `npm pkg fix` | **no-op** — nothing left to correct |
| `npm publish --dry-run` | **zero warnings** |
| `npm pack` → install into a throwaway prefix | `node_modules/.bin/coco` linked and executable |
| Running that linked binary | prints usage, every line reading `npx cocosuperintelligence` |
| Shebang | `#!/usr/bin/env node` present |

## Note for whoever publishes

`npm publish` alone returns `E403` on this account because 2FA is required for write actions and the CLI did not prompt. It needs an explicit one-time code:

```bash
npm publish --otp=<6-digit-code>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)