### PR TITLE
feat(si): make the local build endpoint configurable

### DIFF
--- a/systems/superintelligence/README.md
+++ b/systems/superintelligence/README.md
@@ -71,6 +71,20 @@ Persona generation was an explicit cost/quality experiment, settled by evidence:
 3. **gemini-3.5-flash** (`build_cursor.py`, Cursor headless agent) — top quality, but agent-latency-flaky at batch scale.
 4. **Claude research agents (WebSearch)** — the quality winner; built the pending tail via a fan-out workflow.
 
+`build_local.py` talks plain OpenAI chat-completions, so it is not tied to LM Studio. Point
+it at any server speaking that shape — including an [exo](https://github.com/exo-explore/exo)
+cluster, which lets a model span several machines rather than being capped by one:
+
+```bash
+COCO_LOCAL_ENDPOINT=http://localhost:52415/v1/chat/completions \
+COCO_LOCAL_MODEL=mlx-community/Qwen3.6-35B-A3B-8bit \
+  python3 finance/scripts/build_local.py --all
+```
+
+Both variables are optional; unset, the defaults remain LM Studio and `qwen/qwen3.6-35b-a3b`,
+which is what the roster above was actually built with. An explicit `--model` still wins over
+`COCO_LOCAL_MODEL`. Whichever model you name must already be loaded by that server.
+
 Plus cheap repair/recalibration: `yaml_repair.py` + `topup_cheap.py` (fix malformed YAML, prune dead URLs), and a **recalibrated validator** ([`*/scripts/validate_persona.py`](finance/scripts/validate_persona.py)) that keeps the anti-fabrication core (≥4 **live** real URLs, every stance cited, no invented quotes) while relaxing arbitrary quotas and tolerating link-rot. `activate_teams.py` flips `built=true` + regenerates commands for teams clearing threshold. Full write-up in [`QUALITY-FINDINGS.md`](QUALITY-FINDINGS.md).
 
 ## Persona schema

--- a/systems/superintelligence/data-analytics/scripts/build_local.py
+++ b/systems/superintelligence/data-analytics/scripts/build_local.py
@@ -4,15 +4,22 @@ Production local-first persona builder for the Finance SIT (and reusable for any
 Pipeline per persona:  retrieve (deep, free) -> draft (local) -> repair/cite pass (local)
   -> write personas/<slug>.md + research/<slug>/notes.md -> validate -> verdict.
 
-All generation is local (LM Studio) => ~$0. Validator enforces the verify-gate.
+All generation runs against a local OpenAI-compatible server => ~$0. Validator enforces
+the verify-gate. The defaults target LM Studio, which this pipeline was built against;
+set COCO_LOCAL_ENDPOINT to use any other OpenAI-compatible server (exo, llama.cpp, vLLM).
 
 Usage:
   python3 build_local.py --all
   python3 build_local.py --only aswath-damodaran
   python3 build_local.py --cell macro-economics
-  (model defaults to qwen/qwen3.6-35b-a3b; must be loaded in LM Studio)
+  (model defaults to $COCO_LOCAL_MODEL, else qwen/qwen3.6-35b-a3b; whichever it is
+   must already be loaded by the server at $COCO_LOCAL_ENDPOINT)
+
+  # run against an exo cluster instead of LM Studio:
+  COCO_LOCAL_ENDPOINT=http://localhost:52415/v1/chat/completions \\
+  COCO_LOCAL_MODEL=mlx-community/Qwen3.6-35B-A3B-8bit python3 build_local.py --all
 """
-import argparse, json, re, sys, time, urllib.request, pathlib, yaml
+import argparse, json, os, re, sys, time, urllib.request, pathlib, yaml
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import retriever
 from validate_persona import validate
@@ -21,7 +28,11 @@ FIN = pathlib.Path(__file__).resolve().parents[1]          # superintelligence/f
 ROSTER = json.loads((FIN / "roster.json").read_text())
 PERSONAS = FIN / "personas"; PERSONAS.mkdir(exist_ok=True)
 RESEARCH = FIN / "research"; RESEARCH.mkdir(exist_ok=True)
-ENDPOINT = "http://127.0.0.1:1234/v1/chat/completions"
+# Any OpenAI-compatible chat-completions endpoint works. Kept as the default because the
+# roster was built against LM Studio; exo serves the identical shape on port 52415.
+DEFAULT_ENDPOINT = "http://127.0.0.1:1234/v1/chat/completions"
+DEFAULT_MODEL = "qwen/qwen3.6-35b-a3b"
+ENDPOINT = os.environ.get("COCO_LOCAL_ENDPOINT") or DEFAULT_ENDPOINT
 POOL = [p["slug"] for p in ROSTER["personas"]]
 
 FM = """slug, real_name, archetype (one line), teams (list), home_team, cell, cell_role, status (active|archetype), affiliations_2026 (list; single-quote values with a colon), domains (list), signature_moves (list), canonical_works (list), key_publications (list), recent_signal_12mo (list of {title,date,url}), public_stances (list of {stance,evidence_url}), mental_models (list), pairs_well_with (list of slugs), productive_conflict_with (list of slugs), blind_spots (list), voice_style (text), when_to_summon (list), confidence, last_verified, sources (list of URLs)"""
@@ -97,7 +108,7 @@ def build_one(p, model):
 
 def main():
     ap=argparse.ArgumentParser()
-    ap.add_argument("--model",default="qwen/qwen3.6-35b-a3b")
+    ap.add_argument("--model",default=os.environ.get("COCO_LOCAL_MODEL") or DEFAULT_MODEL)
     ap.add_argument("--all",action="store_true"); ap.add_argument("--only",default=""); ap.add_argument("--cell",default="")
     ap.add_argument("--force",action="store_true",help="rebuild even if persona file already exists")
     a=ap.parse_args()
@@ -107,7 +118,7 @@ def main():
     elif not a.all: sys.exit("pass --all | --only <slug> | --cell <cell>")
     if not a.force:
         todo=[p for p in todo if not (PERSONAS/f"{p['slug']}.md").exists()]  # resume: skip built
-    print(f"building {len(todo)} persona(s) with {a.model}")
+    print(f"building {len(todo)} persona(s) with {a.model} via {ENDPOINT}")
     npass=0
     for i,p in enumerate(todo,1):
         try:

--- a/systems/superintelligence/finance/scripts/build_local.py
+++ b/systems/superintelligence/finance/scripts/build_local.py
@@ -4,15 +4,22 @@ Production local-first persona builder for the Finance SIT (and reusable for any
 Pipeline per persona:  retrieve (deep, free) -> draft (local) -> repair/cite pass (local)
   -> write personas/<slug>.md + research/<slug>/notes.md -> validate -> verdict.
 
-All generation is local (LM Studio) => ~$0. Validator enforces the verify-gate.
+All generation runs against a local OpenAI-compatible server => ~$0. Validator enforces
+the verify-gate. The defaults target LM Studio, which this pipeline was built against;
+set COCO_LOCAL_ENDPOINT to use any other OpenAI-compatible server (exo, llama.cpp, vLLM).
 
 Usage:
   python3 build_local.py --all
   python3 build_local.py --only aswath-damodaran
   python3 build_local.py --cell macro-economics
-  (model defaults to qwen/qwen3.6-35b-a3b; must be loaded in LM Studio)
+  (model defaults to $COCO_LOCAL_MODEL, else qwen/qwen3.6-35b-a3b; whichever it is
+   must already be loaded by the server at $COCO_LOCAL_ENDPOINT)
+
+  # run against an exo cluster instead of LM Studio:
+  COCO_LOCAL_ENDPOINT=http://localhost:52415/v1/chat/completions \\
+  COCO_LOCAL_MODEL=mlx-community/Qwen3.6-35B-A3B-8bit python3 build_local.py --all
 """
-import argparse, json, re, sys, time, urllib.request, pathlib, yaml
+import argparse, json, os, re, sys, time, urllib.request, pathlib, yaml
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import retriever
 from validate_persona import validate
@@ -21,7 +28,11 @@ FIN = pathlib.Path(__file__).resolve().parents[1]          # superintelligence/f
 ROSTER = json.loads((FIN / "roster.json").read_text())
 PERSONAS = FIN / "personas"; PERSONAS.mkdir(exist_ok=True)
 RESEARCH = FIN / "research"; RESEARCH.mkdir(exist_ok=True)
-ENDPOINT = "http://127.0.0.1:1234/v1/chat/completions"
+# Any OpenAI-compatible chat-completions endpoint works. Kept as the default because the
+# roster was built against LM Studio; exo serves the identical shape on port 52415.
+DEFAULT_ENDPOINT = "http://127.0.0.1:1234/v1/chat/completions"
+DEFAULT_MODEL = "qwen/qwen3.6-35b-a3b"
+ENDPOINT = os.environ.get("COCO_LOCAL_ENDPOINT") or DEFAULT_ENDPOINT
 POOL = [p["slug"] for p in ROSTER["personas"]]
 
 FM = """slug, real_name, archetype (one line), teams (list), home_team, cell, cell_role, status (active|archetype), affiliations_2026 (list; single-quote values with a colon), domains (list), signature_moves (list), canonical_works (list), key_publications (list), recent_signal_12mo (list of {title,date,url}), public_stances (list of {stance,evidence_url}), mental_models (list), pairs_well_with (list of slugs), productive_conflict_with (list of slugs), blind_spots (list), voice_style (text), when_to_summon (list), confidence, last_verified, sources (list of URLs)"""
@@ -97,7 +108,7 @@ def build_one(p, model):
 
 def main():
     ap=argparse.ArgumentParser()
-    ap.add_argument("--model",default="qwen/qwen3.6-35b-a3b")
+    ap.add_argument("--model",default=os.environ.get("COCO_LOCAL_MODEL") or DEFAULT_MODEL)
     ap.add_argument("--all",action="store_true"); ap.add_argument("--only",default=""); ap.add_argument("--cell",default="")
     ap.add_argument("--force",action="store_true",help="rebuild even if persona file already exists")
     a=ap.parse_args()
@@ -107,7 +118,7 @@ def main():
     elif not a.all: sys.exit("pass --all | --only <slug> | --cell <cell>")
     if not a.force:
         todo=[p for p in todo if not (PERSONAS/f"{p['slug']}.md").exists()]  # resume: skip built
-    print(f"building {len(todo)} persona(s) with {a.model}")
+    print(f"building {len(todo)} persona(s) with {a.model} via {ENDPOINT}")
     npass=0
     for i,p in enumerate(todo,1):
         try:

--- a/systems/superintelligence/gtm/scripts/build_local.py
+++ b/systems/superintelligence/gtm/scripts/build_local.py
@@ -4,15 +4,22 @@ Production local-first persona builder for the Finance SIT (and reusable for any
 Pipeline per persona:  retrieve (deep, free) -> draft (local) -> repair/cite pass (local)
   -> write personas/<slug>.md + research/<slug>/notes.md -> validate -> verdict.
 
-All generation is local (LM Studio) => ~$0. Validator enforces the verify-gate.
+All generation runs against a local OpenAI-compatible server => ~$0. Validator enforces
+the verify-gate. The defaults target LM Studio, which this pipeline was built against;
+set COCO_LOCAL_ENDPOINT to use any other OpenAI-compatible server (exo, llama.cpp, vLLM).
 
 Usage:
   python3 build_local.py --all
   python3 build_local.py --only aswath-damodaran
   python3 build_local.py --cell macro-economics
-  (model defaults to qwen/qwen3.6-35b-a3b; must be loaded in LM Studio)
+  (model defaults to $COCO_LOCAL_MODEL, else qwen/qwen3.6-35b-a3b; whichever it is
+   must already be loaded by the server at $COCO_LOCAL_ENDPOINT)
+
+  # run against an exo cluster instead of LM Studio:
+  COCO_LOCAL_ENDPOINT=http://localhost:52415/v1/chat/completions \\
+  COCO_LOCAL_MODEL=mlx-community/Qwen3.6-35B-A3B-8bit python3 build_local.py --all
 """
-import argparse, json, re, sys, time, urllib.request, pathlib, yaml
+import argparse, json, os, re, sys, time, urllib.request, pathlib, yaml
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import retriever
 from validate_persona import validate
@@ -21,7 +28,11 @@ FIN = pathlib.Path(__file__).resolve().parents[1]          # superintelligence/f
 ROSTER = json.loads((FIN / "roster.json").read_text())
 PERSONAS = FIN / "personas"; PERSONAS.mkdir(exist_ok=True)
 RESEARCH = FIN / "research"; RESEARCH.mkdir(exist_ok=True)
-ENDPOINT = "http://127.0.0.1:1234/v1/chat/completions"
+# Any OpenAI-compatible chat-completions endpoint works. Kept as the default because the
+# roster was built against LM Studio; exo serves the identical shape on port 52415.
+DEFAULT_ENDPOINT = "http://127.0.0.1:1234/v1/chat/completions"
+DEFAULT_MODEL = "qwen/qwen3.6-35b-a3b"
+ENDPOINT = os.environ.get("COCO_LOCAL_ENDPOINT") or DEFAULT_ENDPOINT
 POOL = [p["slug"] for p in ROSTER["personas"]]
 
 FM = """slug, real_name, archetype (one line), teams (list), home_team, cell, cell_role, status (active|archetype), affiliations_2026 (list; single-quote values with a colon), domains (list), signature_moves (list), canonical_works (list), key_publications (list), recent_signal_12mo (list of {title,date,url}), public_stances (list of {stance,evidence_url}), mental_models (list), pairs_well_with (list of slugs), productive_conflict_with (list of slugs), blind_spots (list), voice_style (text), when_to_summon (list), confidence, last_verified, sources (list of URLs)"""
@@ -97,7 +108,7 @@ def build_one(p, model):
 
 def main():
     ap=argparse.ArgumentParser()
-    ap.add_argument("--model",default="qwen/qwen3.6-35b-a3b")
+    ap.add_argument("--model",default=os.environ.get("COCO_LOCAL_MODEL") or DEFAULT_MODEL)
     ap.add_argument("--all",action="store_true"); ap.add_argument("--only",default=""); ap.add_argument("--cell",default="")
     ap.add_argument("--force",action="store_true",help="rebuild even if persona file already exists")
     a=ap.parse_args()
@@ -107,7 +118,7 @@ def main():
     elif not a.all: sys.exit("pass --all | --only <slug> | --cell <cell>")
     if not a.force:
         todo=[p for p in todo if not (PERSONAS/f"{p['slug']}.md").exists()]  # resume: skip built
-    print(f"building {len(todo)} persona(s) with {a.model}")
+    print(f"building {len(todo)} persona(s) with {a.model} via {ENDPOINT}")
     npass=0
     for i,p in enumerate(todo,1):
         try:

--- a/systems/superintelligence/risk-compliance/scripts/build_local.py
+++ b/systems/superintelligence/risk-compliance/scripts/build_local.py
@@ -4,15 +4,22 @@ Production local-first persona builder for the Finance SIT (and reusable for any
 Pipeline per persona:  retrieve (deep, free) -> draft (local) -> repair/cite pass (local)
   -> write personas/<slug>.md + research/<slug>/notes.md -> validate -> verdict.
 
-All generation is local (LM Studio) => ~$0. Validator enforces the verify-gate.
+All generation runs against a local OpenAI-compatible server => ~$0. Validator enforces
+the verify-gate. The defaults target LM Studio, which this pipeline was built against;
+set COCO_LOCAL_ENDPOINT to use any other OpenAI-compatible server (exo, llama.cpp, vLLM).
 
 Usage:
   python3 build_local.py --all
   python3 build_local.py --only aswath-damodaran
   python3 build_local.py --cell macro-economics
-  (model defaults to qwen/qwen3.6-35b-a3b; must be loaded in LM Studio)
+  (model defaults to $COCO_LOCAL_MODEL, else qwen/qwen3.6-35b-a3b; whichever it is
+   must already be loaded by the server at $COCO_LOCAL_ENDPOINT)
+
+  # run against an exo cluster instead of LM Studio:
+  COCO_LOCAL_ENDPOINT=http://localhost:52415/v1/chat/completions \\
+  COCO_LOCAL_MODEL=mlx-community/Qwen3.6-35B-A3B-8bit python3 build_local.py --all
 """
-import argparse, json, re, sys, time, urllib.request, pathlib, yaml
+import argparse, json, os, re, sys, time, urllib.request, pathlib, yaml
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import retriever
 from validate_persona import validate
@@ -21,7 +28,11 @@ FIN = pathlib.Path(__file__).resolve().parents[1]          # superintelligence/f
 ROSTER = json.loads((FIN / "roster.json").read_text())
 PERSONAS = FIN / "personas"; PERSONAS.mkdir(exist_ok=True)
 RESEARCH = FIN / "research"; RESEARCH.mkdir(exist_ok=True)
-ENDPOINT = "http://127.0.0.1:1234/v1/chat/completions"
+# Any OpenAI-compatible chat-completions endpoint works. Kept as the default because the
+# roster was built against LM Studio; exo serves the identical shape on port 52415.
+DEFAULT_ENDPOINT = "http://127.0.0.1:1234/v1/chat/completions"
+DEFAULT_MODEL = "qwen/qwen3.6-35b-a3b"
+ENDPOINT = os.environ.get("COCO_LOCAL_ENDPOINT") or DEFAULT_ENDPOINT
 POOL = [p["slug"] for p in ROSTER["personas"]]
 
 FM = """slug, real_name, archetype (one line), teams (list), home_team, cell, cell_role, status (active|archetype), affiliations_2026 (list; single-quote values with a colon), domains (list), signature_moves (list), canonical_works (list), key_publications (list), recent_signal_12mo (list of {title,date,url}), public_stances (list of {stance,evidence_url}), mental_models (list), pairs_well_with (list of slugs), productive_conflict_with (list of slugs), blind_spots (list), voice_style (text), when_to_summon (list), confidence, last_verified, sources (list of URLs)"""
@@ -97,7 +108,7 @@ def build_one(p, model):
 
 def main():
     ap=argparse.ArgumentParser()
-    ap.add_argument("--model",default="qwen/qwen3.6-35b-a3b")
+    ap.add_argument("--model",default=os.environ.get("COCO_LOCAL_MODEL") or DEFAULT_MODEL)
     ap.add_argument("--all",action="store_true"); ap.add_argument("--only",default=""); ap.add_argument("--cell",default="")
     ap.add_argument("--force",action="store_true",help="rebuild even if persona file already exists")
     a=ap.parse_args()
@@ -107,7 +118,7 @@ def main():
     elif not a.all: sys.exit("pass --all | --only <slug> | --cell <cell>")
     if not a.force:
         todo=[p for p in todo if not (PERSONAS/f"{p['slug']}.md").exists()]  # resume: skip built
-    print(f"building {len(todo)} persona(s) with {a.model}")
+    print(f"building {len(todo)} persona(s) with {a.model} via {ENDPOINT}")
     npass=0
     for i,p in enumerate(todo,1):
         try:

--- a/systems/superintelligence/strategy/scripts/build_local.py
+++ b/systems/superintelligence/strategy/scripts/build_local.py
@@ -4,15 +4,22 @@ Production local-first persona builder for the Finance SIT (and reusable for any
 Pipeline per persona:  retrieve (deep, free) -> draft (local) -> repair/cite pass (local)
   -> write personas/<slug>.md + research/<slug>/notes.md -> validate -> verdict.
 
-All generation is local (LM Studio) => ~$0. Validator enforces the verify-gate.
+All generation runs against a local OpenAI-compatible server => ~$0. Validator enforces
+the verify-gate. The defaults target LM Studio, which this pipeline was built against;
+set COCO_LOCAL_ENDPOINT to use any other OpenAI-compatible server (exo, llama.cpp, vLLM).
 
 Usage:
   python3 build_local.py --all
   python3 build_local.py --only aswath-damodaran
   python3 build_local.py --cell macro-economics
-  (model defaults to qwen/qwen3.6-35b-a3b; must be loaded in LM Studio)
+  (model defaults to $COCO_LOCAL_MODEL, else qwen/qwen3.6-35b-a3b; whichever it is
+   must already be loaded by the server at $COCO_LOCAL_ENDPOINT)
+
+  # run against an exo cluster instead of LM Studio:
+  COCO_LOCAL_ENDPOINT=http://localhost:52415/v1/chat/completions \\
+  COCO_LOCAL_MODEL=mlx-community/Qwen3.6-35B-A3B-8bit python3 build_local.py --all
 """
-import argparse, json, re, sys, time, urllib.request, pathlib, yaml
+import argparse, json, os, re, sys, time, urllib.request, pathlib, yaml
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import retriever
 from validate_persona import validate
@@ -21,7 +28,11 @@ FIN = pathlib.Path(__file__).resolve().parents[1]          # superintelligence/f
 ROSTER = json.loads((FIN / "roster.json").read_text())
 PERSONAS = FIN / "personas"; PERSONAS.mkdir(exist_ok=True)
 RESEARCH = FIN / "research"; RESEARCH.mkdir(exist_ok=True)
-ENDPOINT = "http://127.0.0.1:1234/v1/chat/completions"
+# Any OpenAI-compatible chat-completions endpoint works. Kept as the default because the
+# roster was built against LM Studio; exo serves the identical shape on port 52415.
+DEFAULT_ENDPOINT = "http://127.0.0.1:1234/v1/chat/completions"
+DEFAULT_MODEL = "qwen/qwen3.6-35b-a3b"
+ENDPOINT = os.environ.get("COCO_LOCAL_ENDPOINT") or DEFAULT_ENDPOINT
 POOL = [p["slug"] for p in ROSTER["personas"]]
 
 FM = """slug, real_name, archetype (one line), teams (list), home_team, cell, cell_role, status (active|archetype), affiliations_2026 (list; single-quote values with a colon), domains (list), signature_moves (list), canonical_works (list), key_publications (list), recent_signal_12mo (list of {title,date,url}), public_stances (list of {stance,evidence_url}), mental_models (list), pairs_well_with (list of slugs), productive_conflict_with (list of slugs), blind_spots (list), voice_style (text), when_to_summon (list), confidence, last_verified, sources (list of URLs)"""
@@ -97,7 +108,7 @@ def build_one(p, model):
 
 def main():
     ap=argparse.ArgumentParser()
-    ap.add_argument("--model",default="qwen/qwen3.6-35b-a3b")
+    ap.add_argument("--model",default=os.environ.get("COCO_LOCAL_MODEL") or DEFAULT_MODEL)
     ap.add_argument("--all",action="store_true"); ap.add_argument("--only",default=""); ap.add_argument("--cell",default="")
     ap.add_argument("--force",action="store_true",help="rebuild even if persona file already exists")
     a=ap.parse_args()
@@ -107,7 +118,7 @@ def main():
     elif not a.all: sys.exit("pass --all | --only <slug> | --cell <cell>")
     if not a.force:
         todo=[p for p in todo if not (PERSONAS/f"{p['slug']}.md").exists()]  # resume: skip built
-    print(f"building {len(todo)} persona(s) with {a.model}")
+    print(f"building {len(todo)} persona(s) with {a.model} via {ENDPOINT}")
     npass=0
     for i,p in enumerate(todo,1):
         try:

--- a/systems/superintelligence/trading/scripts/build_local.py
+++ b/systems/superintelligence/trading/scripts/build_local.py
@@ -4,15 +4,22 @@ Production local-first persona builder for the Finance SIT (and reusable for any
 Pipeline per persona:  retrieve (deep, free) -> draft (local) -> repair/cite pass (local)
   -> write personas/<slug>.md + research/<slug>/notes.md -> validate -> verdict.
 
-All generation is local (LM Studio) => ~$0. Validator enforces the verify-gate.
+All generation runs against a local OpenAI-compatible server => ~$0. Validator enforces
+the verify-gate. The defaults target LM Studio, which this pipeline was built against;
+set COCO_LOCAL_ENDPOINT to use any other OpenAI-compatible server (exo, llama.cpp, vLLM).
 
 Usage:
   python3 build_local.py --all
   python3 build_local.py --only aswath-damodaran
   python3 build_local.py --cell macro-economics
-  (model defaults to qwen/qwen3.6-35b-a3b; must be loaded in LM Studio)
+  (model defaults to $COCO_LOCAL_MODEL, else qwen/qwen3.6-35b-a3b; whichever it is
+   must already be loaded by the server at $COCO_LOCAL_ENDPOINT)
+
+  # run against an exo cluster instead of LM Studio:
+  COCO_LOCAL_ENDPOINT=http://localhost:52415/v1/chat/completions \\
+  COCO_LOCAL_MODEL=mlx-community/Qwen3.6-35B-A3B-8bit python3 build_local.py --all
 """
-import argparse, json, re, sys, time, urllib.request, pathlib, yaml
+import argparse, json, os, re, sys, time, urllib.request, pathlib, yaml
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import retriever
 from validate_persona import validate
@@ -21,7 +28,11 @@ FIN = pathlib.Path(__file__).resolve().parents[1]          # superintelligence/f
 ROSTER = json.loads((FIN / "roster.json").read_text())
 PERSONAS = FIN / "personas"; PERSONAS.mkdir(exist_ok=True)
 RESEARCH = FIN / "research"; RESEARCH.mkdir(exist_ok=True)
-ENDPOINT = "http://127.0.0.1:1234/v1/chat/completions"
+# Any OpenAI-compatible chat-completions endpoint works. Kept as the default because the
+# roster was built against LM Studio; exo serves the identical shape on port 52415.
+DEFAULT_ENDPOINT = "http://127.0.0.1:1234/v1/chat/completions"
+DEFAULT_MODEL = "qwen/qwen3.6-35b-a3b"
+ENDPOINT = os.environ.get("COCO_LOCAL_ENDPOINT") or DEFAULT_ENDPOINT
 POOL = [p["slug"] for p in ROSTER["personas"]]
 
 FM = """slug, real_name, archetype (one line), teams (list), home_team, cell, cell_role, status (active|archetype), affiliations_2026 (list; single-quote values with a colon), domains (list), signature_moves (list), canonical_works (list), key_publications (list), recent_signal_12mo (list of {title,date,url}), public_stances (list of {stance,evidence_url}), mental_models (list), pairs_well_with (list of slugs), productive_conflict_with (list of slugs), blind_spots (list), voice_style (text), when_to_summon (list), confidence, last_verified, sources (list of URLs)"""
@@ -97,7 +108,7 @@ def build_one(p, model):
 
 def main():
     ap=argparse.ArgumentParser()
-    ap.add_argument("--model",default="qwen/qwen3.6-35b-a3b")
+    ap.add_argument("--model",default=os.environ.get("COCO_LOCAL_MODEL") or DEFAULT_MODEL)
     ap.add_argument("--all",action="store_true"); ap.add_argument("--only",default=""); ap.add_argument("--cell",default="")
     ap.add_argument("--force",action="store_true",help="rebuild even if persona file already exists")
     a=ap.parse_args()
@@ -107,7 +118,7 @@ def main():
     elif not a.all: sys.exit("pass --all | --only <slug> | --cell <cell>")
     if not a.force:
         todo=[p for p in todo if not (PERSONAS/f"{p['slug']}.md").exists()]  # resume: skip built
-    print(f"building {len(todo)} persona(s) with {a.model}")
+    print(f"building {len(todo)} persona(s) with {a.model} via {ENDPOINT}")
     npass=0
     for i,p in enumerate(todo,1):
         try:


### PR DESCRIPTION
## Why

`build_local.py` already speaks plain OpenAI chat-completions, but the endpoint was hardcoded:

```python
ENDPOINT = "http://127.0.0.1:1234/v1/chat/completions"   # LM Studio
```

That line is duplicated verbatim across **six** byte-identical copies (`finance`, `gtm`, `strategy`, `trading`, `risk-compliance`, `data-analytics`), so pointing the pipeline at any other local server meant editing all six.

## What changed

- `COCO_LOCAL_ENDPOINT` and `COCO_LOCAL_MODEL` are now read from the environment.
- Defaults are unchanged (`127.0.0.1:1234`, `qwen/qwen3.6-35b-a3b`), so existing runs behave exactly as before.
- An explicit `--model` still wins over `COCO_LOCAL_MODEL`.
- The resolved endpoint is printed next to the model — previously "which server did that actually hit" was invisible.

## Why it matters

This makes an [exo](https://github.com/exo-explore/exo) cluster a drop-in backend. exo serves the identical OpenAI shape on `:52415`, and unlike a single-process server it can span several machines, so the model is no longer capped by one box's RAM. `mlx-community/Qwen3.6-35B-A3B-8bit` is in exo's built-in catalogue and is the same base model the roster was built with.

```bash
COCO_LOCAL_ENDPOINT=http://localhost:52415/v1/chat/completions \
COCO_LOCAL_MODEL=mlx-community/Qwen3.6-35B-A3B-8bit \
  python3 finance/scripts/build_local.py --all
```

## Verification

- All 6 scripts compile clean under `-W error::SyntaxWarning` and remain byte-identical to each other.
- Precedence exercised end-to-end via the real CLI:
  - default → `qwen/qwen3.6-35b-a3b via http://127.0.0.1:1234/...`
  - env → `mlx-community/Qwen3.6-35B-A3B-8bit via http://localhost:52415/...`
  - `--model flag-model` beats `COCO_LOCAL_MODEL=env-model`
- `tests/smoke.sh` 18/18; `build-index.py` reports no INDEX drift.

One bug caught while reviewing my own diff: the usage example's trailing `\` was being consumed as a string line-continuation, silently collapsing the two env vars onto one line and yielding a broken copy-pasteable command. Escaped so it renders literally.

Note: `registry.json` / `roster.json` `build_method` fields still say "LM Studio" — those are historical records of how the roster was actually built, so they were deliberately left alone.
