### PR TITLE
fix(site): correct published counts after the local-llm skill landed

### DIFF
--- a/coco/index.html
+++ b/coco/index.html
@@ -4,15 +4,15 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>CoCo: An entire engineering department, inside your editor</title>
-<meta name="description" content="Each of the 389 requires a live, checkable source. Then 184 skills ship what they decided.">
+<meta name="description" content="Each of the 389 requires a live, checkable source. Then 185 skills ship what they decided.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://cocoresearch.org/coco/">
 <meta property="og:title" content="CoCo: An entire engineering department, inside your editor">
-<meta property="og:description" content="Each of the 389 requires a live, checkable source. Then 184 skills ship what they decided.">
+<meta property="og:description" content="Each of the 389 requires a live, checkable source. Then 185 skills ship what they decided.">
 <meta property="og:image" content="https://cocoresearch.org/assets/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="CoCo: An entire engineering department, inside your editor">
-<meta name="twitter:description" content="Each of the 389 requires a live, checkable source. Then 184 skills ship what they decided.">
+<meta name="twitter:description" content="Each of the 389 requires a live, checkable source. Then 185 skills ship what they decided.">
 <meta name="twitter:image" content="https://cocoresearch.org/assets/og-image.png">
 <style>
 /* ============================================================================
@@ -257,7 +257,7 @@ video{display:block;width:100%;height:auto}
   <div class="wrap">
     <p class="eyebrow reveal">CoCo 1.2.0 &middot; the CoCo Research flagship</p>
     <h1 class="reveal">Your editor, arguing with itself before anything ships.</h1>
-    <p class="sub reveal">Each of the 389 requires a live, checkable source. Then 184 skills ship what they decided.</p>
+    <p class="sub reveal">Each of the 389 requires a live, checkable source. Then 185 skills ship what they decided.</p>
     <div class="cta reveal">
       <a class="btn" href="https://github.com/coco-research/coco">Get CoCo on GitHub</a>
       <a class="arrow" href="#board">See how it decides</a>
@@ -312,8 +312,8 @@ video{display:block;width:100%;height:auto}
         <p>Each requires a live, checkable source link. Quotes are illustrative reconstructions, not verbatim; see the <a href="https://github.com/coco-research/coco/blob/main/systems/superintelligence/DISCLAIMER.md">disclaimer</a>.</p></div>
       <div class="tile reveal"><p class="n">9</p><p class="lbl">Departments</p>
         <p>Engineering, AI, product and design, finance, trading, risk and compliance, strategy, data, sales and go-to-market.</p></div>
-      <div class="tile reveal"><p class="n">279</p><p class="lbl">Commands</p>
-        <p>37 core, plus 242 generated locally at install from the team registries.</p></div>
+      <div class="tile reveal"><p class="n">280</p><p class="lbl">Commands</p>
+        <p>38 core, plus 242 generated locally at install from the team registries.</p></div>
       <div class="tile reveal"><p class="n">34</p><p class="lbl">Agents</p>
         <p>Specialists that carry the decision into code, review it, and verify the result.</p></div>
     </div>
@@ -323,7 +323,7 @@ video{display:block;width:100%;height:auto}
 <!-- ================= CAPABILITIES ================= -->
 <section id="capabilities">
   <div class="wrap center">
-    <h2 class="reveal">184 skills. One instruction set each.</h2>
+    <h2 class="reveal">185 skills. One instruction set each.</h2>
     <p class="body reveal" style="margin:0 auto 0;text-align:center">
       Not prompt snippets. Every skill carries state management, verification logic and
       error handling, so the work survives being handed between sessions and between tools.
@@ -394,8 +394,8 @@ video{display:block;width:100%;height:auto}
     <h2 class="reveal center" style="margin-bottom:8px">By the numbers</h2>
     <table class="reveal">
       <tr><th>Version</th><td>1.2.0</td></tr>
-      <tr><th>Skills</th><td>184 with all bundles installed. 69 core, plus 68 GSD, 20 HyperFrames, 9 Super Intelligence, 6 Brain, 5 Cursor, 4 M0 and 3 Cognee.</td></tr>
-      <tr><th>Commands</th><td>279. 37 core, plus 242 generated locally at install.</td></tr>
+      <tr><th>Skills</th><td>185 with all bundles installed. 70 core, plus 68 GSD, 20 HyperFrames, 9 Super Intelligence, 6 Brain, 5 Cursor, 4 M0 and 3 Cognee.</td></tr>
+      <tr><th>Commands</th><td>280. 38 core, plus 242 generated locally at install.</td></tr>
       <tr><th>Agents</th><td>34. 10 core, plus 24 in the GSD bundle.</td></tr>
       <tr><th>Personas</th><td>389 across 9 departments, each behind an evidence-validation gate.</td></tr>
       <tr><th>Editors</th><td>Claude Code, Cursor, Codex, and any AGENTS.md-compatible tool.</td></tr>

--- a/index.html
+++ b/index.html
@@ -337,7 +337,7 @@ video{display:block;width:100%;height:auto}
       <div>
         <span class="chip flag">Flagship &middot; version 1.2.0</span>
         <h2>CoCo turns your editor into an engineering department.</h2>
-        <p class="body" style="max-width:56ch">389 experts deliberate. Then 184 skills ship
+        <p class="body" style="max-width:56ch">389 experts deliberate. Then 185 skills ship
           the decision.</p>
         <div class="links" style="margin-top:20px;display:flex;gap:22px;flex-wrap:wrap">
           <button type="button" class="arrow" id="film-trigger" data-film-trigger data-video="assets/site/coco-ads-launch.mp4" data-poster="assets/site/coco-ads-launch-poster.jpg" style="background:none;border:0;cursor:pointer;font-family:inherit;padding:0;color:var(--link)">Watch the film (20s)</button>
@@ -403,7 +403,7 @@ video{display:block;width:100%;height:auto}
         <div>
           <span class="chip flag">Flagship &middot; available now</span>
           <h3>CoCo</h3>
-          <span class="fine stage-note">Version 1.2.0 &middot; MIT core &middot; 184 skills</span>
+          <span class="fine stage-note">Version 1.2.0 &middot; MIT core &middot; 185 skills</span>
           <p>The advisory board and skills library described above. Installs into Claude
             Code, Cursor, or Codex in about ninety seconds and keeps every decision on your
             own machine.</p>


### PR DESCRIPTION
## Summary

Landing `skills/local-llm` + `commands/eng/local-llm.md` in #110 moved the real totals and left the published figures stale. This site's whole premise is that its numbers are verifiable against the repo, so a wrong count is a correctness bug, not cosmetics.

Verified against `scripts/build-index.py` on `main`: **185 skills, 38 core commands.**

| Claim | Was | Now |
|---|---|---|
| Skills (7 places, incl. OG/Twitter meta) | 184 | **185** |
| Skills breakdown, core | 69 | **70** |
| Commands, core | 37 | **38** |
| Commands, published total | 279 | **280** |

Bundle figures unchanged. `70 + 68 + 20 + 9 + 6 + 5 + 4 + 3 = 185`, and `38 + 242 = 280`. Arithmetic checked, not assumed.

## Test plan

- [x] `scripts/build-index.py` on main reports 185 / 38 — the source of both numbers
- [x] `tests/smoke.sh` — 19 passed, 0 failed
- [x] Grepped both pages for every stale form (`184 skills`, `>184`, `279.`, `>279<`, `37 core`) — zero remaining