### PR TITLE
fix(site): finish the design-methodology audit items

### DIFF
--- a/coco/index.html
+++ b/coco/index.html
@@ -13,10 +13,10 @@
    Font stack resolves to real SF Pro on Apple devices, the system default elsewhere.
    ========================================================================== */
 :root{
-  --ink:#1d1d1f;            /* primary text, never pure black */
+  --ink:#14171c;            /* primary text, never pure black */
   --ink-2:#333336;          /* secondary */
-  --muted:#6e6e73;          /* tertiary */
-  --surface:#f5f5f7;        /* the one off-white */
+  --muted:#5b6169;          /* tertiary */
+  --surface:#f6f5f2;        /* the one off-white, warm rather than Apple's cool grey */
   --white:#fff;
   --blue:#0a3a66;           /* button fill — deep navy, our own, not Apple's blue */
   --link:#0a3a66;           /* link — same navy, one accent throughout */
@@ -24,7 +24,7 @@
   --shadow:0 5px 30px rgba(0,0,0,.22);   /* the single shadow */
   --ease:cubic-bezier(.4,0,.6,1);        /* the single curve */
   --dur:.32s;
-  --stadium:980px;
+  --stadium:100px;
   --wide:1024px;
   --sans:-apple-system,BlinkMacSystemFont,"SF Pro Display","SF Pro Text","Helvetica Neue",Helvetica,Arial,sans-serif;
 }
@@ -37,10 +37,10 @@ a{color:var(--link);text-decoration:none}
 a:hover{text-decoration:underline}
 .wrap{max-width:var(--wide);margin:0 auto;padding:0 22px}
 
-/* ---- nav: 12px, translucent, hairline. Apple's exact proportions ---- */
+/* ---- nav: 12px, translucent, hairline. Own blur recipe, not Apple's documented one. ---- */
 .nav{position:sticky;top:0;z-index:100;height:44px;
-  background:rgba(255,255,255,.72);backdrop-filter:saturate(180%) blur(20px);
-  -webkit-backdrop-filter:saturate(180%) blur(20px);border-bottom:1px solid var(--hair)}
+  background:rgba(255,255,255,.78);backdrop-filter:saturate(150%) blur(16px);
+  -webkit-backdrop-filter:saturate(150%) blur(16px);border-bottom:1px solid var(--hair)}
 .nav-in{max-width:var(--wide);margin:0 auto;padding:0 22px;height:44px;
   display:flex;align-items:center;gap:34px}
 .nav a{font-size:12px;letter-spacing:-.01em;color:var(--ink);opacity:.85;transition:opacity var(--dur) var(--ease)}
@@ -233,8 +233,8 @@ video{display:block;width:100%;height:auto}
 <section id="top" class="center" style="padding-top:76px">
   <div class="wrap">
     <p class="eyebrow reveal">CoCo 1.2.0 &middot; the CoCo Research flagship</p>
-    <h1 class="reveal">An entire engineering<br>department. In your editor.</h1>
-    <p class="sub reveal">389 experts deliberate. Then 184 skills ship the decision.</p>
+    <h1 class="reveal">Your editor, arguing with itself before anything ships.</h1>
+    <p class="sub reveal">Each of the 389 requires a live, checkable source. Then 184 skills ship what they decided.</p>
     <p class="body reveal" style="margin:16px auto 0;text-align:center">
       Runs on the model and editor you already have — Claude Code, Cursor, or Codex.
       Your keys never leave your machine.
@@ -254,10 +254,10 @@ video{display:block;width:100%;height:auto}
           </radialGradient>
         </defs>
         <rect width="820" height="380" fill="url(#glow)"/>
-        <g id="spokes" stroke="#1d1d1f" stroke-opacity=".14" stroke-width="1"></g>
+        <g id="spokes" stroke="#14171c" stroke-opacity=".14" stroke-width="1"></g>
         <g id="seats"></g>
         <g id="depts"></g>
-        <circle cx="410" cy="196" r="46" fill="#1d1d1f"/>
+        <circle cx="410" cy="196" r="46" fill="#14171c"/>
         <text x="410" y="192" text-anchor="middle" fill="#fff" font-size="15" font-weight="600"
               letter-spacing="-.3" font-family="-apple-system,sans-serif">Your</text>
         <text x="410" y="210" text-anchor="middle" fill="#fff" font-size="15" font-weight="600"
@@ -429,13 +429,13 @@ if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
       var col=s%per, row=Math.floor(s/per);
       seats.appendChild(el('circle',{
         cx:x+(col-(Math.min(n,per)-1)/2)*4.6, cy:y+(row-(rows-1)/2)*4.6, r:1.5,
-        fill:'#1d1d1f', 'fill-opacity':0.32
+        fill:'#14171c', 'fill-opacity':0.32
       }));
     }
     var anchor = (x<cx-20)?'end':(x>cx+20)?'start':'middle';
     var ly = y + (y<cy? -26 : 30);
     labels.appendChild((function(){
-      var t=el('text',{x:x,y:ly,'text-anchor':anchor,fill:'#6e6e73','font-size':11,
+      var t=el('text',{x:x,y:ly,'text-anchor':anchor,fill:'#5b6169','font-size':11,
         'font-weight':600,'letter-spacing':'.02em','font-family':'-apple-system,sans-serif'});
       t.textContent=d[0]+' · '+d[1]; return t;})());
   });

--- a/index.html
+++ b/index.html
@@ -13,10 +13,10 @@
    Font stack resolves to real SF Pro on Apple devices, the system default elsewhere.
    ========================================================================== */
 :root{
-  --ink:#1d1d1f;
+  --ink:#14171c;
   --ink-2:#333336;
-  --muted:#6e6e73;
-  --surface:#f5f5f7;
+  --muted:#5b6169;
+  --surface:#f6f5f2;        /* warm rather than Apple's cool grey */
   --white:#fff;
   --blue:#0a3a66;           /* deep navy, our own, not Apple's blue */
   --link:#0a3a66;           /* same navy, one accent throughout */
@@ -24,7 +24,7 @@
   --shadow:0 5px 30px rgba(0,0,0,.22);
   --ease:cubic-bezier(.4,0,.6,1);
   --dur:.32s;
-  --stadium:980px;
+  --stadium:100px;
   --wide:1024px;
   --sans:-apple-system,BlinkMacSystemFont,"SF Pro Display","SF Pro Text","Helvetica Neue",Helvetica,Arial,sans-serif;
 }
@@ -38,8 +38,8 @@ a:hover{text-decoration:underline}
 .wrap{max-width:var(--wide);margin:0 auto;padding:0 22px}
 
 .nav{position:sticky;top:0;z-index:100;height:44px;
-  background:rgba(255,255,255,.72);backdrop-filter:saturate(180%) blur(20px);
-  -webkit-backdrop-filter:saturate(180%) blur(20px);border-bottom:1px solid var(--hair)}
+  background:rgba(255,255,255,.78);backdrop-filter:saturate(150%) blur(16px);
+  -webkit-backdrop-filter:saturate(150%) blur(16px);border-bottom:1px solid var(--hair)}
 .nav-in{max-width:var(--wide);margin:0 auto;padding:0 22px;height:44px;
   display:flex;align-items:center;gap:34px}
 .nav a{font-size:12px;letter-spacing:-.01em;color:var(--ink);opacity:.85;transition:opacity var(--dur) var(--ease)}
@@ -295,7 +295,7 @@ video{display:block;width:100%;height:auto}
   <div class="wrap">
     <p class="eyebrow reveal">CoCo Research</p>
     <h1 class="reveal">Governed AI,<br>built in the open.</h1>
-    <p class="sub reveal">One flagship framework. Thirteen more things around it, each shown at its real stage.</p>
+    <p class="sub reveal">One flagship framework, and thirteen more things around it — each shown at its real stage.</p>
     <p class="body reveal" style="margin:16px auto 0;text-align:center;max-width:56ch">
       CoCo Research is where a regulated-risk product leader builds and open-sources the
       agentic AI he designs by day. The concerns carry over either way: governed memory,
@@ -448,21 +448,8 @@ video{display:block;width:100%;height:auto}
           </div>
         </div>
       </div>
-      <div class="feat">
-        <div>
-          <h4>Installs the whole family</h4>
-          <p>Adds and removes CoCo modules without you editing a settings file by hand.</p>
-        </div>
-        <div>
-          <h4>Tells you what is broken</h4>
-          <p>Health checks every module and reports which ones are actually wired up.</p>
-        </div>
-        <div>
-          <h4>Updates itself</h4>
-          <p>Ships as a signed build with an auto-update feed, so upgrades are not a re-install.</p>
-        </div>
-      </div>
-      <p class="fine" style="margin-top:34px">The published build is Apple silicon. Other
+      <p class="body" style="margin-top:28px;max-width:60ch"><strong style="color:var(--ink)">Tells you what is broken</strong> — health checks every module and reports which ones are actually wired up.</p>
+      <p class="fine" style="margin-top:20px">The published build is Apple silicon. Other
         platforms are not packaged yet.</p>
     </div>
 
@@ -595,7 +582,7 @@ video{display:block;width:100%;height:auto}
       <a href="mailto:product@cocoresearch.org">product@cocoresearch.org</a>
       <a href="mailto:sales@cocoresearch.org">sales@cocoresearch.org</a>
     </div>
-    <p class="fine">CoCo Research is Coco Inc, Rijul Kalra. CoCo is open-core: the framework
+    <p class="fine">CoCo Research is Coco Inc. CoCo is open-core: the framework
       is MIT, the Super Intelligence board is licensed separately and kept proprietary.
       Every stage marked on this page is the actual one, not the one that reads better.</p>
   </div>


### PR DESCRIPTION
## What this closes out

The previous PR fixed the accent color and logo gradient, but left several items from the brand-methodology audit unaddressed. This finishes them:

- **Varied both remaining repeated headlines.** \`/coco/\`'s H1 is now a single flowing sentence rather than Apple's "[Claim]. [Fragment]." construction, and the homepage subtitle's two fragments are now one sentence.
- **Escalated \`/coco/\`'s hero sub-line** instead of repeating the homepage teaser verbatim — it now names the actual verification mechanism (a live, checkable source per persona) rather than restating "389 experts deliberate."
- **Trimmed CoCo Connect** from three feature-grid claims to the one the audit called strongest, rather than fabricating a screenshot to keep the other two.
- **Replaced Apple's own documented neutral values.** The audit's real point was that fixing the accent color alone left "the whole system" — Apple's exact `#1d1d1f`/`#6e6e73`/`#f5f5f7`, the `980px` pill radius, the `saturate(180%) blur(20px)` nav recipe — still matching Apple's own documented values number-for-number. All replaced with original values (re-verified for WCAG AA contrast before use), including two spots in the board diagram's inline SVG that were hardcoded and hadn't been going through the CSS variable at all.

## Also

Removes the owner's name from the homepage footer, per request.

## Verification

- All repository gates pass: `scripts/build-index.py` (no drift), `tests/check-command-refs.sh`, `tests/check-evidence-gate.sh`.
- Zero remaining Apple-exact color/radius/blur values, swept programmatically across both pages after the change.
- Zero remaining occurrences of the owner's name.
- New neutral palette re-verified for WCAG AA contrast (muted text clears 5.7:1+ on both backgrounds).
- Tag balance checked, spot-checked in-browser (computed styles + screenshot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)