### PR TITLE
feat(site): add meta description + OG/Twitter tags, fix About nav label

### DIFF
--- a/coco/index.html
+++ b/coco/index.html
@@ -4,6 +4,16 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>CoCo: An entire engineering department, inside your editor</title>
+<meta name="description" content="Each of the 389 requires a live, checkable source. Then 184 skills ship what they decided.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://cocoresearch.org/coco/">
+<meta property="og:title" content="CoCo: An entire engineering department, inside your editor">
+<meta property="og:description" content="Each of the 389 requires a live, checkable source. Then 184 skills ship what they decided.">
+<meta property="og:image" content="https://cocoresearch.org/assets/og-image.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="CoCo: An entire engineering department, inside your editor">
+<meta name="twitter:description" content="Each of the 389 requires a live, checkable source. Then 184 skills ship what they decided.">
+<meta name="twitter:image" content="https://cocoresearch.org/assets/og-image.png">
 <style>
 /* ============================================================================
    Type scale, spacing, and layout proportions follow the Apple methodology

--- a/index.html
+++ b/index.html
@@ -4,6 +4,16 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>CoCo Research: governed AI, built in the open</title>
+<meta name="description" content="One flagship framework, and fourteen more things around it, each shown at its real stage.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://cocoresearch.org/">
+<meta property="og:title" content="CoCo Research: governed AI, built in the open">
+<meta property="og:description" content="One flagship framework, and fourteen more things around it, each shown at its real stage.">
+<meta property="og:image" content="https://cocoresearch.org/assets/og-image.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="CoCo Research: governed AI, built in the open">
+<meta name="twitter:description" content="One flagship framework, and fourteen more things around it, each shown at its real stage.">
+<meta name="twitter:image" content="https://cocoresearch.org/assets/og-image.png">
 <style>
 /* ============================================================================
    Type scale, spacing, and layout proportions follow the Apple methodology
@@ -247,7 +257,7 @@ video{display:block;width:100%;height:auto}
     <div class="spacer"></div>
     <a href="/coco/">CoCo</a>
     <button type="button" class="nav-trigger" id="products-trigger" aria-expanded="false" aria-controls="products-overlay">Products</button>
-    <a href="#about">About</a>
+    <a href="#about">Principles</a>
     <a href="https://github.com/coco-research">GitHub</a>
   </div>
 </nav>


### PR DESCRIPTION
## Summary
- TODO item 17: both pages had only `charset`/`viewport`/`title` in `<head>` — shared links unfurled with no description or image. Added `meta description`, Open Graph, and Twitter Card tags to both pages, reusing each page's own existing verified copy (no new claims), pointing at the `og-image.png` already live in the repo at `/assets/og-image.png`.
- TODO item 18: renamed the home nav's "About" link to "Principles" — it points to the "What stays the same across every product" section, which never contained the word "About."

## Test plan
- [x] Ran `scripts/build-index.py`, `tests/check-command-refs.sh`, `tests/check-evidence-gate.sh` — all pass
- [x] Verified in browser preview: meta tags present and correct on both pages, `og:image` resolves to the absolute root-level image (important since `/coco/`'s own relative asset paths point at a different local `assets/` dir), nav renamed and pointing at the same anchor