### PR TITLE
feat(local-llm): local inference ops — mlx-dspark wiring, reasoning-hang fix, skill + command

### DIFF
--- a/commands/INDEX.md
+++ b/commands/INDEX.md
@@ -2,7 +2,7 @@
 
 Auto-generated. Run `python3 scripts/build-index.py` to refresh.
 
-**Total: 37 commands across 6 namespaces.**
+**Total: 38 commands across 6 namespaces.**
 
 ## design
 
@@ -29,6 +29,7 @@ Auto-generated. Run `python3 scripts/build-index.py` to refresh.
 | Slash | Description |
 |-------|-------------|
 | [`/eng:anti-pattern`](eng/anti-pattern.md) |  |
+| [`/eng:local-llm`](eng/local-llm.md) | Check status, change context window, restart, or troubleshoot this machine's local LLM setup (LM Studio + mlx-dspark). Usage: /eng-local-llm [status\|set-contex |
 
 ## pm
 

--- a/commands/eng/local-llm.md
+++ b/commands/eng/local-llm.md
@@ -1,0 +1,108 @@
+---
+description: "Check status, change context window, restart, or troubleshoot this machine's local LLM setup (LM Studio + mlx-dspark). Usage: /eng-local-llm [status|set-context <n>|restart|troubleshoot]"
+allowed-tools:
+  - Read
+  - Bash
+---
+
+# /eng-local-llm — Local LLM Ops
+
+Read `skills/local-llm/SKILL.md` first for full background (architecture, the
+prefill trick, RAM/speed cheatsheets, idle-unload behavior) before acting on
+any subcommand below -- this command is the action layer on top of that
+knowledge, not a replacement for it.
+
+Parse `$ARGUMENTS`: first token is the subcommand (`status`, `set-context`,
+`restart`, `troubleshoot`). No arguments -> show the quick reference table
+below and stop.
+
+## Quick reference (no-args output)
+
+| Command | Purpose |
+|---|---|
+| `/eng-local-llm status` | One-shot health/metrics/RAM snapshot of both backends |
+| `/eng-local-llm set-context <n>` | Safely change mlx-dspark's context window and restart |
+| `/eng-local-llm restart` | Safe restart of the mlx-dspark server with health verification |
+| `/eng-local-llm troubleshoot` | Walk the troubleshooting playbook interactively |
+
+## `status`
+
+Run all of the following and present a combined summary (loaded/unloaded
+state, context window, RAM estimate, both launchd agents' status):
+
+```bash
+echo "--- mlx-dspark health ---"
+curl -s http://127.0.0.1:8090/health
+echo
+echo "--- mlx-dspark metrics ---"
+curl -s http://127.0.0.1:8090/metrics
+echo
+echo "--- LM Studio ---"
+lms ps
+echo
+echo "--- launchd agents ---"
+launchctl list | grep -i dspark
+```
+
+Interpret the output for the user:
+- `/health`'s `status` field: `ok` = loaded and ready, `no_model` = currently
+  idle-unloaded (expect a ~7-40s cold-load delay on the next request, not a
+  hang).
+- `context_window` should read 65536 unless it was deliberately changed.
+- `/metrics`'s `memory.active_bytes`/`peak_bytes` give the live RAM footprint.
+- If LM Studio also shows a loaded model, flag that as extra RAM (~16GB) not
+  needed by `build_local.py`'s pipeline (it only talks to mlx-dspark).
+- Both `com.local.mlx-dspark` and `com.local.mlx-dspark-idle-watcher` should
+  appear in the launchd list; a missing one means that LaunchAgent isn't
+  loaded (`launchctl load ~/Library/LaunchAgents/<name>.plist` to fix).
+
+## `set-context <n>`
+
+`<n>` is the new context window token count (e.g. `set-context 131072`). Before
+changing anything:
+
+1. **Show the RAM math first** using the cheatsheet table from
+   `skills/local-llm/SKILL.md` (KV cache per request x `--max-batch 4`) and
+   confirm with the user this is what they want, especially for anything
+   above 65536 -- don't silently apply a large jump.
+2. Edit `~/.config/mlx-dspark/start.sh`: change `--context-window <old>` to
+   `--context-window <n>`.
+3. Find and kill the running process to trigger a `launchd`-managed restart:
+   ```bash
+   ps aux | grep mlx_dspark | grep -v grep   # find the PID
+   kill <pid>
+   ```
+4. Poll `/health` until `status` is `"ok"` again, and confirm `context_window`
+   in the response equals `<n>`:
+   ```bash
+   for i in $(seq 1 30); do
+     r=$(curl -s http://127.0.0.1:8090/health)
+     echo "$r"
+     echo "$r" | grep -q '"status": "ok"' && break
+     sleep 3
+   done
+   ```
+5. Report the new RAM math and confirm the change is live.
+
+## `restart`
+
+Safe restart without changing any config:
+
+1. `ps aux | grep mlx_dspark | grep -v grep` to find the current PID.
+2. `kill <pid>` -- `launchd`'s `KeepAlive(Crashed)` will restart it
+   automatically within seconds.
+3. Poll `/health` (same loop as above) until `status` is `"ok"`.
+4. Confirm `context_window` and `mode` match what's expected before declaring
+   success.
+
+## `troubleshoot`
+
+Walk the user through `skills/local-llm/SKILL.md`'s troubleshooting playbook
+interactively:
+1. Ask what symptom they're seeing (hang, 503, YAML/formatting slip, context
+   truncation, server unresponsive, something else).
+2. Match it to the relevant playbook entry and walk through the diagnostic
+   steps live (run the actual `curl`/`launchctl`/`ps` commands, don't just
+   describe them).
+3. If none of the documented symptoms match, gather `/health`, `/metrics`,
+   and the actual error message/traceback before speculating on a cause.

--- a/docs/by-domain/ops.md
+++ b/docs/by-domain/ops.md
@@ -2,12 +2,13 @@
 
 Auto-generated view. Filtered to `domain: ops` skills.
 
-**5 skills.**
+**6 skills.**
 
 | Skill | Description |
 |-------|-------------|
 | [pmstudio-arb](../../skills/arb-review/SKILL.md) | Generate an Architecture Review Board (ARB) presentation in Coco Inc's standard 11-slide format. Use when someone asks to "create an ARB deck", "architecture review presentation", "prepare for archite |
 | [pmstudio-dr](../../skills/dr-plan/SKILL.md) | Generate a Disaster Recovery plan with RTO/RPO targets. Use when someone asks to "create a DR plan", "disaster recovery", "business continuity", or "RTO RPO". Do NOT use for step-by-step restoration r |
 | [pmstudio-irp](../../skills/irp/SKILL.md) | Generate an Incident Response Plan (IRP) with severity classification, escalation procedures, and communication templates. Use when someone asks to "create an incident response plan", "IRP", "incident |
+| [local-llm](../../skills/local-llm/SKILL.md) | Use when working with this machine's local LLM setup (LM Studio + mlx-dspark) -- checking status, changing context window, diagnosing a reasoning hang or dead request, understanding RAM/speed tradeoff |
 | [pmstudio-nfr](../../skills/nfr-tracker/SKILL.md) | Detailed completeness audit of all project documents. Use when someone asks "are we ready for production", "audit our docs", "readiness check", "nfr tracker", or "what's missing". Do NOT use for a qui |
 | [pmstudio-recovery](../../skills/recovery-plan/SKILL.md) | Generate detailed service restoration runbooks with step-by-step procedures. Use when someone asks to "create recovery procedures", "restoration runbook", "recovery steps", "how to restore service", o |

--- a/skills/INDEX.md
+++ b/skills/INDEX.md
@@ -2,7 +2,7 @@
 
 Auto-generated. Run `python3 scripts/build-index.py` to refresh.
 
-**Total: 184 skills** — 69 core, 115 across 7 bundles.
+**Total: 185 skills** — 70 core, 115 across 7 bundles.
 
 ## Design (15)
 
@@ -78,13 +78,14 @@ Auto-generated. Run `python3 scripts/build-index.py` to refresh.
 | [skill-creator](skill-creator/SKILL.md) | Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends Claude's capabil |
 | [writing-skills](writing-skills/SKILL.md) | Use when creating new skills, editing existing skills, or verifying skills work before deployment |
 
-## Ops (5)
+## Ops (6)
 
 | Skill | Description |
 |-------|-------------|
 | [pmstudio-arb](arb-review/SKILL.md) | Generate an Architecture Review Board (ARB) presentation in Coco Inc's standard 11-slide format. Use when someone asks to "create an ARB deck", "architecture re |
 | [pmstudio-dr](dr-plan/SKILL.md) | Generate a Disaster Recovery plan with RTO/RPO targets. Use when someone asks to "create a DR plan", "disaster recovery", "business continuity", or "RTO RPO". D |
 | [pmstudio-irp](irp/SKILL.md) | Generate an Incident Response Plan (IRP) with severity classification, escalation procedures, and communication templates. Use when someone asks to "create an i |
+| [local-llm](local-llm/SKILL.md) | Use when working with this machine's local LLM setup (LM Studio + mlx-dspark) -- checking status, changing context window, diagnosing a reasoning hang or dead r |
 | [pmstudio-nfr](nfr-tracker/SKILL.md) | Detailed completeness audit of all project documents. Use when someone asks "are we ready for production", "audit our docs", "readiness check", "nfr tracker", o |
 | [pmstudio-recovery](recovery-plan/SKILL.md) | Generate detailed service restoration runbooks with step-by-step procedures. Use when someone asks to "create recovery procedures", "restoration runbook", "reco |
 

--- a/skills/local-llm/SKILL.md
+++ b/skills/local-llm/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: local-llm
+description: Use when working with this machine's local LLM setup (LM Studio + mlx-dspark) -- checking status, changing context window, diagnosing a reasoning hang or dead request, understanding RAM/speed tradeoffs, or wiring a new script to the local inference endpoint.
+domain: ops
+---
+
+# Local LLM Setup (LM Studio + mlx-dspark)
+
+## Announce at start
+"I'm using the local-llm skill to work with the local inference setup."
+
+## Architecture
+
+Two local LLM backends exist on this machine, serving the same underlying model
+family (`Qwen3.8-27B`, 4-bit, hybrid attention -- see RAM cheatsheet below):
+
+| Backend | Port | Role | Managed by |
+|---|---|---|---|
+| **LM Studio** | 1234 | Interactive chat UI use only | LM Studio app itself (own TTL-based auto-unload) |
+| **mlx-dspark** | 8090 | Production -- everything `build_local.py` and any script under `systems/superintelligence/*` talks to | `launchd` (`~/Library/LaunchAgents/com.local.mlx-dspark.plist`) |
+
+`build_local.py` (all 6 copies under `systems/superintelligence/{data-analytics,
+finance,gtm,risk-compliance,strategy,trading}/scripts/`) talks **only** to
+mlx-dspark. LM Studio is not in that pipeline's path at all -- it exists purely
+for manual/interactive use. Do not assume both are always loaded; see
+"Idle-unload" below.
+
+Config lives outside the repo (never committed, never touched by git):
+- `~/.config/mlx-dspark/start.sh` -- the server launch command (model, mode,
+  context window, batch size, host/port, API key).
+- `~/.config/mlx-dspark/api_key` -- 0600-perms API key file. `build_local.py`
+  reads `MLX_DSPARK_API_KEY` env var first, falls back to this file.
+- `~/.config/mlx-dspark/idle_watcher.py` -- the idle-unload poller (see below).
+- `~/Library/LaunchAgents/com.local.mlx-dspark.plist` -- the server's LaunchAgent
+  (`RunAtLoad` + `KeepAlive(Crashed)` -- verified to auto-restart on a crash).
+- `~/Library/LaunchAgents/com.local.mlx-dspark-idle-watcher.plist` -- the
+  watcher's own LaunchAgent (same pattern, negligible RAM, just a polling loop).
+
+## The prefill trick (why this matters)
+
+Both LM Studio and mlx-dspark, when hit via `/v1/chat/completions`, silently
+ignore every attempt to suppress reasoning for this model (`reasoning.effort`,
+top-level `reasoning`, camelCase variants, `chat_template_kwargs`, and even a
+persisted per-model load config -- all tried, none worked). The model just
+burns its entire `max_tokens` budget "thinking" and the caller sees total
+silence until a timeout fires. This was the original "thinks then dies after 5
+minutes" bug report.
+
+**Fix:** use the raw `/v1/completions` endpoint (not chat/completions) and
+hand-build a ChatML prompt with the assistant turn's `<think>` block
+**pre-closed and empty**:
+
+```
+<|im_start|>user
+...<|im_end|>
+<|im_start|>assistant
+<think>
+
+</think>
+
+```
+
+Since reasoning is already "closed" in the prompt itself, the model has no
+room left to think and goes straight to the real answer, giving the full
+token budget to the answer instead of unbounded reasoning. This is exactly
+what `_raw_prompt()` in every `build_local.py` does -- see that function's
+docstring for the full investigation trail. Works identically against both
+backends since they share the same jinja chat-template mechanics.
+
+If you're wiring a **new** script to either backend, reuse this pattern --
+don't call `/v1/chat/completions` and hope reasoning-suppression flags work.
+
+## Idle-unload (don't keep the model hot-loaded when nothing is working)
+
+Neither backend should sit fully loaded in RAM 24/7 if nothing is using it.
+
+- **LM Studio**: has its own TTL (currently 60m/1h) that auto-unloads an idle
+  model loaded via the chat UI. No extra config needed -- just don't rely on
+  it staying loaded indefinitely.
+- **mlx-dspark**: `idle_watcher.py` polls `/metrics`'s `requests` counter every
+  60s; if it hasn't changed for 15 minutes (env var `DSPARK_IDLE_TIMEOUT_SEC`,
+  default 900) **and** `/health` shows a model loaded, it calls
+  `POST /admin/unload`. This frees the full target+drafter footprint (~20GB).
+
+**What happens to a request that lands while unloaded:** `build_local.py`'s
+`llm()` catches the resulting `HTTP 503` (`"no model is loaded"`), calls
+`POST /admin/load` once (re-supplying only `model`+`mode` -- `context_window`
+is **sticky across loads** server-side, no need to resend it), and retries the
+request once. This is invisible to callers except for one cold-load delay.
+Measured empirically on this machine (weights warm in OS page cache): a
+reload-and-retry completed in ~7s total. A truly cold boot (fresh page cache,
+e.g. right after a machine restart) would be slower -- budget more like
+20-40s the first time until you've measured it fresh.
+
+If you're calling mlx-dspark from something that ISN'T `build_local.py`
+(a one-off script, a curl command, etc.), you don't get this retry for free --
+either reuse `_dspark_request`/`_dspark_load` from `build_local.py`, or catch
+503 yourself and POST `/admin/load` before retrying.
+
+## RAM cheatsheet
+
+The loaded model (`mlx-community/Qwen3.8-27B-4bit`, HF architecture
+`Qwen3_5ForConditionalGeneration`) is a **hybrid attention** model: only 16 of
+64 layers use full (quadratic-KV-cost) attention; the other 48 use linear
+attention with ~constant memory cost. That makes its KV cache scale far
+better with context length than a plain transformer, and is why 64k context is
+cheap here when it wouldn't be on an all-full-attention model of this size.
+`max_position_embeddings: 262144`, so 64k (and even 128k) are both well within
+the model's trained range, not extrapolation.
+
+| Context window | KV cache / request | x4 concurrent (`--max-batch 4`) |
+|---|---|---|
+| 32,768 | 2.0 GB | 8 GB |
+| **65,536 (current default)** | **4.0 GB** | **16 GB** |
+| 131,072 (128k, considered, not adopted) | 8.0 GB | 32 GB |
+
+Base model weights: ~16GB (target) + ~4GB (drafter, `dflash` mode) = ~20GB,
+before any KV cache. Add LM Studio's own separate ~16GB if it's also loaded
+(chat UI use) -- this is exactly why idle-unload matters: without it, both
+backends can be loaded simultaneously and there's no config-time guard against
+that (each one only knows about its own footprint).
+
+## Speed cheatsheet
+
+LLM autoregressive decoding is **memory-bandwidth-bound**, not compute-bound:
+each output token requires reading the entire model's weights once. The
+theoretical per-token ceiling for single-stream (batch=1) decoding is:
+
+```
+tokens/sec ceiling = GPU memory bandwidth / model size in bytes
+```
+
+On this machine (Apple M4 Max, 40-core GPU, 546 GB/s) with this model
+(~16.08GB at 4-bit): `546 / 16.08 ~= 34 tok/s` ceiling.
+
+Measured against that ceiling:
+- LM Studio: 25-27.5 tok/s (74-81% of ceiling -- well-optimized).
+- mlx-dspark baseline (non-speculative): 15.2-19 tok/s (45-56% -- less
+  optimized kernels than LM Studio's llama.cpp-derived backend).
+- mlx-dspark `dflash` (speculative decoding): 20-35.9 tok/s (59-106% --
+  *can exceed* the naive per-token ceiling, because speculative decoding
+  amortizes one expensive full-weight read over `accept_len` ~2.7 accepted
+  tokens per verification round instead of one token per read).
+
+**Untapped levers, if more speed is ever needed** (ranked by expected impact):
+1. **`kv_bits` (KV-cache quantization)** -- currently `0`/unused. Helps most at
+   long context, since it shrinks the growing KV cache instead of the fixed
+   model weights. Directly relevant now that context is 64k.
+2. **`--lookup-drafts`** -- currently `false`. A cheap draft-generation mode
+   worth trying if `dflash`'s drafter model ever becomes a bottleneck.
+3. Lower weight quantization below 4-bit -- diminishing returns, not
+   recommended without re-benchmarking accuracy.
+4. **`--max-batch`** -- already at 4, matching `build_local.py`'s worker pool;
+   this raises aggregate throughput across concurrent requests, not
+   single-request speed.
+5. Hardware upgrade (M4 Ultra ~= 2x memory bandwidth) -- out of scope, just
+   noted for completeness.
+
+## Troubleshooting playbook
+
+**Symptom: request hangs / "thinks" forever, dies after a client timeout.**
+- Confirm the request is going through the prefill trick (raw
+  `/v1/completions` with a pre-closed `<think>` block), not
+  `/v1/chat/completions`. Chat/completions ignores every reasoning-suppression
+  flag for this model on both backends.
+
+**Symptom: build_local.py raises "no content after 90s".**
+- `REASONING_TIMEOUT` safety-net fired -- the prefill trick didn't suppress
+  reasoning for some reason (unusual). Check the server is actually serving
+  the expected model (`/health`'s `model` field) and that the request really
+  used the raw-completions + pre-closed-think shape.
+
+**Symptom: YAML/formatting slip in the model's own output.**
+- This is a stochastic LLM output issue, not a pipeline bug. The existing
+  validator (`validate_persona.py`, `pick_parseable`) is designed to catch
+  this -- retry the same command; it usually self-resolves and the
+  verify-gate will flag it rather than silently writing bad output if it
+  doesn't.
+
+**Symptom: request against mlx-dspark returns 503.**
+- Expected if idle-unload just fired. `build_local.py`'s `llm()` already
+  retries automatically once. If calling the endpoint directly (curl, a
+  one-off script), POST `/admin/load` with `{"model": "mlx-community/
+  Qwen3.8-27B-4bit", "mode": "auto"}` first.
+
+**Symptom: context length errors / truncated output on long prompts.**
+- Check `/health`'s `context_window` field matches what you expect (currently
+  65536). If you need to raise it, see "Changing the context window" below --
+  don't just increase `max_tokens` in the request, that's the output budget,
+  not the context window.
+
+**Symptom: server not responding at all.**
+- `launchctl list | grep dspark` -- confirm both
+  `com.local.mlx-dspark` and `com.local.mlx-dspark-idle-watcher` are listed.
+  `KeepAlive(Crashed)` means a crashed server process auto-restarts within
+  seconds; if it's genuinely down, `launchctl kickstart -k
+  gui/$(id -u)/com.local.mlx-dspark`.
+
+## Changing the context window
+
+1. Edit `~/.config/mlx-dspark/start.sh`: change the `--context-window <n>`
+   flag value.
+2. Find and kill the running server process (`ps aux | grep mlx_dspark`) --
+   `launchd`'s `KeepAlive` will restart it immediately with the new flags.
+3. Poll `curl -s http://127.0.0.1:8090/health` until `status` is `"ok"` and
+   confirm `context_window` matches the new value.
+4. Recompute the RAM cheatsheet table above for the new value before deciding
+   to go higher -- KV cache scales linearly with context and multiplies by
+   `--max-batch`.
+
+## Forward-looking note: `m0`
+
+A **different, not-checked-out branch/worktree** of the `m0` project (this
+system's operational-memory store) reportedly has an LLM-enrich step that also
+talks to LM Studio. This repo's checked-out `systems/m0/` is explicitly
+LLM-free by design (its own README/SPEC state "Python standard library only,
+no network calls... no embedding") -- so there's nothing to reconcile here yet.
+Whoever picks up that other branch should be aware of this skill and the
+mlx-dspark production endpoint before wiring anything new to LM Studio, given
+LM Studio is meant to stay interactive-only per this setup.

--- a/systems/superintelligence/data-analytics/scripts/build_local.py
+++ b/systems/superintelligence/data-analytics/scripts/build_local.py
@@ -13,6 +13,7 @@ Usage:
   (model defaults to qwen/qwen3.6-35b-a3b; must be loaded in LM Studio)
 """
 import argparse, json, re, sys, time, urllib.request, pathlib, yaml
+from concurrent.futures import ThreadPoolExecutor, as_completed
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import retriever
 from validate_persona import validate
@@ -21,7 +22,7 @@ FIN = pathlib.Path(__file__).resolve().parents[1]          # superintelligence/f
 ROSTER = json.loads((FIN / "roster.json").read_text())
 PERSONAS = FIN / "personas"; PERSONAS.mkdir(exist_ok=True)
 RESEARCH = FIN / "research"; RESEARCH.mkdir(exist_ok=True)
-ENDPOINT = "http://127.0.0.1:1234/v1/chat/completions"
+ENDPOINT = "http://127.0.0.1:1234/v1/completions"  # raw prompt endpoint (see llm() below)
 POOL = [p["slug"] for p in ROSTER["personas"]]
 
 FM = """slug, real_name, archetype (one line), teams (list), home_team, cell, cell_role, status (active|archetype), affiliations_2026 (list; single-quote values with a colon), domains (list), signature_moves (list), canonical_works (list), key_publications (list), recent_signal_12mo (list of {title,date,url}), public_stances (list of {stance,evidence_url}), mental_models (list), pairs_well_with (list of slugs), productive_conflict_with (list of slugs), blind_spots (list), voice_style (text), when_to_summon (list), confidence, last_verified, sources (list of URLs)"""
@@ -38,12 +39,42 @@ def sys_prompt(pool):
             "CRITICAL YAML FORMAT: use BLOCK style for every list. For lists of objects (recent_signal_12mo, public_stances) put each item on its own line as `  - title: ...` then indented `    date: ...` / `    url: ...` / `    stance: ...` / `    evidence_url: ...`. NEVER use inline flow style [{...}, {...}]. Single-quote any scalar value that contains a colon, comma, or quote. "
             f"pairs_well_with / productive_conflict_with: choose ONLY from this slug list (omit if none fit): {pool}")
 
+REASONING_TIMEOUT = 90  # safety-net: abort if literally nothing streams back for this long
+
+def _raw_prompt(messages):
+    # ChatML prompt with the assistant turn's <think> block pre-closed and EMPTY.
+    # This is the "prefill trick": since reasoning is already closed, the model has
+    # no room left to think and must go straight to the answer. Verified empirically
+    # that LM Studio does not honor reasoning_effort/enable_thinking for this model
+    # via /v1/chat/completions (tried top-level, camelCase, chat_template_kwargs, and
+    # baked into the server's persisted per-model load config — none suppressed
+    # reasoning). Using the raw /v1/completions endpoint with a forced-empty <think>
+    # block bypasses that gap entirely and gives the full max_tokens budget to the
+    # real answer instead of burning it on unbounded reasoning.
+    parts=[f"<|im_start|>{m['role']}\n{m['content']}<|im_end|>\n" for m in messages]
+    parts.append("<|im_start|>assistant\n<think>\n\n</think>\n\n")
+    return "".join(parts)
+
 def llm(model, messages, max_tokens=11000, temp=0.4):
-    payload={"model":model,"messages":messages,"temperature":temp,"max_tokens":max_tokens,"stream":False}
+    prompt=_raw_prompt(messages)
+    payload={"model":model,"prompt":prompt,"temperature":temp,"max_tokens":max_tokens,"stream":True,"stop":["<|im_end|>"]}
     req=urllib.request.Request(ENDPOINT,data=json.dumps(payload).encode(),headers={"Content-Type":"application/json"})
     t0=time.time()
-    with urllib.request.urlopen(req,timeout=900) as r: d=json.loads(r.read())
-    return d["choices"][0]["message"]["content"], time.time()-t0
+    text_parts=[]
+    with urllib.request.urlopen(req,timeout=900) as r:
+        for line in r:
+            if not line.startswith(b"data: "): continue
+            chunk=line[6:].strip()
+            if chunk==b"[DONE]": break
+            try: d=json.loads(chunk)
+            except Exception: continue
+            t=d["choices"][0].get("text","")
+            if t: text_parts.append(t)
+            if not text_parts and (time.time()-t0) > REASONING_TIMEOUT:
+                raise RuntimeError(f"no content after {REASONING_TIMEOUT}s — aborting (prefill trick may not have suppressed reasoning)")
+    if not text_parts:
+        raise RuntimeError("LLM returned no answer content (empty response)")
+    return "".join(text_parts), time.time()-t0
 
 def clean(t):
     t=re.sub(r"<think>.*?</think>","",t,flags=re.S).strip()
@@ -109,13 +140,18 @@ def main():
         todo=[p for p in todo if not (PERSONAS/f"{p['slug']}.md").exists()]  # resume: skip built
     print(f"building {len(todo)} persona(s) with {a.model}")
     npass=0
-    for i,p in enumerate(todo,1):
-        try:
-            v,reasons,ok,n,dt=build_one(p,a.model)
-        except Exception as e:
-            print(f"[{i}/{len(todo)}] {p['slug']:24} ERROR {type(e).__name__}: {str(e)[:80]}"); continue
-        npass += v=="PASS"
-        print(f"[{i}/{len(todo)}] {p['slug']:24} {v:11} urls {ok}/{n} {dt:.0f}s  {('; '.join(reasons))[:90]}")
+    # 4 concurrent workers, matching LM Studio's configured `parallel: 4` slots
+    # (measured ~1.71x aggregate throughput vs sequential on this server).
+    with ThreadPoolExecutor(max_workers=4) as ex:
+        futs={ex.submit(build_one,p,a.model):p for p in todo}
+        for i,fut in enumerate(as_completed(futs),1):
+            p=futs[fut]
+            try:
+                v,reasons,ok,n,dt=fut.result()
+            except Exception as e:
+                print(f"[{i}/{len(todo)}] {p['slug']:24} ERROR {type(e).__name__}: {str(e)[:80]}"); continue
+            npass += v=="PASS"
+            print(f"[{i}/{len(todo)}] {p['slug']:24} {v:11} urls {ok}/{n} {dt:.0f}s  {('; '.join(reasons))[:90]}")
     print(f"\nDONE: {npass}/{len(todo)} PASS")
 
 if __name__=="__main__":

--- a/systems/superintelligence/data-analytics/scripts/build_local.py
+++ b/systems/superintelligence/data-analytics/scripts/build_local.py
@@ -4,15 +4,16 @@ Production local-first persona builder for the Finance SIT (and reusable for any
 Pipeline per persona:  retrieve (deep, free) -> draft (local) -> repair/cite pass (local)
   -> write personas/<slug>.md + research/<slug>/notes.md -> validate -> verdict.
 
-All generation is local (LM Studio) => ~$0. Validator enforces the verify-gate.
+All generation is local (mlx-dspark speculative-decoding server) => ~$0. Validator enforces the verify-gate.
 
 Usage:
   python3 build_local.py --all
   python3 build_local.py --only aswath-damodaran
   python3 build_local.py --cell macro-economics
-  (model defaults to qwen/qwen3.6-35b-a3b; must be loaded in LM Studio)
+  (model defaults to qwen/qwen3.6-35b-a3b; must be served by the mlx-dspark launchd service --
+   see ~/.config/mlx-dspark/start.sh, or export MLX_DSPARK_API_KEY to override the key source)
 """
-import argparse, json, re, sys, time, urllib.request, pathlib, yaml
+import argparse, json, os, re, sys, time, urllib.request, pathlib, yaml
 from concurrent.futures import ThreadPoolExecutor, as_completed
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import retriever
@@ -22,7 +23,7 @@ FIN = pathlib.Path(__file__).resolve().parents[1]          # superintelligence/f
 ROSTER = json.loads((FIN / "roster.json").read_text())
 PERSONAS = FIN / "personas"; PERSONAS.mkdir(exist_ok=True)
 RESEARCH = FIN / "research"; RESEARCH.mkdir(exist_ok=True)
-ENDPOINT = "http://127.0.0.1:1234/v1/completions"  # raw prompt endpoint (see llm() below)
+ENDPOINT = "http://127.0.0.1:8090/v1/completions"  # mlx-dspark server, raw prompt endpoint (see llm() below)
 POOL = [p["slug"] for p in ROSTER["personas"]]
 
 FM = """slug, real_name, archetype (one line), teams (list), home_team, cell, cell_role, status (active|archetype), affiliations_2026 (list; single-quote values with a colon), domains (list), signature_moves (list), canonical_works (list), key_publications (list), recent_signal_12mo (list of {title,date,url}), public_stances (list of {stance,evidence_url}), mental_models (list), pairs_well_with (list of slugs), productive_conflict_with (list of slugs), blind_spots (list), voice_style (text), when_to_summon (list), confidence, last_verified, sources (list of URLs)"""
@@ -45,20 +46,37 @@ def _raw_prompt(messages):
     # ChatML prompt with the assistant turn's <think> block pre-closed and EMPTY.
     # This is the "prefill trick": since reasoning is already closed, the model has
     # no room left to think and must go straight to the answer. Verified empirically
-    # that LM Studio does not honor reasoning_effort/enable_thinking for this model
-    # via /v1/chat/completions (tried top-level, camelCase, chat_template_kwargs, and
-    # baked into the server's persisted per-model load config — none suppressed
-    # reasoning). Using the raw /v1/completions endpoint with a forced-empty <think>
-    # block bypasses that gap entirely and gives the full max_tokens budget to the
-    # real answer instead of burning it on unbounded reasoning.
+    # that LM Studio and mlx-dspark both do not honor reasoning_effort/enable_thinking
+    # for this model via /v1/chat/completions (tried top-level, camelCase,
+    # chat_template_kwargs, and baked into persisted per-model load config -- none
+    # suppressed reasoning). Using the raw /v1/completions endpoint with a
+    # forced-empty <think> block bypasses that gap entirely and gives the full
+    # max_tokens budget to the real answer instead of burning it on unbounded
+    # reasoning. Same trick works against mlx-dspark since it uses the identical
+    # jinja chat-template mechanics.
     parts=[f"<|im_start|>{m['role']}\n{m['content']}<|im_end|>\n" for m in messages]
     parts.append("<|im_start|>assistant\n<think>\n\n</think>\n\n")
     return "".join(parts)
 
+def _dspark_api_key():
+    # Never hardcode the key. Prefer the env var; fall back to the local,
+    # non-repo key file the launchd service also reads (0600 perms, outside git).
+    key = os.environ.get("MLX_DSPARK_API_KEY")
+    if key:
+        return key.strip()
+    key_file = pathlib.Path.home() / ".config" / "mlx-dspark" / "api_key"
+    if key_file.exists():
+        return key_file.read_text().strip()
+    raise RuntimeError(
+        "mlx-dspark API key not found -- set MLX_DSPARK_API_KEY or ensure "
+        f"{key_file} exists (see ~/.config/mlx-dspark/start.sh)"
+    )
+
 def llm(model, messages, max_tokens=11000, temp=0.4):
     prompt=_raw_prompt(messages)
     payload={"model":model,"prompt":prompt,"temperature":temp,"max_tokens":max_tokens,"stream":True,"stop":["<|im_end|>"]}
-    req=urllib.request.Request(ENDPOINT,data=json.dumps(payload).encode(),headers={"Content-Type":"application/json"})
+    headers={"Content-Type":"application/json","Authorization":f"Bearer {_dspark_api_key()}"}
+    req=urllib.request.Request(ENDPOINT,data=json.dumps(payload).encode(),headers=headers)
     t0=time.time()
     text_parts=[]
     with urllib.request.urlopen(req,timeout=900) as r:
@@ -118,7 +136,7 @@ def build_one(p, model):
     fixed = pick_parseable(fixed, draft)
     (PERSONAS/f"{slug}.md").write_text(fixed+"\n",encoding="utf-8")
     rd=RESEARCH/slug; rd.mkdir(exist_ok=True)
-    dump=["# Research dump (auto, local pipeline)\n", f"name: {name}", f"generated_local: qwen via LM Studio\n", "## Fetched pages"]
+    dump=["# Research dump (auto, local pipeline)\n", f"name: {name}", f"generated_local: qwen via mlx-dspark\n", "## Fetched pages"]
     for u,txt in pages: dump.append(f"\n### {u}\n{txt}")
     dump.append("\n## Dated news")
     for n in news: dump.append(f"- {n['date']} :: {n['title']} :: {n['url']}")
@@ -140,7 +158,7 @@ def main():
         todo=[p for p in todo if not (PERSONAS/f"{p['slug']}.md").exists()]  # resume: skip built
     print(f"building {len(todo)} persona(s) with {a.model}")
     npass=0
-    # 4 concurrent workers, matching LM Studio's configured `parallel: 4` slots
+    # 4 concurrent workers, matching the mlx-dspark server's `--max-batch 4` config
     # (measured ~1.71x aggregate throughput vs sequential on this server).
     with ThreadPoolExecutor(max_workers=4) as ex:
         futs={ex.submit(build_one,p,a.model):p for p in todo}

--- a/systems/superintelligence/data-analytics/scripts/build_local.py
+++ b/systems/superintelligence/data-analytics/scripts/build_local.py
@@ -13,7 +13,7 @@ Usage:
   (model defaults to qwen/qwen3.6-35b-a3b; must be served by the mlx-dspark launchd service --
    see ~/.config/mlx-dspark/start.sh, or export MLX_DSPARK_API_KEY to override the key source)
 """
-import argparse, json, os, re, sys, time, urllib.request, pathlib, yaml
+import argparse, json, os, re, sys, time, urllib.request, urllib.error, pathlib, yaml
 from concurrent.futures import ThreadPoolExecutor, as_completed
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import retriever
@@ -24,6 +24,7 @@ ROSTER = json.loads((FIN / "roster.json").read_text())
 PERSONAS = FIN / "personas"; PERSONAS.mkdir(exist_ok=True)
 RESEARCH = FIN / "research"; RESEARCH.mkdir(exist_ok=True)
 ENDPOINT = "http://127.0.0.1:8090/v1/completions"  # mlx-dspark server, raw prompt endpoint (see llm() below)
+ADMIN_LOAD_ENDPOINT = "http://127.0.0.1:8090/admin/load"  # used to reload the model after an idle-unload (see llm() 503 handling)
 POOL = [p["slug"] for p in ROSTER["personas"]]
 
 FM = """slug, real_name, archetype (one line), teams (list), home_team, cell, cell_role, status (active|archetype), affiliations_2026 (list; single-quote values with a colon), domains (list), signature_moves (list), canonical_works (list), key_publications (list), recent_signal_12mo (list of {title,date,url}), public_stances (list of {stance,evidence_url}), mental_models (list), pairs_well_with (list of slugs), productive_conflict_with (list of slugs), blind_spots (list), voice_style (text), when_to_summon (list), confidence, last_verified, sources (list of URLs)"""
@@ -72,14 +73,40 @@ def _dspark_api_key():
         f"{key_file} exists (see ~/.config/mlx-dspark/start.sh)"
     )
 
+def _dspark_headers():
+    # Build the auth header at call time from the key helper above -- never
+    # store or format the header value as a literal anywhere in this file.
+    auth_value = f"Bearer {_dspark_api_key()}"
+    return {"Content-Type": "application/json", "Authorization": auth_value}
+
+def _dspark_load(model):
+    # Reload the model after an idle-unload (mlx-dspark's idle_watcher.py may
+    # have called /admin/unload after 15min of no traffic). context_window is
+    # sticky across loads server-side, so it does not need to be resent here.
+    # /admin/load blocks until the swap finishes -- no polling loop needed.
+    payload = json.dumps({"model": model, "mode": "auto"}).encode()
+    req = urllib.request.Request(ADMIN_LOAD_ENDPOINT, data=payload, headers=_dspark_headers(), method="POST")
+    with urllib.request.urlopen(req, timeout=120) as r:
+        return json.loads(r.read().decode())
+
+def _dspark_request(payload):
+    req = urllib.request.Request(ENDPOINT, data=json.dumps(payload).encode(), headers=_dspark_headers())
+    return urllib.request.urlopen(req, timeout=900)
+
 def llm(model, messages, max_tokens=11000, temp=0.4):
     prompt=_raw_prompt(messages)
     payload={"model":model,"prompt":prompt,"temperature":temp,"max_tokens":max_tokens,"stream":True,"stop":["<|im_end|>"]}
-    headers={"Content-Type":"application/json","Authorization":f"Bearer {_dspark_api_key()}"}
-    req=urllib.request.Request(ENDPOINT,data=json.dumps(payload).encode(),headers=headers)
     t0=time.time()
     text_parts=[]
-    with urllib.request.urlopen(req,timeout=900) as r:
+    try:
+        response = _dspark_request(payload)
+    except urllib.error.HTTPError as e:
+        if e.code != 503:
+            raise
+        # Model was idle-unloaded -- reload once and retry the request once.
+        _dspark_load(model)
+        response = _dspark_request(payload)
+    with response as r:
         for line in r:
             if not line.startswith(b"data: "): continue
             chunk=line[6:].strip()

--- a/systems/superintelligence/finance/scripts/build_local.py
+++ b/systems/superintelligence/finance/scripts/build_local.py
@@ -13,6 +13,7 @@ Usage:
   (model defaults to qwen/qwen3.6-35b-a3b; must be loaded in LM Studio)
 """
 import argparse, json, re, sys, time, urllib.request, pathlib, yaml
+from concurrent.futures import ThreadPoolExecutor, as_completed
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import retriever
 from validate_persona import validate
@@ -21,7 +22,7 @@ FIN = pathlib.Path(__file__).resolve().parents[1]          # superintelligence/f
 ROSTER = json.loads((FIN / "roster.json").read_text())
 PERSONAS = FIN / "personas"; PERSONAS.mkdir(exist_ok=True)
 RESEARCH = FIN / "research"; RESEARCH.mkdir(exist_ok=True)
-ENDPOINT = "http://127.0.0.1:1234/v1/chat/completions"
+ENDPOINT = "http://127.0.0.1:1234/v1/completions"  # raw prompt endpoint (see llm() below)
 POOL = [p["slug"] for p in ROSTER["personas"]]
 
 FM = """slug, real_name, archetype (one line), teams (list), home_team, cell, cell_role, status (active|archetype), affiliations_2026 (list; single-quote values with a colon), domains (list), signature_moves (list), canonical_works (list), key_publications (list), recent_signal_12mo (list of {title,date,url}), public_stances (list of {stance,evidence_url}), mental_models (list), pairs_well_with (list of slugs), productive_conflict_with (list of slugs), blind_spots (list), voice_style (text), when_to_summon (list), confidence, last_verified, sources (list of URLs)"""
@@ -38,12 +39,42 @@ def sys_prompt(pool):
             "CRITICAL YAML FORMAT: use BLOCK style for every list. For lists of objects (recent_signal_12mo, public_stances) put each item on its own line as `  - title: ...` then indented `    date: ...` / `    url: ...` / `    stance: ...` / `    evidence_url: ...`. NEVER use inline flow style [{...}, {...}]. Single-quote any scalar value that contains a colon, comma, or quote. "
             f"pairs_well_with / productive_conflict_with: choose ONLY from this slug list (omit if none fit): {pool}")
 
+REASONING_TIMEOUT = 90  # safety-net: abort if literally nothing streams back for this long
+
+def _raw_prompt(messages):
+    # ChatML prompt with the assistant turn's <think> block pre-closed and EMPTY.
+    # This is the "prefill trick": since reasoning is already closed, the model has
+    # no room left to think and must go straight to the answer. Verified empirically
+    # that LM Studio does not honor reasoning_effort/enable_thinking for this model
+    # via /v1/chat/completions (tried top-level, camelCase, chat_template_kwargs, and
+    # baked into the server's persisted per-model load config — none suppressed
+    # reasoning). Using the raw /v1/completions endpoint with a forced-empty <think>
+    # block bypasses that gap entirely and gives the full max_tokens budget to the
+    # real answer instead of burning it on unbounded reasoning.
+    parts=[f"<|im_start|>{m['role']}\n{m['content']}<|im_end|>\n" for m in messages]
+    parts.append("<|im_start|>assistant\n<think>\n\n</think>\n\n")
+    return "".join(parts)
+
 def llm(model, messages, max_tokens=11000, temp=0.4):
-    payload={"model":model,"messages":messages,"temperature":temp,"max_tokens":max_tokens,"stream":False}
+    prompt=_raw_prompt(messages)
+    payload={"model":model,"prompt":prompt,"temperature":temp,"max_tokens":max_tokens,"stream":True,"stop":["<|im_end|>"]}
     req=urllib.request.Request(ENDPOINT,data=json.dumps(payload).encode(),headers={"Content-Type":"application/json"})
     t0=time.time()
-    with urllib.request.urlopen(req,timeout=900) as r: d=json.loads(r.read())
-    return d["choices"][0]["message"]["content"], time.time()-t0
+    text_parts=[]
+    with urllib.request.urlopen(req,timeout=900) as r:
+        for line in r:
+            if not line.startswith(b"data: "): continue
+            chunk=line[6:].strip()
+            if chunk==b"[DONE]": break
+            try: d=json.loads(chunk)
+            except Exception: continue
+            t=d["choices"][0].get("text","")
+            if t: text_parts.append(t)
+            if not text_parts and (time.time()-t0) > REASONING_TIMEOUT:
+                raise RuntimeError(f"no content after {REASONING_TIMEOUT}s — aborting (prefill trick may not have suppressed reasoning)")
+    if not text_parts:
+        raise RuntimeError("LLM returned no answer content (empty response)")
+    return "".join(text_parts), time.time()-t0
 
 def clean(t):
     t=re.sub(r"<think>.*?</think>","",t,flags=re.S).strip()
@@ -109,13 +140,18 @@ def main():
         todo=[p for p in todo if not (PERSONAS/f"{p['slug']}.md").exists()]  # resume: skip built
     print(f"building {len(todo)} persona(s) with {a.model}")
     npass=0
-    for i,p in enumerate(todo,1):
-        try:
-            v,reasons,ok,n,dt=build_one(p,a.model)
-        except Exception as e:
-            print(f"[{i}/{len(todo)}] {p['slug']:24} ERROR {type(e).__name__}: {str(e)[:80]}"); continue
-        npass += v=="PASS"
-        print(f"[{i}/{len(todo)}] {p['slug']:24} {v:11} urls {ok}/{n} {dt:.0f}s  {('; '.join(reasons))[:90]}")
+    # 4 concurrent workers, matching LM Studio's configured `parallel: 4` slots
+    # (measured ~1.71x aggregate throughput vs sequential on this server).
+    with ThreadPoolExecutor(max_workers=4) as ex:
+        futs={ex.submit(build_one,p,a.model):p for p in todo}
+        for i,fut in enumerate(as_completed(futs),1):
+            p=futs[fut]
+            try:
+                v,reasons,ok,n,dt=fut.result()
+            except Exception as e:
+                print(f"[{i}/{len(todo)}] {p['slug']:24} ERROR {type(e).__name__}: {str(e)[:80]}"); continue
+            npass += v=="PASS"
+            print(f"[{i}/{len(todo)}] {p['slug']:24} {v:11} urls {ok}/{n} {dt:.0f}s  {('; '.join(reasons))[:90]}")
     print(f"\nDONE: {npass}/{len(todo)} PASS")
 
 if __name__=="__main__":

--- a/systems/superintelligence/finance/scripts/build_local.py
+++ b/systems/superintelligence/finance/scripts/build_local.py
@@ -4,15 +4,16 @@ Production local-first persona builder for the Finance SIT (and reusable for any
 Pipeline per persona:  retrieve (deep, free) -> draft (local) -> repair/cite pass (local)
   -> write personas/<slug>.md + research/<slug>/notes.md -> validate -> verdict.
 
-All generation is local (LM Studio) => ~$0. Validator enforces the verify-gate.
+All generation is local (mlx-dspark speculative-decoding server) => ~$0. Validator enforces the verify-gate.
 
 Usage:
   python3 build_local.py --all
   python3 build_local.py --only aswath-damodaran
   python3 build_local.py --cell macro-economics
-  (model defaults to qwen/qwen3.6-35b-a3b; must be loaded in LM Studio)
+  (model defaults to qwen/qwen3.6-35b-a3b; must be served by the mlx-dspark launchd service --
+   see ~/.config/mlx-dspark/start.sh, or export MLX_DSPARK_API_KEY to override the key source)
 """
-import argparse, json, re, sys, time, urllib.request, pathlib, yaml
+import argparse, json, os, re, sys, time, urllib.request, pathlib, yaml
 from concurrent.futures import ThreadPoolExecutor, as_completed
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import retriever
@@ -22,7 +23,7 @@ FIN = pathlib.Path(__file__).resolve().parents[1]          # superintelligence/f
 ROSTER = json.loads((FIN / "roster.json").read_text())
 PERSONAS = FIN / "personas"; PERSONAS.mkdir(exist_ok=True)
 RESEARCH = FIN / "research"; RESEARCH.mkdir(exist_ok=True)
-ENDPOINT = "http://127.0.0.1:1234/v1/completions"  # raw prompt endpoint (see llm() below)
+ENDPOINT = "http://127.0.0.1:8090/v1/completions"  # mlx-dspark server, raw prompt endpoint (see llm() below)
 POOL = [p["slug"] for p in ROSTER["personas"]]
 
 FM = """slug, real_name, archetype (one line), teams (list), home_team, cell, cell_role, status (active|archetype), affiliations_2026 (list; single-quote values with a colon), domains (list), signature_moves (list), canonical_works (list), key_publications (list), recent_signal_12mo (list of {title,date,url}), public_stances (list of {stance,evidence_url}), mental_models (list), pairs_well_with (list of slugs), productive_conflict_with (list of slugs), blind_spots (list), voice_style (text), when_to_summon (list), confidence, last_verified, sources (list of URLs)"""
@@ -45,20 +46,37 @@ def _raw_prompt(messages):
     # ChatML prompt with the assistant turn's <think> block pre-closed and EMPTY.
     # This is the "prefill trick": since reasoning is already closed, the model has
     # no room left to think and must go straight to the answer. Verified empirically
-    # that LM Studio does not honor reasoning_effort/enable_thinking for this model
-    # via /v1/chat/completions (tried top-level, camelCase, chat_template_kwargs, and
-    # baked into the server's persisted per-model load config — none suppressed
-    # reasoning). Using the raw /v1/completions endpoint with a forced-empty <think>
-    # block bypasses that gap entirely and gives the full max_tokens budget to the
-    # real answer instead of burning it on unbounded reasoning.
+    # that LM Studio and mlx-dspark both do not honor reasoning_effort/enable_thinking
+    # for this model via /v1/chat/completions (tried top-level, camelCase,
+    # chat_template_kwargs, and baked into persisted per-model load config -- none
+    # suppressed reasoning). Using the raw /v1/completions endpoint with a
+    # forced-empty <think> block bypasses that gap entirely and gives the full
+    # max_tokens budget to the real answer instead of burning it on unbounded
+    # reasoning. Same trick works against mlx-dspark since it uses the identical
+    # jinja chat-template mechanics.
     parts=[f"<|im_start|>{m['role']}\n{m['content']}<|im_end|>\n" for m in messages]
     parts.append("<|im_start|>assistant\n<think>\n\n</think>\n\n")
     return "".join(parts)
 
+def _dspark_api_key():
+    # Never hardcode the key. Prefer the env var; fall back to the local,
+    # non-repo key file the launchd service also reads (0600 perms, outside git).
+    key = os.environ.get("MLX_DSPARK_API_KEY")
+    if key:
+        return key.strip()
+    key_file = pathlib.Path.home() / ".config" / "mlx-dspark" / "api_key"
+    if key_file.exists():
+        return key_file.read_text().strip()
+    raise RuntimeError(
+        "mlx-dspark API key not found -- set MLX_DSPARK_API_KEY or ensure "
+        f"{key_file} exists (see ~/.config/mlx-dspark/start.sh)"
+    )
+
 def llm(model, messages, max_tokens=11000, temp=0.4):
     prompt=_raw_prompt(messages)
     payload={"model":model,"prompt":prompt,"temperature":temp,"max_tokens":max_tokens,"stream":True,"stop":["<|im_end|>"]}
-    req=urllib.request.Request(ENDPOINT,data=json.dumps(payload).encode(),headers={"Content-Type":"application/json"})
+    headers={"Content-Type":"application/json","Authorization":f"Bearer {_dspark_api_key()}"}
+    req=urllib.request.Request(ENDPOINT,data=json.dumps(payload).encode(),headers=headers)
     t0=time.time()
     text_parts=[]
     with urllib.request.urlopen(req,timeout=900) as r:
@@ -118,7 +136,7 @@ def build_one(p, model):
     fixed = pick_parseable(fixed, draft)
     (PERSONAS/f"{slug}.md").write_text(fixed+"\n",encoding="utf-8")
     rd=RESEARCH/slug; rd.mkdir(exist_ok=True)
-    dump=["# Research dump (auto, local pipeline)\n", f"name: {name}", f"generated_local: qwen via LM Studio\n", "## Fetched pages"]
+    dump=["# Research dump (auto, local pipeline)\n", f"name: {name}", f"generated_local: qwen via mlx-dspark\n", "## Fetched pages"]
     for u,txt in pages: dump.append(f"\n### {u}\n{txt}")
     dump.append("\n## Dated news")
     for n in news: dump.append(f"- {n['date']} :: {n['title']} :: {n['url']}")
@@ -140,7 +158,7 @@ def main():
         todo=[p for p in todo if not (PERSONAS/f"{p['slug']}.md").exists()]  # resume: skip built
     print(f"building {len(todo)} persona(s) with {a.model}")
     npass=0
-    # 4 concurrent workers, matching LM Studio's configured `parallel: 4` slots
+    # 4 concurrent workers, matching the mlx-dspark server's `--max-batch 4` config
     # (measured ~1.71x aggregate throughput vs sequential on this server).
     with ThreadPoolExecutor(max_workers=4) as ex:
         futs={ex.submit(build_one,p,a.model):p for p in todo}

--- a/systems/superintelligence/finance/scripts/build_local.py
+++ b/systems/superintelligence/finance/scripts/build_local.py
@@ -13,7 +13,7 @@ Usage:
   (model defaults to qwen/qwen3.6-35b-a3b; must be served by the mlx-dspark launchd service --
    see ~/.config/mlx-dspark/start.sh, or export MLX_DSPARK_API_KEY to override the key source)
 """
-import argparse, json, os, re, sys, time, urllib.request, pathlib, yaml
+import argparse, json, os, re, sys, time, urllib.request, urllib.error, pathlib, yaml
 from concurrent.futures import ThreadPoolExecutor, as_completed
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import retriever
@@ -24,6 +24,7 @@ ROSTER = json.loads((FIN / "roster.json").read_text())
 PERSONAS = FIN / "personas"; PERSONAS.mkdir(exist_ok=True)
 RESEARCH = FIN / "research"; RESEARCH.mkdir(exist_ok=True)
 ENDPOINT = "http://127.0.0.1:8090/v1/completions"  # mlx-dspark server, raw prompt endpoint (see llm() below)
+ADMIN_LOAD_ENDPOINT = "http://127.0.0.1:8090/admin/load"  # used to reload the model after an idle-unload (see llm() 503 handling)
 POOL = [p["slug"] for p in ROSTER["personas"]]
 
 FM = """slug, real_name, archetype (one line), teams (list), home_team, cell, cell_role, status (active|archetype), affiliations_2026 (list; single-quote values with a colon), domains (list), signature_moves (list), canonical_works (list), key_publications (list), recent_signal_12mo (list of {title,date,url}), public_stances (list of {stance,evidence_url}), mental_models (list), pairs_well_with (list of slugs), productive_conflict_with (list of slugs), blind_spots (list), voice_style (text), when_to_summon (list), confidence, last_verified, sources (list of URLs)"""
@@ -72,14 +73,40 @@ def _dspark_api_key():
         f"{key_file} exists (see ~/.config/mlx-dspark/start.sh)"
     )
 
+def _dspark_headers():
+    # Build the auth header at call time from the key helper above -- never
+    # store or format the header value as a literal anywhere in this file.
+    auth_value = f"Bearer {_dspark_api_key()}"
+    return {"Content-Type": "application/json", "Authorization": auth_value}
+
+def _dspark_load(model):
+    # Reload the model after an idle-unload (mlx-dspark's idle_watcher.py may
+    # have called /admin/unload after 15min of no traffic). context_window is
+    # sticky across loads server-side, so it does not need to be resent here.
+    # /admin/load blocks until the swap finishes -- no polling loop needed.
+    payload = json.dumps({"model": model, "mode": "auto"}).encode()
+    req = urllib.request.Request(ADMIN_LOAD_ENDPOINT, data=payload, headers=_dspark_headers(), method="POST")
+    with urllib.request.urlopen(req, timeout=120) as r:
+        return json.loads(r.read().decode())
+
+def _dspark_request(payload):
+    req = urllib.request.Request(ENDPOINT, data=json.dumps(payload).encode(), headers=_dspark_headers())
+    return urllib.request.urlopen(req, timeout=900)
+
 def llm(model, messages, max_tokens=11000, temp=0.4):
     prompt=_raw_prompt(messages)
     payload={"model":model,"prompt":prompt,"temperature":temp,"max_tokens":max_tokens,"stream":True,"stop":["<|im_end|>"]}
-    headers={"Content-Type":"application/json","Authorization":f"Bearer {_dspark_api_key()}"}
-    req=urllib.request.Request(ENDPOINT,data=json.dumps(payload).encode(),headers=headers)
     t0=time.time()
     text_parts=[]
-    with urllib.request.urlopen(req,timeout=900) as r:
+    try:
+        response = _dspark_request(payload)
+    except urllib.error.HTTPError as e:
+        if e.code != 503:
+            raise
+        # Model was idle-unloaded -- reload once and retry the request once.
+        _dspark_load(model)
+        response = _dspark_request(payload)
+    with response as r:
         for line in r:
             if not line.startswith(b"data: "): continue
             chunk=line[6:].strip()

--- a/systems/superintelligence/gtm/scripts/build_local.py
+++ b/systems/superintelligence/gtm/scripts/build_local.py
@@ -13,6 +13,7 @@ Usage:
   (model defaults to qwen/qwen3.6-35b-a3b; must be loaded in LM Studio)
 """
 import argparse, json, re, sys, time, urllib.request, pathlib, yaml
+from concurrent.futures import ThreadPoolExecutor, as_completed
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import retriever
 from validate_persona import validate
@@ -21,7 +22,7 @@ FIN = pathlib.Path(__file__).resolve().parents[1]          # superintelligence/f
 ROSTER = json.loads((FIN / "roster.json").read_text())
 PERSONAS = FIN / "personas"; PERSONAS.mkdir(exist_ok=True)
 RESEARCH = FIN / "research"; RESEARCH.mkdir(exist_ok=True)
-ENDPOINT = "http://127.0.0.1:1234/v1/chat/completions"
+ENDPOINT = "http://127.0.0.1:1234/v1/completions"  # raw prompt endpoint (see llm() below)
 POOL = [p["slug"] for p in ROSTER["personas"]]
 
 FM = """slug, real_name, archetype (one line), teams (list), home_team, cell, cell_role, status (active|archetype), affiliations_2026 (list; single-quote values with a colon), domains (list), signature_moves (list), canonical_works (list), key_publications (list), recent_signal_12mo (list of {title,date,url}), public_stances (list of {stance,evidence_url}), mental_models (list), pairs_well_with (list of slugs), productive_conflict_with (list of slugs), blind_spots (list), voice_style (text), when_to_summon (list), confidence, last_verified, sources (list of URLs)"""
@@ -38,12 +39,42 @@ def sys_prompt(pool):
             "CRITICAL YAML FORMAT: use BLOCK style for every list. For lists of objects (recent_signal_12mo, public_stances) put each item on its own line as `  - title: ...` then indented `    date: ...` / `    url: ...` / `    stance: ...` / `    evidence_url: ...`. NEVER use inline flow style [{...}, {...}]. Single-quote any scalar value that contains a colon, comma, or quote. "
             f"pairs_well_with / productive_conflict_with: choose ONLY from this slug list (omit if none fit): {pool}")
 
+REASONING_TIMEOUT = 90  # safety-net: abort if literally nothing streams back for this long
+
+def _raw_prompt(messages):
+    # ChatML prompt with the assistant turn's <think> block pre-closed and EMPTY.
+    # This is the "prefill trick": since reasoning is already closed, the model has
+    # no room left to think and must go straight to the answer. Verified empirically
+    # that LM Studio does not honor reasoning_effort/enable_thinking for this model
+    # via /v1/chat/completions (tried top-level, camelCase, chat_template_kwargs, and
+    # baked into the server's persisted per-model load config — none suppressed
+    # reasoning). Using the raw /v1/completions endpoint with a forced-empty <think>
+    # block bypasses that gap entirely and gives the full max_tokens budget to the
+    # real answer instead of burning it on unbounded reasoning.
+    parts=[f"<|im_start|>{m['role']}\n{m['content']}<|im_end|>\n" for m in messages]
+    parts.append("<|im_start|>assistant\n<think>\n\n</think>\n\n")
+    return "".join(parts)
+
 def llm(model, messages, max_tokens=11000, temp=0.4):
-    payload={"model":model,"messages":messages,"temperature":temp,"max_tokens":max_tokens,"stream":False}
+    prompt=_raw_prompt(messages)
+    payload={"model":model,"prompt":prompt,"temperature":temp,"max_tokens":max_tokens,"stream":True,"stop":["<|im_end|>"]}
     req=urllib.request.Request(ENDPOINT,data=json.dumps(payload).encode(),headers={"Content-Type":"application/json"})
     t0=time.time()
-    with urllib.request.urlopen(req,timeout=900) as r: d=json.loads(r.read())
-    return d["choices"][0]["message"]["content"], time.time()-t0
+    text_parts=[]
+    with urllib.request.urlopen(req,timeout=900) as r:
+        for line in r:
+            if not line.startswith(b"data: "): continue
+            chunk=line[6:].strip()
+            if chunk==b"[DONE]": break
+            try: d=json.loads(chunk)
+            except Exception: continue
+            t=d["choices"][0].get("text","")
+            if t: text_parts.append(t)
+            if not text_parts and (time.time()-t0) > REASONING_TIMEOUT:
+                raise RuntimeError(f"no content after {REASONING_TIMEOUT}s — aborting (prefill trick may not have suppressed reasoning)")
+    if not text_parts:
+        raise RuntimeError("LLM returned no answer content (empty response)")
+    return "".join(text_parts), time.time()-t0
 
 def clean(t):
     t=re.sub(r"<think>.*?</think>","",t,flags=re.S).strip()
@@ -109,13 +140,18 @@ def main():
         todo=[p for p in todo if not (PERSONAS/f"{p['slug']}.md").exists()]  # resume: skip built
     print(f"building {len(todo)} persona(s) with {a.model}")
     npass=0
-    for i,p in enumerate(todo,1):
-        try:
-            v,reasons,ok,n,dt=build_one(p,a.model)
-        except Exception as e:
-            print(f"[{i}/{len(todo)}] {p['slug']:24} ERROR {type(e).__name__}: {str(e)[:80]}"); continue
-        npass += v=="PASS"
-        print(f"[{i}/{len(todo)}] {p['slug']:24} {v:11} urls {ok}/{n} {dt:.0f}s  {('; '.join(reasons))[:90]}")
+    # 4 concurrent workers, matching LM Studio's configured `parallel: 4` slots
+    # (measured ~1.71x aggregate throughput vs sequential on this server).
+    with ThreadPoolExecutor(max_workers=4) as ex:
+        futs={ex.submit(build_one,p,a.model):p for p in todo}
+        for i,fut in enumerate(as_completed(futs),1):
+            p=futs[fut]
+            try:
+                v,reasons,ok,n,dt=fut.result()
+            except Exception as e:
+                print(f"[{i}/{len(todo)}] {p['slug']:24} ERROR {type(e).__name__}: {str(e)[:80]}"); continue
+            npass += v=="PASS"
+            print(f"[{i}/{len(todo)}] {p['slug']:24} {v:11} urls {ok}/{n} {dt:.0f}s  {('; '.join(reasons))[:90]}")
     print(f"\nDONE: {npass}/{len(todo)} PASS")
 
 if __name__=="__main__":

--- a/systems/superintelligence/gtm/scripts/build_local.py
+++ b/systems/superintelligence/gtm/scripts/build_local.py
@@ -4,15 +4,16 @@ Production local-first persona builder for the Finance SIT (and reusable for any
 Pipeline per persona:  retrieve (deep, free) -> draft (local) -> repair/cite pass (local)
   -> write personas/<slug>.md + research/<slug>/notes.md -> validate -> verdict.
 
-All generation is local (LM Studio) => ~$0. Validator enforces the verify-gate.
+All generation is local (mlx-dspark speculative-decoding server) => ~$0. Validator enforces the verify-gate.
 
 Usage:
   python3 build_local.py --all
   python3 build_local.py --only aswath-damodaran
   python3 build_local.py --cell macro-economics
-  (model defaults to qwen/qwen3.6-35b-a3b; must be loaded in LM Studio)
+  (model defaults to qwen/qwen3.6-35b-a3b; must be served by the mlx-dspark launchd service --
+   see ~/.config/mlx-dspark/start.sh, or export MLX_DSPARK_API_KEY to override the key source)
 """
-import argparse, json, re, sys, time, urllib.request, pathlib, yaml
+import argparse, json, os, re, sys, time, urllib.request, pathlib, yaml
 from concurrent.futures import ThreadPoolExecutor, as_completed
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import retriever
@@ -22,7 +23,7 @@ FIN = pathlib.Path(__file__).resolve().parents[1]          # superintelligence/f
 ROSTER = json.loads((FIN / "roster.json").read_text())
 PERSONAS = FIN / "personas"; PERSONAS.mkdir(exist_ok=True)
 RESEARCH = FIN / "research"; RESEARCH.mkdir(exist_ok=True)
-ENDPOINT = "http://127.0.0.1:1234/v1/completions"  # raw prompt endpoint (see llm() below)
+ENDPOINT = "http://127.0.0.1:8090/v1/completions"  # mlx-dspark server, raw prompt endpoint (see llm() below)
 POOL = [p["slug"] for p in ROSTER["personas"]]
 
 FM = """slug, real_name, archetype (one line), teams (list), home_team, cell, cell_role, status (active|archetype), affiliations_2026 (list; single-quote values with a colon), domains (list), signature_moves (list), canonical_works (list), key_publications (list), recent_signal_12mo (list of {title,date,url}), public_stances (list of {stance,evidence_url}), mental_models (list), pairs_well_with (list of slugs), productive_conflict_with (list of slugs), blind_spots (list), voice_style (text), when_to_summon (list), confidence, last_verified, sources (list of URLs)"""
@@ -45,20 +46,37 @@ def _raw_prompt(messages):
     # ChatML prompt with the assistant turn's <think> block pre-closed and EMPTY.
     # This is the "prefill trick": since reasoning is already closed, the model has
     # no room left to think and must go straight to the answer. Verified empirically
-    # that LM Studio does not honor reasoning_effort/enable_thinking for this model
-    # via /v1/chat/completions (tried top-level, camelCase, chat_template_kwargs, and
-    # baked into the server's persisted per-model load config — none suppressed
-    # reasoning). Using the raw /v1/completions endpoint with a forced-empty <think>
-    # block bypasses that gap entirely and gives the full max_tokens budget to the
-    # real answer instead of burning it on unbounded reasoning.
+    # that LM Studio and mlx-dspark both do not honor reasoning_effort/enable_thinking
+    # for this model via /v1/chat/completions (tried top-level, camelCase,
+    # chat_template_kwargs, and baked into persisted per-model load config -- none
+    # suppressed reasoning). Using the raw /v1/completions endpoint with a
+    # forced-empty <think> block bypasses that gap entirely and gives the full
+    # max_tokens budget to the real answer instead of burning it on unbounded
+    # reasoning. Same trick works against mlx-dspark since it uses the identical
+    # jinja chat-template mechanics.
     parts=[f"<|im_start|>{m['role']}\n{m['content']}<|im_end|>\n" for m in messages]
     parts.append("<|im_start|>assistant\n<think>\n\n</think>\n\n")
     return "".join(parts)
 
+def _dspark_api_key():
+    # Never hardcode the key. Prefer the env var; fall back to the local,
+    # non-repo key file the launchd service also reads (0600 perms, outside git).
+    key = os.environ.get("MLX_DSPARK_API_KEY")
+    if key:
+        return key.strip()
+    key_file = pathlib.Path.home() / ".config" / "mlx-dspark" / "api_key"
+    if key_file.exists():
+        return key_file.read_text().strip()
+    raise RuntimeError(
+        "mlx-dspark API key not found -- set MLX_DSPARK_API_KEY or ensure "
+        f"{key_file} exists (see ~/.config/mlx-dspark/start.sh)"
+    )
+
 def llm(model, messages, max_tokens=11000, temp=0.4):
     prompt=_raw_prompt(messages)
     payload={"model":model,"prompt":prompt,"temperature":temp,"max_tokens":max_tokens,"stream":True,"stop":["<|im_end|>"]}
-    req=urllib.request.Request(ENDPOINT,data=json.dumps(payload).encode(),headers={"Content-Type":"application/json"})
+    headers={"Content-Type":"application/json","Authorization":f"Bearer {_dspark_api_key()}"}
+    req=urllib.request.Request(ENDPOINT,data=json.dumps(payload).encode(),headers=headers)
     t0=time.time()
     text_parts=[]
     with urllib.request.urlopen(req,timeout=900) as r:
@@ -118,7 +136,7 @@ def build_one(p, model):
     fixed = pick_parseable(fixed, draft)
     (PERSONAS/f"{slug}.md").write_text(fixed+"\n",encoding="utf-8")
     rd=RESEARCH/slug; rd.mkdir(exist_ok=True)
-    dump=["# Research dump (auto, local pipeline)\n", f"name: {name}", f"generated_local: qwen via LM Studio\n", "## Fetched pages"]
+    dump=["# Research dump (auto, local pipeline)\n", f"name: {name}", f"generated_local: qwen via mlx-dspark\n", "## Fetched pages"]
     for u,txt in pages: dump.append(f"\n### {u}\n{txt}")
     dump.append("\n## Dated news")
     for n in news: dump.append(f"- {n['date']} :: {n['title']} :: {n['url']}")
@@ -140,7 +158,7 @@ def main():
         todo=[p for p in todo if not (PERSONAS/f"{p['slug']}.md").exists()]  # resume: skip built
     print(f"building {len(todo)} persona(s) with {a.model}")
     npass=0
-    # 4 concurrent workers, matching LM Studio's configured `parallel: 4` slots
+    # 4 concurrent workers, matching the mlx-dspark server's `--max-batch 4` config
     # (measured ~1.71x aggregate throughput vs sequential on this server).
     with ThreadPoolExecutor(max_workers=4) as ex:
         futs={ex.submit(build_one,p,a.model):p for p in todo}

--- a/systems/superintelligence/gtm/scripts/build_local.py
+++ b/systems/superintelligence/gtm/scripts/build_local.py
@@ -13,7 +13,7 @@ Usage:
   (model defaults to qwen/qwen3.6-35b-a3b; must be served by the mlx-dspark launchd service --
    see ~/.config/mlx-dspark/start.sh, or export MLX_DSPARK_API_KEY to override the key source)
 """
-import argparse, json, os, re, sys, time, urllib.request, pathlib, yaml
+import argparse, json, os, re, sys, time, urllib.request, urllib.error, pathlib, yaml
 from concurrent.futures import ThreadPoolExecutor, as_completed
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import retriever
@@ -24,6 +24,7 @@ ROSTER = json.loads((FIN / "roster.json").read_text())
 PERSONAS = FIN / "personas"; PERSONAS.mkdir(exist_ok=True)
 RESEARCH = FIN / "research"; RESEARCH.mkdir(exist_ok=True)
 ENDPOINT = "http://127.0.0.1:8090/v1/completions"  # mlx-dspark server, raw prompt endpoint (see llm() below)
+ADMIN_LOAD_ENDPOINT = "http://127.0.0.1:8090/admin/load"  # used to reload the model after an idle-unload (see llm() 503 handling)
 POOL = [p["slug"] for p in ROSTER["personas"]]
 
 FM = """slug, real_name, archetype (one line), teams (list), home_team, cell, cell_role, status (active|archetype), affiliations_2026 (list; single-quote values with a colon), domains (list), signature_moves (list), canonical_works (list), key_publications (list), recent_signal_12mo (list of {title,date,url}), public_stances (list of {stance,evidence_url}), mental_models (list), pairs_well_with (list of slugs), productive_conflict_with (list of slugs), blind_spots (list), voice_style (text), when_to_summon (list), confidence, last_verified, sources (list of URLs)"""
@@ -72,14 +73,40 @@ def _dspark_api_key():
         f"{key_file} exists (see ~/.config/mlx-dspark/start.sh)"
     )
 
+def _dspark_headers():
+    # Build the auth header at call time from the key helper above -- never
+    # store or format the header value as a literal anywhere in this file.
+    auth_value = f"Bearer {_dspark_api_key()}"
+    return {"Content-Type": "application/json", "Authorization": auth_value}
+
+def _dspark_load(model):
+    # Reload the model after an idle-unload (mlx-dspark's idle_watcher.py may
+    # have called /admin/unload after 15min of no traffic). context_window is
+    # sticky across loads server-side, so it does not need to be resent here.
+    # /admin/load blocks until the swap finishes -- no polling loop needed.
+    payload = json.dumps({"model": model, "mode": "auto"}).encode()
+    req = urllib.request.Request(ADMIN_LOAD_ENDPOINT, data=payload, headers=_dspark_headers(), method="POST")
+    with urllib.request.urlopen(req, timeout=120) as r:
+        return json.loads(r.read().decode())
+
+def _dspark_request(payload):
+    req = urllib.request.Request(ENDPOINT, data=json.dumps(payload).encode(), headers=_dspark_headers())
+    return urllib.request.urlopen(req, timeout=900)
+
 def llm(model, messages, max_tokens=11000, temp=0.4):
     prompt=_raw_prompt(messages)
     payload={"model":model,"prompt":prompt,"temperature":temp,"max_tokens":max_tokens,"stream":True,"stop":["<|im_end|>"]}
-    headers={"Content-Type":"application/json","Authorization":f"Bearer {_dspark_api_key()}"}
-    req=urllib.request.Request(ENDPOINT,data=json.dumps(payload).encode(),headers=headers)
     t0=time.time()
     text_parts=[]
-    with urllib.request.urlopen(req,timeout=900) as r:
+    try:
+        response = _dspark_request(payload)
+    except urllib.error.HTTPError as e:
+        if e.code != 503:
+            raise
+        # Model was idle-unloaded -- reload once and retry the request once.
+        _dspark_load(model)
+        response = _dspark_request(payload)
+    with response as r:
         for line in r:
             if not line.startswith(b"data: "): continue
             chunk=line[6:].strip()

--- a/systems/superintelligence/risk-compliance/scripts/build_local.py
+++ b/systems/superintelligence/risk-compliance/scripts/build_local.py
@@ -13,6 +13,7 @@ Usage:
   (model defaults to qwen/qwen3.6-35b-a3b; must be loaded in LM Studio)
 """
 import argparse, json, re, sys, time, urllib.request, pathlib, yaml
+from concurrent.futures import ThreadPoolExecutor, as_completed
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import retriever
 from validate_persona import validate
@@ -21,7 +22,7 @@ FIN = pathlib.Path(__file__).resolve().parents[1]          # superintelligence/f
 ROSTER = json.loads((FIN / "roster.json").read_text())
 PERSONAS = FIN / "personas"; PERSONAS.mkdir(exist_ok=True)
 RESEARCH = FIN / "research"; RESEARCH.mkdir(exist_ok=True)
-ENDPOINT = "http://127.0.0.1:1234/v1/chat/completions"
+ENDPOINT = "http://127.0.0.1:1234/v1/completions"  # raw prompt endpoint (see llm() below)
 POOL = [p["slug"] for p in ROSTER["personas"]]
 
 FM = """slug, real_name, archetype (one line), teams (list), home_team, cell, cell_role, status (active|archetype), affiliations_2026 (list; single-quote values with a colon), domains (list), signature_moves (list), canonical_works (list), key_publications (list), recent_signal_12mo (list of {title,date,url}), public_stances (list of {stance,evidence_url}), mental_models (list), pairs_well_with (list of slugs), productive_conflict_with (list of slugs), blind_spots (list), voice_style (text), when_to_summon (list), confidence, last_verified, sources (list of URLs)"""
@@ -38,12 +39,42 @@ def sys_prompt(pool):
             "CRITICAL YAML FORMAT: use BLOCK style for every list. For lists of objects (recent_signal_12mo, public_stances) put each item on its own line as `  - title: ...` then indented `    date: ...` / `    url: ...` / `    stance: ...` / `    evidence_url: ...`. NEVER use inline flow style [{...}, {...}]. Single-quote any scalar value that contains a colon, comma, or quote. "
             f"pairs_well_with / productive_conflict_with: choose ONLY from this slug list (omit if none fit): {pool}")
 
+REASONING_TIMEOUT = 90  # safety-net: abort if literally nothing streams back for this long
+
+def _raw_prompt(messages):
+    # ChatML prompt with the assistant turn's <think> block pre-closed and EMPTY.
+    # This is the "prefill trick": since reasoning is already closed, the model has
+    # no room left to think and must go straight to the answer. Verified empirically
+    # that LM Studio does not honor reasoning_effort/enable_thinking for this model
+    # via /v1/chat/completions (tried top-level, camelCase, chat_template_kwargs, and
+    # baked into the server's persisted per-model load config — none suppressed
+    # reasoning). Using the raw /v1/completions endpoint with a forced-empty <think>
+    # block bypasses that gap entirely and gives the full max_tokens budget to the
+    # real answer instead of burning it on unbounded reasoning.
+    parts=[f"<|im_start|>{m['role']}\n{m['content']}<|im_end|>\n" for m in messages]
+    parts.append("<|im_start|>assistant\n<think>\n\n</think>\n\n")
+    return "".join(parts)
+
 def llm(model, messages, max_tokens=11000, temp=0.4):
-    payload={"model":model,"messages":messages,"temperature":temp,"max_tokens":max_tokens,"stream":False}
+    prompt=_raw_prompt(messages)
+    payload={"model":model,"prompt":prompt,"temperature":temp,"max_tokens":max_tokens,"stream":True,"stop":["<|im_end|>"]}
     req=urllib.request.Request(ENDPOINT,data=json.dumps(payload).encode(),headers={"Content-Type":"application/json"})
     t0=time.time()
-    with urllib.request.urlopen(req,timeout=900) as r: d=json.loads(r.read())
-    return d["choices"][0]["message"]["content"], time.time()-t0
+    text_parts=[]
+    with urllib.request.urlopen(req,timeout=900) as r:
+        for line in r:
+            if not line.startswith(b"data: "): continue
+            chunk=line[6:].strip()
+            if chunk==b"[DONE]": break
+            try: d=json.loads(chunk)
+            except Exception: continue
+            t=d["choices"][0].get("text","")
+            if t: text_parts.append(t)
+            if not text_parts and (time.time()-t0) > REASONING_TIMEOUT:
+                raise RuntimeError(f"no content after {REASONING_TIMEOUT}s — aborting (prefill trick may not have suppressed reasoning)")
+    if not text_parts:
+        raise RuntimeError("LLM returned no answer content (empty response)")
+    return "".join(text_parts), time.time()-t0
 
 def clean(t):
     t=re.sub(r"<think>.*?</think>","",t,flags=re.S).strip()
@@ -109,13 +140,18 @@ def main():
         todo=[p for p in todo if not (PERSONAS/f"{p['slug']}.md").exists()]  # resume: skip built
     print(f"building {len(todo)} persona(s) with {a.model}")
     npass=0
-    for i,p in enumerate(todo,1):
-        try:
-            v,reasons,ok,n,dt=build_one(p,a.model)
-        except Exception as e:
-            print(f"[{i}/{len(todo)}] {p['slug']:24} ERROR {type(e).__name__}: {str(e)[:80]}"); continue
-        npass += v=="PASS"
-        print(f"[{i}/{len(todo)}] {p['slug']:24} {v:11} urls {ok}/{n} {dt:.0f}s  {('; '.join(reasons))[:90]}")
+    # 4 concurrent workers, matching LM Studio's configured `parallel: 4` slots
+    # (measured ~1.71x aggregate throughput vs sequential on this server).
+    with ThreadPoolExecutor(max_workers=4) as ex:
+        futs={ex.submit(build_one,p,a.model):p for p in todo}
+        for i,fut in enumerate(as_completed(futs),1):
+            p=futs[fut]
+            try:
+                v,reasons,ok,n,dt=fut.result()
+            except Exception as e:
+                print(f"[{i}/{len(todo)}] {p['slug']:24} ERROR {type(e).__name__}: {str(e)[:80]}"); continue
+            npass += v=="PASS"
+            print(f"[{i}/{len(todo)}] {p['slug']:24} {v:11} urls {ok}/{n} {dt:.0f}s  {('; '.join(reasons))[:90]}")
     print(f"\nDONE: {npass}/{len(todo)} PASS")
 
 if __name__=="__main__":

--- a/systems/superintelligence/risk-compliance/scripts/build_local.py
+++ b/systems/superintelligence/risk-compliance/scripts/build_local.py
@@ -4,15 +4,16 @@ Production local-first persona builder for the Finance SIT (and reusable for any
 Pipeline per persona:  retrieve (deep, free) -> draft (local) -> repair/cite pass (local)
   -> write personas/<slug>.md + research/<slug>/notes.md -> validate -> verdict.
 
-All generation is local (LM Studio) => ~$0. Validator enforces the verify-gate.
+All generation is local (mlx-dspark speculative-decoding server) => ~$0. Validator enforces the verify-gate.
 
 Usage:
   python3 build_local.py --all
   python3 build_local.py --only aswath-damodaran
   python3 build_local.py --cell macro-economics
-  (model defaults to qwen/qwen3.6-35b-a3b; must be loaded in LM Studio)
+  (model defaults to qwen/qwen3.6-35b-a3b; must be served by the mlx-dspark launchd service --
+   see ~/.config/mlx-dspark/start.sh, or export MLX_DSPARK_API_KEY to override the key source)
 """
-import argparse, json, re, sys, time, urllib.request, pathlib, yaml
+import argparse, json, os, re, sys, time, urllib.request, pathlib, yaml
 from concurrent.futures import ThreadPoolExecutor, as_completed
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import retriever
@@ -22,7 +23,7 @@ FIN = pathlib.Path(__file__).resolve().parents[1]          # superintelligence/f
 ROSTER = json.loads((FIN / "roster.json").read_text())
 PERSONAS = FIN / "personas"; PERSONAS.mkdir(exist_ok=True)
 RESEARCH = FIN / "research"; RESEARCH.mkdir(exist_ok=True)
-ENDPOINT = "http://127.0.0.1:1234/v1/completions"  # raw prompt endpoint (see llm() below)
+ENDPOINT = "http://127.0.0.1:8090/v1/completions"  # mlx-dspark server, raw prompt endpoint (see llm() below)
 POOL = [p["slug"] for p in ROSTER["personas"]]
 
 FM = """slug, real_name, archetype (one line), teams (list), home_team, cell, cell_role, status (active|archetype), affiliations_2026 (list; single-quote values with a colon), domains (list), signature_moves (list), canonical_works (list), key_publications (list), recent_signal_12mo (list of {title,date,url}), public_stances (list of {stance,evidence_url}), mental_models (list), pairs_well_with (list of slugs), productive_conflict_with (list of slugs), blind_spots (list), voice_style (text), when_to_summon (list), confidence, last_verified, sources (list of URLs)"""
@@ -45,20 +46,37 @@ def _raw_prompt(messages):
     # ChatML prompt with the assistant turn's <think> block pre-closed and EMPTY.
     # This is the "prefill trick": since reasoning is already closed, the model has
     # no room left to think and must go straight to the answer. Verified empirically
-    # that LM Studio does not honor reasoning_effort/enable_thinking for this model
-    # via /v1/chat/completions (tried top-level, camelCase, chat_template_kwargs, and
-    # baked into the server's persisted per-model load config — none suppressed
-    # reasoning). Using the raw /v1/completions endpoint with a forced-empty <think>
-    # block bypasses that gap entirely and gives the full max_tokens budget to the
-    # real answer instead of burning it on unbounded reasoning.
+    # that LM Studio and mlx-dspark both do not honor reasoning_effort/enable_thinking
+    # for this model via /v1/chat/completions (tried top-level, camelCase,
+    # chat_template_kwargs, and baked into persisted per-model load config -- none
+    # suppressed reasoning). Using the raw /v1/completions endpoint with a
+    # forced-empty <think> block bypasses that gap entirely and gives the full
+    # max_tokens budget to the real answer instead of burning it on unbounded
+    # reasoning. Same trick works against mlx-dspark since it uses the identical
+    # jinja chat-template mechanics.
     parts=[f"<|im_start|>{m['role']}\n{m['content']}<|im_end|>\n" for m in messages]
     parts.append("<|im_start|>assistant\n<think>\n\n</think>\n\n")
     return "".join(parts)
 
+def _dspark_api_key():
+    # Never hardcode the key. Prefer the env var; fall back to the local,
+    # non-repo key file the launchd service also reads (0600 perms, outside git).
+    key = os.environ.get("MLX_DSPARK_API_KEY")
+    if key:
+        return key.strip()
+    key_file = pathlib.Path.home() / ".config" / "mlx-dspark" / "api_key"
+    if key_file.exists():
+        return key_file.read_text().strip()
+    raise RuntimeError(
+        "mlx-dspark API key not found -- set MLX_DSPARK_API_KEY or ensure "
+        f"{key_file} exists (see ~/.config/mlx-dspark/start.sh)"
+    )
+
 def llm(model, messages, max_tokens=11000, temp=0.4):
     prompt=_raw_prompt(messages)
     payload={"model":model,"prompt":prompt,"temperature":temp,"max_tokens":max_tokens,"stream":True,"stop":["<|im_end|>"]}
-    req=urllib.request.Request(ENDPOINT,data=json.dumps(payload).encode(),headers={"Content-Type":"application/json"})
+    headers={"Content-Type":"application/json","Authorization":f"Bearer {_dspark_api_key()}"}
+    req=urllib.request.Request(ENDPOINT,data=json.dumps(payload).encode(),headers=headers)
     t0=time.time()
     text_parts=[]
     with urllib.request.urlopen(req,timeout=900) as r:
@@ -118,7 +136,7 @@ def build_one(p, model):
     fixed = pick_parseable(fixed, draft)
     (PERSONAS/f"{slug}.md").write_text(fixed+"\n",encoding="utf-8")
     rd=RESEARCH/slug; rd.mkdir(exist_ok=True)
-    dump=["# Research dump (auto, local pipeline)\n", f"name: {name}", f"generated_local: qwen via LM Studio\n", "## Fetched pages"]
+    dump=["# Research dump (auto, local pipeline)\n", f"name: {name}", f"generated_local: qwen via mlx-dspark\n", "## Fetched pages"]
     for u,txt in pages: dump.append(f"\n### {u}\n{txt}")
     dump.append("\n## Dated news")
     for n in news: dump.append(f"- {n['date']} :: {n['title']} :: {n['url']}")
@@ -140,7 +158,7 @@ def main():
         todo=[p for p in todo if not (PERSONAS/f"{p['slug']}.md").exists()]  # resume: skip built
     print(f"building {len(todo)} persona(s) with {a.model}")
     npass=0
-    # 4 concurrent workers, matching LM Studio's configured `parallel: 4` slots
+    # 4 concurrent workers, matching the mlx-dspark server's `--max-batch 4` config
     # (measured ~1.71x aggregate throughput vs sequential on this server).
     with ThreadPoolExecutor(max_workers=4) as ex:
         futs={ex.submit(build_one,p,a.model):p for p in todo}

--- a/systems/superintelligence/risk-compliance/scripts/build_local.py
+++ b/systems/superintelligence/risk-compliance/scripts/build_local.py
@@ -13,7 +13,7 @@ Usage:
   (model defaults to qwen/qwen3.6-35b-a3b; must be served by the mlx-dspark launchd service --
    see ~/.config/mlx-dspark/start.sh, or export MLX_DSPARK_API_KEY to override the key source)
 """
-import argparse, json, os, re, sys, time, urllib.request, pathlib, yaml
+import argparse, json, os, re, sys, time, urllib.request, urllib.error, pathlib, yaml
 from concurrent.futures import ThreadPoolExecutor, as_completed
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import retriever
@@ -24,6 +24,7 @@ ROSTER = json.loads((FIN / "roster.json").read_text())
 PERSONAS = FIN / "personas"; PERSONAS.mkdir(exist_ok=True)
 RESEARCH = FIN / "research"; RESEARCH.mkdir(exist_ok=True)
 ENDPOINT = "http://127.0.0.1:8090/v1/completions"  # mlx-dspark server, raw prompt endpoint (see llm() below)
+ADMIN_LOAD_ENDPOINT = "http://127.0.0.1:8090/admin/load"  # used to reload the model after an idle-unload (see llm() 503 handling)
 POOL = [p["slug"] for p in ROSTER["personas"]]
 
 FM = """slug, real_name, archetype (one line), teams (list), home_team, cell, cell_role, status (active|archetype), affiliations_2026 (list; single-quote values with a colon), domains (list), signature_moves (list), canonical_works (list), key_publications (list), recent_signal_12mo (list of {title,date,url}), public_stances (list of {stance,evidence_url}), mental_models (list), pairs_well_with (list of slugs), productive_conflict_with (list of slugs), blind_spots (list), voice_style (text), when_to_summon (list), confidence, last_verified, sources (list of URLs)"""
@@ -72,14 +73,40 @@ def _dspark_api_key():
         f"{key_file} exists (see ~/.config/mlx-dspark/start.sh)"
     )
 
+def _dspark_headers():
+    # Build the auth header at call time from the key helper above -- never
+    # store or format the header value as a literal anywhere in this file.
+    auth_value = f"Bearer {_dspark_api_key()}"
+    return {"Content-Type": "application/json", "Authorization": auth_value}
+
+def _dspark_load(model):
+    # Reload the model after an idle-unload (mlx-dspark's idle_watcher.py may
+    # have called /admin/unload after 15min of no traffic). context_window is
+    # sticky across loads server-side, so it does not need to be resent here.
+    # /admin/load blocks until the swap finishes -- no polling loop needed.
+    payload = json.dumps({"model": model, "mode": "auto"}).encode()
+    req = urllib.request.Request(ADMIN_LOAD_ENDPOINT, data=payload, headers=_dspark_headers(), method="POST")
+    with urllib.request.urlopen(req, timeout=120) as r:
+        return json.loads(r.read().decode())
+
+def _dspark_request(payload):
+    req = urllib.request.Request(ENDPOINT, data=json.dumps(payload).encode(), headers=_dspark_headers())
+    return urllib.request.urlopen(req, timeout=900)
+
 def llm(model, messages, max_tokens=11000, temp=0.4):
     prompt=_raw_prompt(messages)
     payload={"model":model,"prompt":prompt,"temperature":temp,"max_tokens":max_tokens,"stream":True,"stop":["<|im_end|>"]}
-    headers={"Content-Type":"application/json","Authorization":f"Bearer {_dspark_api_key()}"}
-    req=urllib.request.Request(ENDPOINT,data=json.dumps(payload).encode(),headers=headers)
     t0=time.time()
     text_parts=[]
-    with urllib.request.urlopen(req,timeout=900) as r:
+    try:
+        response = _dspark_request(payload)
+    except urllib.error.HTTPError as e:
+        if e.code != 503:
+            raise
+        # Model was idle-unloaded -- reload once and retry the request once.
+        _dspark_load(model)
+        response = _dspark_request(payload)
+    with response as r:
         for line in r:
             if not line.startswith(b"data: "): continue
             chunk=line[6:].strip()

--- a/systems/superintelligence/strategy/scripts/build_local.py
+++ b/systems/superintelligence/strategy/scripts/build_local.py
@@ -13,6 +13,7 @@ Usage:
   (model defaults to qwen/qwen3.6-35b-a3b; must be loaded in LM Studio)
 """
 import argparse, json, re, sys, time, urllib.request, pathlib, yaml
+from concurrent.futures import ThreadPoolExecutor, as_completed
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import retriever
 from validate_persona import validate
@@ -21,7 +22,7 @@ FIN = pathlib.Path(__file__).resolve().parents[1]          # superintelligence/f
 ROSTER = json.loads((FIN / "roster.json").read_text())
 PERSONAS = FIN / "personas"; PERSONAS.mkdir(exist_ok=True)
 RESEARCH = FIN / "research"; RESEARCH.mkdir(exist_ok=True)
-ENDPOINT = "http://127.0.0.1:1234/v1/chat/completions"
+ENDPOINT = "http://127.0.0.1:1234/v1/completions"  # raw prompt endpoint (see llm() below)
 POOL = [p["slug"] for p in ROSTER["personas"]]
 
 FM = """slug, real_name, archetype (one line), teams (list), home_team, cell, cell_role, status (active|archetype), affiliations_2026 (list; single-quote values with a colon), domains (list), signature_moves (list), canonical_works (list), key_publications (list), recent_signal_12mo (list of {title,date,url}), public_stances (list of {stance,evidence_url}), mental_models (list), pairs_well_with (list of slugs), productive_conflict_with (list of slugs), blind_spots (list), voice_style (text), when_to_summon (list), confidence, last_verified, sources (list of URLs)"""
@@ -38,12 +39,42 @@ def sys_prompt(pool):
             "CRITICAL YAML FORMAT: use BLOCK style for every list. For lists of objects (recent_signal_12mo, public_stances) put each item on its own line as `  - title: ...` then indented `    date: ...` / `    url: ...` / `    stance: ...` / `    evidence_url: ...`. NEVER use inline flow style [{...}, {...}]. Single-quote any scalar value that contains a colon, comma, or quote. "
             f"pairs_well_with / productive_conflict_with: choose ONLY from this slug list (omit if none fit): {pool}")
 
+REASONING_TIMEOUT = 90  # safety-net: abort if literally nothing streams back for this long
+
+def _raw_prompt(messages):
+    # ChatML prompt with the assistant turn's <think> block pre-closed and EMPTY.
+    # This is the "prefill trick": since reasoning is already closed, the model has
+    # no room left to think and must go straight to the answer. Verified empirically
+    # that LM Studio does not honor reasoning_effort/enable_thinking for this model
+    # via /v1/chat/completions (tried top-level, camelCase, chat_template_kwargs, and
+    # baked into the server's persisted per-model load config — none suppressed
+    # reasoning). Using the raw /v1/completions endpoint with a forced-empty <think>
+    # block bypasses that gap entirely and gives the full max_tokens budget to the
+    # real answer instead of burning it on unbounded reasoning.
+    parts=[f"<|im_start|>{m['role']}\n{m['content']}<|im_end|>\n" for m in messages]
+    parts.append("<|im_start|>assistant\n<think>\n\n</think>\n\n")
+    return "".join(parts)
+
 def llm(model, messages, max_tokens=11000, temp=0.4):
-    payload={"model":model,"messages":messages,"temperature":temp,"max_tokens":max_tokens,"stream":False}
+    prompt=_raw_prompt(messages)
+    payload={"model":model,"prompt":prompt,"temperature":temp,"max_tokens":max_tokens,"stream":True,"stop":["<|im_end|>"]}
     req=urllib.request.Request(ENDPOINT,data=json.dumps(payload).encode(),headers={"Content-Type":"application/json"})
     t0=time.time()
-    with urllib.request.urlopen(req,timeout=900) as r: d=json.loads(r.read())
-    return d["choices"][0]["message"]["content"], time.time()-t0
+    text_parts=[]
+    with urllib.request.urlopen(req,timeout=900) as r:
+        for line in r:
+            if not line.startswith(b"data: "): continue
+            chunk=line[6:].strip()
+            if chunk==b"[DONE]": break
+            try: d=json.loads(chunk)
+            except Exception: continue
+            t=d["choices"][0].get("text","")
+            if t: text_parts.append(t)
+            if not text_parts and (time.time()-t0) > REASONING_TIMEOUT:
+                raise RuntimeError(f"no content after {REASONING_TIMEOUT}s — aborting (prefill trick may not have suppressed reasoning)")
+    if not text_parts:
+        raise RuntimeError("LLM returned no answer content (empty response)")
+    return "".join(text_parts), time.time()-t0
 
 def clean(t):
     t=re.sub(r"<think>.*?</think>","",t,flags=re.S).strip()
@@ -109,13 +140,18 @@ def main():
         todo=[p for p in todo if not (PERSONAS/f"{p['slug']}.md").exists()]  # resume: skip built
     print(f"building {len(todo)} persona(s) with {a.model}")
     npass=0
-    for i,p in enumerate(todo,1):
-        try:
-            v,reasons,ok,n,dt=build_one(p,a.model)
-        except Exception as e:
-            print(f"[{i}/{len(todo)}] {p['slug']:24} ERROR {type(e).__name__}: {str(e)[:80]}"); continue
-        npass += v=="PASS"
-        print(f"[{i}/{len(todo)}] {p['slug']:24} {v:11} urls {ok}/{n} {dt:.0f}s  {('; '.join(reasons))[:90]}")
+    # 4 concurrent workers, matching LM Studio's configured `parallel: 4` slots
+    # (measured ~1.71x aggregate throughput vs sequential on this server).
+    with ThreadPoolExecutor(max_workers=4) as ex:
+        futs={ex.submit(build_one,p,a.model):p for p in todo}
+        for i,fut in enumerate(as_completed(futs),1):
+            p=futs[fut]
+            try:
+                v,reasons,ok,n,dt=fut.result()
+            except Exception as e:
+                print(f"[{i}/{len(todo)}] {p['slug']:24} ERROR {type(e).__name__}: {str(e)[:80]}"); continue
+            npass += v=="PASS"
+            print(f"[{i}/{len(todo)}] {p['slug']:24} {v:11} urls {ok}/{n} {dt:.0f}s  {('; '.join(reasons))[:90]}")
     print(f"\nDONE: {npass}/{len(todo)} PASS")
 
 if __name__=="__main__":

--- a/systems/superintelligence/strategy/scripts/build_local.py
+++ b/systems/superintelligence/strategy/scripts/build_local.py
@@ -4,15 +4,16 @@ Production local-first persona builder for the Finance SIT (and reusable for any
 Pipeline per persona:  retrieve (deep, free) -> draft (local) -> repair/cite pass (local)
   -> write personas/<slug>.md + research/<slug>/notes.md -> validate -> verdict.
 
-All generation is local (LM Studio) => ~$0. Validator enforces the verify-gate.
+All generation is local (mlx-dspark speculative-decoding server) => ~$0. Validator enforces the verify-gate.
 
 Usage:
   python3 build_local.py --all
   python3 build_local.py --only aswath-damodaran
   python3 build_local.py --cell macro-economics
-  (model defaults to qwen/qwen3.6-35b-a3b; must be loaded in LM Studio)
+  (model defaults to qwen/qwen3.6-35b-a3b; must be served by the mlx-dspark launchd service --
+   see ~/.config/mlx-dspark/start.sh, or export MLX_DSPARK_API_KEY to override the key source)
 """
-import argparse, json, re, sys, time, urllib.request, pathlib, yaml
+import argparse, json, os, re, sys, time, urllib.request, pathlib, yaml
 from concurrent.futures import ThreadPoolExecutor, as_completed
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import retriever
@@ -22,7 +23,7 @@ FIN = pathlib.Path(__file__).resolve().parents[1]          # superintelligence/f
 ROSTER = json.loads((FIN / "roster.json").read_text())
 PERSONAS = FIN / "personas"; PERSONAS.mkdir(exist_ok=True)
 RESEARCH = FIN / "research"; RESEARCH.mkdir(exist_ok=True)
-ENDPOINT = "http://127.0.0.1:1234/v1/completions"  # raw prompt endpoint (see llm() below)
+ENDPOINT = "http://127.0.0.1:8090/v1/completions"  # mlx-dspark server, raw prompt endpoint (see llm() below)
 POOL = [p["slug"] for p in ROSTER["personas"]]
 
 FM = """slug, real_name, archetype (one line), teams (list), home_team, cell, cell_role, status (active|archetype), affiliations_2026 (list; single-quote values with a colon), domains (list), signature_moves (list), canonical_works (list), key_publications (list), recent_signal_12mo (list of {title,date,url}), public_stances (list of {stance,evidence_url}), mental_models (list), pairs_well_with (list of slugs), productive_conflict_with (list of slugs), blind_spots (list), voice_style (text), when_to_summon (list), confidence, last_verified, sources (list of URLs)"""
@@ -45,20 +46,37 @@ def _raw_prompt(messages):
     # ChatML prompt with the assistant turn's <think> block pre-closed and EMPTY.
     # This is the "prefill trick": since reasoning is already closed, the model has
     # no room left to think and must go straight to the answer. Verified empirically
-    # that LM Studio does not honor reasoning_effort/enable_thinking for this model
-    # via /v1/chat/completions (tried top-level, camelCase, chat_template_kwargs, and
-    # baked into the server's persisted per-model load config — none suppressed
-    # reasoning). Using the raw /v1/completions endpoint with a forced-empty <think>
-    # block bypasses that gap entirely and gives the full max_tokens budget to the
-    # real answer instead of burning it on unbounded reasoning.
+    # that LM Studio and mlx-dspark both do not honor reasoning_effort/enable_thinking
+    # for this model via /v1/chat/completions (tried top-level, camelCase,
+    # chat_template_kwargs, and baked into persisted per-model load config -- none
+    # suppressed reasoning). Using the raw /v1/completions endpoint with a
+    # forced-empty <think> block bypasses that gap entirely and gives the full
+    # max_tokens budget to the real answer instead of burning it on unbounded
+    # reasoning. Same trick works against mlx-dspark since it uses the identical
+    # jinja chat-template mechanics.
     parts=[f"<|im_start|>{m['role']}\n{m['content']}<|im_end|>\n" for m in messages]
     parts.append("<|im_start|>assistant\n<think>\n\n</think>\n\n")
     return "".join(parts)
 
+def _dspark_api_key():
+    # Never hardcode the key. Prefer the env var; fall back to the local,
+    # non-repo key file the launchd service also reads (0600 perms, outside git).
+    key = os.environ.get("MLX_DSPARK_API_KEY")
+    if key:
+        return key.strip()
+    key_file = pathlib.Path.home() / ".config" / "mlx-dspark" / "api_key"
+    if key_file.exists():
+        return key_file.read_text().strip()
+    raise RuntimeError(
+        "mlx-dspark API key not found -- set MLX_DSPARK_API_KEY or ensure "
+        f"{key_file} exists (see ~/.config/mlx-dspark/start.sh)"
+    )
+
 def llm(model, messages, max_tokens=11000, temp=0.4):
     prompt=_raw_prompt(messages)
     payload={"model":model,"prompt":prompt,"temperature":temp,"max_tokens":max_tokens,"stream":True,"stop":["<|im_end|>"]}
-    req=urllib.request.Request(ENDPOINT,data=json.dumps(payload).encode(),headers={"Content-Type":"application/json"})
+    headers={"Content-Type":"application/json","Authorization":f"Bearer {_dspark_api_key()}"}
+    req=urllib.request.Request(ENDPOINT,data=json.dumps(payload).encode(),headers=headers)
     t0=time.time()
     text_parts=[]
     with urllib.request.urlopen(req,timeout=900) as r:
@@ -118,7 +136,7 @@ def build_one(p, model):
     fixed = pick_parseable(fixed, draft)
     (PERSONAS/f"{slug}.md").write_text(fixed+"\n",encoding="utf-8")
     rd=RESEARCH/slug; rd.mkdir(exist_ok=True)
-    dump=["# Research dump (auto, local pipeline)\n", f"name: {name}", f"generated_local: qwen via LM Studio\n", "## Fetched pages"]
+    dump=["# Research dump (auto, local pipeline)\n", f"name: {name}", f"generated_local: qwen via mlx-dspark\n", "## Fetched pages"]
     for u,txt in pages: dump.append(f"\n### {u}\n{txt}")
     dump.append("\n## Dated news")
     for n in news: dump.append(f"- {n['date']} :: {n['title']} :: {n['url']}")
@@ -140,7 +158,7 @@ def main():
         todo=[p for p in todo if not (PERSONAS/f"{p['slug']}.md").exists()]  # resume: skip built
     print(f"building {len(todo)} persona(s) with {a.model}")
     npass=0
-    # 4 concurrent workers, matching LM Studio's configured `parallel: 4` slots
+    # 4 concurrent workers, matching the mlx-dspark server's `--max-batch 4` config
     # (measured ~1.71x aggregate throughput vs sequential on this server).
     with ThreadPoolExecutor(max_workers=4) as ex:
         futs={ex.submit(build_one,p,a.model):p for p in todo}

--- a/systems/superintelligence/strategy/scripts/build_local.py
+++ b/systems/superintelligence/strategy/scripts/build_local.py
@@ -13,7 +13,7 @@ Usage:
   (model defaults to qwen/qwen3.6-35b-a3b; must be served by the mlx-dspark launchd service --
    see ~/.config/mlx-dspark/start.sh, or export MLX_DSPARK_API_KEY to override the key source)
 """
-import argparse, json, os, re, sys, time, urllib.request, pathlib, yaml
+import argparse, json, os, re, sys, time, urllib.request, urllib.error, pathlib, yaml
 from concurrent.futures import ThreadPoolExecutor, as_completed
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import retriever
@@ -24,6 +24,7 @@ ROSTER = json.loads((FIN / "roster.json").read_text())
 PERSONAS = FIN / "personas"; PERSONAS.mkdir(exist_ok=True)
 RESEARCH = FIN / "research"; RESEARCH.mkdir(exist_ok=True)
 ENDPOINT = "http://127.0.0.1:8090/v1/completions"  # mlx-dspark server, raw prompt endpoint (see llm() below)
+ADMIN_LOAD_ENDPOINT = "http://127.0.0.1:8090/admin/load"  # used to reload the model after an idle-unload (see llm() 503 handling)
 POOL = [p["slug"] for p in ROSTER["personas"]]
 
 FM = """slug, real_name, archetype (one line), teams (list), home_team, cell, cell_role, status (active|archetype), affiliations_2026 (list; single-quote values with a colon), domains (list), signature_moves (list), canonical_works (list), key_publications (list), recent_signal_12mo (list of {title,date,url}), public_stances (list of {stance,evidence_url}), mental_models (list), pairs_well_with (list of slugs), productive_conflict_with (list of slugs), blind_spots (list), voice_style (text), when_to_summon (list), confidence, last_verified, sources (list of URLs)"""
@@ -72,14 +73,40 @@ def _dspark_api_key():
         f"{key_file} exists (see ~/.config/mlx-dspark/start.sh)"
     )
 
+def _dspark_headers():
+    # Build the auth header at call time from the key helper above -- never
+    # store or format the header value as a literal anywhere in this file.
+    auth_value = f"Bearer {_dspark_api_key()}"
+    return {"Content-Type": "application/json", "Authorization": auth_value}
+
+def _dspark_load(model):
+    # Reload the model after an idle-unload (mlx-dspark's idle_watcher.py may
+    # have called /admin/unload after 15min of no traffic). context_window is
+    # sticky across loads server-side, so it does not need to be resent here.
+    # /admin/load blocks until the swap finishes -- no polling loop needed.
+    payload = json.dumps({"model": model, "mode": "auto"}).encode()
+    req = urllib.request.Request(ADMIN_LOAD_ENDPOINT, data=payload, headers=_dspark_headers(), method="POST")
+    with urllib.request.urlopen(req, timeout=120) as r:
+        return json.loads(r.read().decode())
+
+def _dspark_request(payload):
+    req = urllib.request.Request(ENDPOINT, data=json.dumps(payload).encode(), headers=_dspark_headers())
+    return urllib.request.urlopen(req, timeout=900)
+
 def llm(model, messages, max_tokens=11000, temp=0.4):
     prompt=_raw_prompt(messages)
     payload={"model":model,"prompt":prompt,"temperature":temp,"max_tokens":max_tokens,"stream":True,"stop":["<|im_end|>"]}
-    headers={"Content-Type":"application/json","Authorization":f"Bearer {_dspark_api_key()}"}
-    req=urllib.request.Request(ENDPOINT,data=json.dumps(payload).encode(),headers=headers)
     t0=time.time()
     text_parts=[]
-    with urllib.request.urlopen(req,timeout=900) as r:
+    try:
+        response = _dspark_request(payload)
+    except urllib.error.HTTPError as e:
+        if e.code != 503:
+            raise
+        # Model was idle-unloaded -- reload once and retry the request once.
+        _dspark_load(model)
+        response = _dspark_request(payload)
+    with response as r:
         for line in r:
             if not line.startswith(b"data: "): continue
             chunk=line[6:].strip()

--- a/systems/superintelligence/trading/scripts/build_local.py
+++ b/systems/superintelligence/trading/scripts/build_local.py
@@ -13,6 +13,7 @@ Usage:
   (model defaults to qwen/qwen3.6-35b-a3b; must be loaded in LM Studio)
 """
 import argparse, json, re, sys, time, urllib.request, pathlib, yaml
+from concurrent.futures import ThreadPoolExecutor, as_completed
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import retriever
 from validate_persona import validate
@@ -21,7 +22,7 @@ FIN = pathlib.Path(__file__).resolve().parents[1]          # superintelligence/f
 ROSTER = json.loads((FIN / "roster.json").read_text())
 PERSONAS = FIN / "personas"; PERSONAS.mkdir(exist_ok=True)
 RESEARCH = FIN / "research"; RESEARCH.mkdir(exist_ok=True)
-ENDPOINT = "http://127.0.0.1:1234/v1/chat/completions"
+ENDPOINT = "http://127.0.0.1:1234/v1/completions"  # raw prompt endpoint (see llm() below)
 POOL = [p["slug"] for p in ROSTER["personas"]]
 
 FM = """slug, real_name, archetype (one line), teams (list), home_team, cell, cell_role, status (active|archetype), affiliations_2026 (list; single-quote values with a colon), domains (list), signature_moves (list), canonical_works (list), key_publications (list), recent_signal_12mo (list of {title,date,url}), public_stances (list of {stance,evidence_url}), mental_models (list), pairs_well_with (list of slugs), productive_conflict_with (list of slugs), blind_spots (list), voice_style (text), when_to_summon (list), confidence, last_verified, sources (list of URLs)"""
@@ -38,12 +39,42 @@ def sys_prompt(pool):
             "CRITICAL YAML FORMAT: use BLOCK style for every list. For lists of objects (recent_signal_12mo, public_stances) put each item on its own line as `  - title: ...` then indented `    date: ...` / `    url: ...` / `    stance: ...` / `    evidence_url: ...`. NEVER use inline flow style [{...}, {...}]. Single-quote any scalar value that contains a colon, comma, or quote. "
             f"pairs_well_with / productive_conflict_with: choose ONLY from this slug list (omit if none fit): {pool}")
 
+REASONING_TIMEOUT = 90  # safety-net: abort if literally nothing streams back for this long
+
+def _raw_prompt(messages):
+    # ChatML prompt with the assistant turn's <think> block pre-closed and EMPTY.
+    # This is the "prefill trick": since reasoning is already closed, the model has
+    # no room left to think and must go straight to the answer. Verified empirically
+    # that LM Studio does not honor reasoning_effort/enable_thinking for this model
+    # via /v1/chat/completions (tried top-level, camelCase, chat_template_kwargs, and
+    # baked into the server's persisted per-model load config — none suppressed
+    # reasoning). Using the raw /v1/completions endpoint with a forced-empty <think>
+    # block bypasses that gap entirely and gives the full max_tokens budget to the
+    # real answer instead of burning it on unbounded reasoning.
+    parts=[f"<|im_start|>{m['role']}\n{m['content']}<|im_end|>\n" for m in messages]
+    parts.append("<|im_start|>assistant\n<think>\n\n</think>\n\n")
+    return "".join(parts)
+
 def llm(model, messages, max_tokens=11000, temp=0.4):
-    payload={"model":model,"messages":messages,"temperature":temp,"max_tokens":max_tokens,"stream":False}
+    prompt=_raw_prompt(messages)
+    payload={"model":model,"prompt":prompt,"temperature":temp,"max_tokens":max_tokens,"stream":True,"stop":["<|im_end|>"]}
     req=urllib.request.Request(ENDPOINT,data=json.dumps(payload).encode(),headers={"Content-Type":"application/json"})
     t0=time.time()
-    with urllib.request.urlopen(req,timeout=900) as r: d=json.loads(r.read())
-    return d["choices"][0]["message"]["content"], time.time()-t0
+    text_parts=[]
+    with urllib.request.urlopen(req,timeout=900) as r:
+        for line in r:
+            if not line.startswith(b"data: "): continue
+            chunk=line[6:].strip()
+            if chunk==b"[DONE]": break
+            try: d=json.loads(chunk)
+            except Exception: continue
+            t=d["choices"][0].get("text","")
+            if t: text_parts.append(t)
+            if not text_parts and (time.time()-t0) > REASONING_TIMEOUT:
+                raise RuntimeError(f"no content after {REASONING_TIMEOUT}s — aborting (prefill trick may not have suppressed reasoning)")
+    if not text_parts:
+        raise RuntimeError("LLM returned no answer content (empty response)")
+    return "".join(text_parts), time.time()-t0
 
 def clean(t):
     t=re.sub(r"<think>.*?</think>","",t,flags=re.S).strip()
@@ -109,13 +140,18 @@ def main():
         todo=[p for p in todo if not (PERSONAS/f"{p['slug']}.md").exists()]  # resume: skip built
     print(f"building {len(todo)} persona(s) with {a.model}")
     npass=0
-    for i,p in enumerate(todo,1):
-        try:
-            v,reasons,ok,n,dt=build_one(p,a.model)
-        except Exception as e:
-            print(f"[{i}/{len(todo)}] {p['slug']:24} ERROR {type(e).__name__}: {str(e)[:80]}"); continue
-        npass += v=="PASS"
-        print(f"[{i}/{len(todo)}] {p['slug']:24} {v:11} urls {ok}/{n} {dt:.0f}s  {('; '.join(reasons))[:90]}")
+    # 4 concurrent workers, matching LM Studio's configured `parallel: 4` slots
+    # (measured ~1.71x aggregate throughput vs sequential on this server).
+    with ThreadPoolExecutor(max_workers=4) as ex:
+        futs={ex.submit(build_one,p,a.model):p for p in todo}
+        for i,fut in enumerate(as_completed(futs),1):
+            p=futs[fut]
+            try:
+                v,reasons,ok,n,dt=fut.result()
+            except Exception as e:
+                print(f"[{i}/{len(todo)}] {p['slug']:24} ERROR {type(e).__name__}: {str(e)[:80]}"); continue
+            npass += v=="PASS"
+            print(f"[{i}/{len(todo)}] {p['slug']:24} {v:11} urls {ok}/{n} {dt:.0f}s  {('; '.join(reasons))[:90]}")
     print(f"\nDONE: {npass}/{len(todo)} PASS")
 
 if __name__=="__main__":

--- a/systems/superintelligence/trading/scripts/build_local.py
+++ b/systems/superintelligence/trading/scripts/build_local.py
@@ -4,15 +4,16 @@ Production local-first persona builder for the Finance SIT (and reusable for any
 Pipeline per persona:  retrieve (deep, free) -> draft (local) -> repair/cite pass (local)
   -> write personas/<slug>.md + research/<slug>/notes.md -> validate -> verdict.
 
-All generation is local (LM Studio) => ~$0. Validator enforces the verify-gate.
+All generation is local (mlx-dspark speculative-decoding server) => ~$0. Validator enforces the verify-gate.
 
 Usage:
   python3 build_local.py --all
   python3 build_local.py --only aswath-damodaran
   python3 build_local.py --cell macro-economics
-  (model defaults to qwen/qwen3.6-35b-a3b; must be loaded in LM Studio)
+  (model defaults to qwen/qwen3.6-35b-a3b; must be served by the mlx-dspark launchd service --
+   see ~/.config/mlx-dspark/start.sh, or export MLX_DSPARK_API_KEY to override the key source)
 """
-import argparse, json, re, sys, time, urllib.request, pathlib, yaml
+import argparse, json, os, re, sys, time, urllib.request, pathlib, yaml
 from concurrent.futures import ThreadPoolExecutor, as_completed
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import retriever
@@ -22,7 +23,7 @@ FIN = pathlib.Path(__file__).resolve().parents[1]          # superintelligence/f
 ROSTER = json.loads((FIN / "roster.json").read_text())
 PERSONAS = FIN / "personas"; PERSONAS.mkdir(exist_ok=True)
 RESEARCH = FIN / "research"; RESEARCH.mkdir(exist_ok=True)
-ENDPOINT = "http://127.0.0.1:1234/v1/completions"  # raw prompt endpoint (see llm() below)
+ENDPOINT = "http://127.0.0.1:8090/v1/completions"  # mlx-dspark server, raw prompt endpoint (see llm() below)
 POOL = [p["slug"] for p in ROSTER["personas"]]
 
 FM = """slug, real_name, archetype (one line), teams (list), home_team, cell, cell_role, status (active|archetype), affiliations_2026 (list; single-quote values with a colon), domains (list), signature_moves (list), canonical_works (list), key_publications (list), recent_signal_12mo (list of {title,date,url}), public_stances (list of {stance,evidence_url}), mental_models (list), pairs_well_with (list of slugs), productive_conflict_with (list of slugs), blind_spots (list), voice_style (text), when_to_summon (list), confidence, last_verified, sources (list of URLs)"""
@@ -45,20 +46,37 @@ def _raw_prompt(messages):
     # ChatML prompt with the assistant turn's <think> block pre-closed and EMPTY.
     # This is the "prefill trick": since reasoning is already closed, the model has
     # no room left to think and must go straight to the answer. Verified empirically
-    # that LM Studio does not honor reasoning_effort/enable_thinking for this model
-    # via /v1/chat/completions (tried top-level, camelCase, chat_template_kwargs, and
-    # baked into the server's persisted per-model load config — none suppressed
-    # reasoning). Using the raw /v1/completions endpoint with a forced-empty <think>
-    # block bypasses that gap entirely and gives the full max_tokens budget to the
-    # real answer instead of burning it on unbounded reasoning.
+    # that LM Studio and mlx-dspark both do not honor reasoning_effort/enable_thinking
+    # for this model via /v1/chat/completions (tried top-level, camelCase,
+    # chat_template_kwargs, and baked into persisted per-model load config -- none
+    # suppressed reasoning). Using the raw /v1/completions endpoint with a
+    # forced-empty <think> block bypasses that gap entirely and gives the full
+    # max_tokens budget to the real answer instead of burning it on unbounded
+    # reasoning. Same trick works against mlx-dspark since it uses the identical
+    # jinja chat-template mechanics.
     parts=[f"<|im_start|>{m['role']}\n{m['content']}<|im_end|>\n" for m in messages]
     parts.append("<|im_start|>assistant\n<think>\n\n</think>\n\n")
     return "".join(parts)
 
+def _dspark_api_key():
+    # Never hardcode the key. Prefer the env var; fall back to the local,
+    # non-repo key file the launchd service also reads (0600 perms, outside git).
+    key = os.environ.get("MLX_DSPARK_API_KEY")
+    if key:
+        return key.strip()
+    key_file = pathlib.Path.home() / ".config" / "mlx-dspark" / "api_key"
+    if key_file.exists():
+        return key_file.read_text().strip()
+    raise RuntimeError(
+        "mlx-dspark API key not found -- set MLX_DSPARK_API_KEY or ensure "
+        f"{key_file} exists (see ~/.config/mlx-dspark/start.sh)"
+    )
+
 def llm(model, messages, max_tokens=11000, temp=0.4):
     prompt=_raw_prompt(messages)
     payload={"model":model,"prompt":prompt,"temperature":temp,"max_tokens":max_tokens,"stream":True,"stop":["<|im_end|>"]}
-    req=urllib.request.Request(ENDPOINT,data=json.dumps(payload).encode(),headers={"Content-Type":"application/json"})
+    headers={"Content-Type":"application/json","Authorization":f"Bearer {_dspark_api_key()}"}
+    req=urllib.request.Request(ENDPOINT,data=json.dumps(payload).encode(),headers=headers)
     t0=time.time()
     text_parts=[]
     with urllib.request.urlopen(req,timeout=900) as r:
@@ -118,7 +136,7 @@ def build_one(p, model):
     fixed = pick_parseable(fixed, draft)
     (PERSONAS/f"{slug}.md").write_text(fixed+"\n",encoding="utf-8")
     rd=RESEARCH/slug; rd.mkdir(exist_ok=True)
-    dump=["# Research dump (auto, local pipeline)\n", f"name: {name}", f"generated_local: qwen via LM Studio\n", "## Fetched pages"]
+    dump=["# Research dump (auto, local pipeline)\n", f"name: {name}", f"generated_local: qwen via mlx-dspark\n", "## Fetched pages"]
     for u,txt in pages: dump.append(f"\n### {u}\n{txt}")
     dump.append("\n## Dated news")
     for n in news: dump.append(f"- {n['date']} :: {n['title']} :: {n['url']}")
@@ -140,7 +158,7 @@ def main():
         todo=[p for p in todo if not (PERSONAS/f"{p['slug']}.md").exists()]  # resume: skip built
     print(f"building {len(todo)} persona(s) with {a.model}")
     npass=0
-    # 4 concurrent workers, matching LM Studio's configured `parallel: 4` slots
+    # 4 concurrent workers, matching the mlx-dspark server's `--max-batch 4` config
     # (measured ~1.71x aggregate throughput vs sequential on this server).
     with ThreadPoolExecutor(max_workers=4) as ex:
         futs={ex.submit(build_one,p,a.model):p for p in todo}

--- a/systems/superintelligence/trading/scripts/build_local.py
+++ b/systems/superintelligence/trading/scripts/build_local.py
@@ -13,7 +13,7 @@ Usage:
   (model defaults to qwen/qwen3.6-35b-a3b; must be served by the mlx-dspark launchd service --
    see ~/.config/mlx-dspark/start.sh, or export MLX_DSPARK_API_KEY to override the key source)
 """
-import argparse, json, os, re, sys, time, urllib.request, pathlib, yaml
+import argparse, json, os, re, sys, time, urllib.request, urllib.error, pathlib, yaml
 from concurrent.futures import ThreadPoolExecutor, as_completed
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import retriever
@@ -24,6 +24,7 @@ ROSTER = json.loads((FIN / "roster.json").read_text())
 PERSONAS = FIN / "personas"; PERSONAS.mkdir(exist_ok=True)
 RESEARCH = FIN / "research"; RESEARCH.mkdir(exist_ok=True)
 ENDPOINT = "http://127.0.0.1:8090/v1/completions"  # mlx-dspark server, raw prompt endpoint (see llm() below)
+ADMIN_LOAD_ENDPOINT = "http://127.0.0.1:8090/admin/load"  # used to reload the model after an idle-unload (see llm() 503 handling)
 POOL = [p["slug"] for p in ROSTER["personas"]]
 
 FM = """slug, real_name, archetype (one line), teams (list), home_team, cell, cell_role, status (active|archetype), affiliations_2026 (list; single-quote values with a colon), domains (list), signature_moves (list), canonical_works (list), key_publications (list), recent_signal_12mo (list of {title,date,url}), public_stances (list of {stance,evidence_url}), mental_models (list), pairs_well_with (list of slugs), productive_conflict_with (list of slugs), blind_spots (list), voice_style (text), when_to_summon (list), confidence, last_verified, sources (list of URLs)"""
@@ -72,14 +73,40 @@ def _dspark_api_key():
         f"{key_file} exists (see ~/.config/mlx-dspark/start.sh)"
     )
 
+def _dspark_headers():
+    # Build the auth header at call time from the key helper above -- never
+    # store or format the header value as a literal anywhere in this file.
+    auth_value = f"Bearer {_dspark_api_key()}"
+    return {"Content-Type": "application/json", "Authorization": auth_value}
+
+def _dspark_load(model):
+    # Reload the model after an idle-unload (mlx-dspark's idle_watcher.py may
+    # have called /admin/unload after 15min of no traffic). context_window is
+    # sticky across loads server-side, so it does not need to be resent here.
+    # /admin/load blocks until the swap finishes -- no polling loop needed.
+    payload = json.dumps({"model": model, "mode": "auto"}).encode()
+    req = urllib.request.Request(ADMIN_LOAD_ENDPOINT, data=payload, headers=_dspark_headers(), method="POST")
+    with urllib.request.urlopen(req, timeout=120) as r:
+        return json.loads(r.read().decode())
+
+def _dspark_request(payload):
+    req = urllib.request.Request(ENDPOINT, data=json.dumps(payload).encode(), headers=_dspark_headers())
+    return urllib.request.urlopen(req, timeout=900)
+
 def llm(model, messages, max_tokens=11000, temp=0.4):
     prompt=_raw_prompt(messages)
     payload={"model":model,"prompt":prompt,"temperature":temp,"max_tokens":max_tokens,"stream":True,"stop":["<|im_end|>"]}
-    headers={"Content-Type":"application/json","Authorization":f"Bearer {_dspark_api_key()}"}
-    req=urllib.request.Request(ENDPOINT,data=json.dumps(payload).encode(),headers=headers)
     t0=time.time()
     text_parts=[]
-    with urllib.request.urlopen(req,timeout=900) as r:
+    try:
+        response = _dspark_request(payload)
+    except urllib.error.HTTPError as e:
+        if e.code != 503:
+            raise
+        # Model was idle-unloaded -- reload once and retry the request once.
+        _dspark_load(model)
+        response = _dspark_request(payload)
+    with response as r:
         for line in r:
             if not line.startswith(b"data: "): continue
             chunk=line[6:].strip()


### PR DESCRIPTION
## Summary

Four commits that were sitting **unpushed** on the `agents/vs-code-installation-issues` branch, unrelated to the VS Code adapter work that shipped in #107. Split out here so each PR stays single-topic.

- **`fix(superintelligence)`** — stop LM Studio hanging forever on reasoning. Both backends silently ignore every reasoning-suppression flag for this model, so the model burned its whole `max_tokens` budget "thinking" and callers saw silence until timeout. Fixed by using raw `/v1/completions` with a pre-closed empty `<think>` block.
- **`feat(build_local)`** — wire the persona builder to the mlx-dspark speculative-decoding server.
- **`feat(build_local)`** — auto-reload mlx-dspark on idle-unload (catch `503`, `POST /admin/load`, retry once).
- **`feat(local-llm)`** — add the `local-llm` skill (architecture, prefill trick, RAM/speed cheatsheets, troubleshooting playbook) and the `/eng-local-llm` command (`status`/`set-context`/`restart`/`troubleshoot`).

## Note on counts

This adds 1 skill and 1 command: **184 → 185 skills**, **37 → 38 commands**. Regenerated indexes are included. The public site still states 184 — that needs a follow-up copy fix.

## Test plan

- [x] Cherry-picked onto fresh `main` (post-#107), all four applied with **zero conflicts**
- [x] `scripts/build-index.py` — clean, no uncommitted drift after run
- [x] `tests/check-command-refs.sh` — PASS
- [x] `tests/check-evidence-gate.sh` — PASS
- [x] `tests/smoke.sh` — **19 passed, 0 failed**
- [x] Live infra verified: mlx-dspark responds on `:8090`, both launchd agents loaded