### PR TITLE
feat(site): add product/sales contact addresses to the footer

### DIFF
--- a/coco/index.html
+++ b/coco/index.html
@@ -396,6 +396,8 @@ video{display:block;width:100%;height:auto}
       <a href="https://github.com/coco-research/coco/blob/main/CHANGELOG.md">Changelog</a>
       <a href="https://github.com/coco-research/coco/blob/main/LICENSE">Licence</a>
       <a href="https://github.com/coco-research/coco/blob/main/CONTRIBUTING.md">Contributing</a>
+      <a href="mailto:product@cocoresearch.org">product@cocoresearch.org</a>
+      <a href="mailto:sales@cocoresearch.org">sales@cocoresearch.org</a>
     </div>
     <p class="fine">CoCo is open-core. The core is MIT licensed. The Super Intelligence
       system is licensed separately and kept proprietary. Figures on this page reflect release 1.2.0.

--- a/index.html
+++ b/index.html
@@ -592,6 +592,8 @@ video{display:block;width:100%;height:auto}
       <a href="https://github.com/coco-research">GitHub organisation</a>
       <a href="https://github.com/coco-research/coco">CoCo repository</a>
       <a href="https://github.com/coco-research/coco/blob/main/LICENSE">Licence</a>
+      <a href="mailto:product@cocoresearch.org">product@cocoresearch.org</a>
+      <a href="mailto:sales@cocoresearch.org">sales@cocoresearch.org</a>
     </div>
     <p class="fine">CoCo Research is Coco Inc, Rijul Kalra. CoCo is open-core: the framework
       is MIT, the Super Intelligence board is licensed separately and kept proprietary.


### PR DESCRIPTION
## What this does

Adds \`mailto:\` links for \`product@cocoresearch.org\` and \`sales@cocoresearch.org\` to both pages' footers, next to the existing repository/licence links.

\`rijul@cocoresearch.org\` is deliberately not published here — the two role addresses cover the same routing without putting a personal-looking address on a public page as a spam target.

## Verification

- Both addresses confirmed to route to a real inbox before this PR (owner-confirmed).
- All repository gates pass: \`scripts/build-index.py\` (no drift), \`tests/check-command-refs.sh\`, \`tests/check-evidence-gate.sh\`.
- Tag balance checked on both pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)