### PR TITLE
fix(ci): cover hermes/vscode adapters in lint and smoke gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,9 @@ jobs:
 
       - name: Adapter smoke test (dry-run)
         run: |
-          for adapter in claude-code cursor vscode codex generic; do
+          for adapter in claude-code cursor vscode codex generic hermes; do
+            # hermes ships via PR #118; skip until it lands on main.
+            [ -d "adapters/$adapter" ] || { echo "SKIP: $adapter (not present)"; continue; }
             echo "--- testing $adapter (dry-run) ---"
             bash adapters/$adapter/install.sh --dry-run > /tmp/$adapter.out 2>&1 || {
               echo "FAIL: $adapter"

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -27,7 +27,9 @@ test -f docs/by-domain/pm.md && pass "docs/by-domain/pm.md generated" || fail "d
 
 echo ""
 echo "=== Smoke test: adapters dry-run ==="
-for adapter in claude-code cursor vscode codex generic; do
+for adapter in claude-code cursor vscode codex generic hermes; do
+  # hermes ships via PR #118; skip until it lands on main.
+  [ -d "adapters/$adapter" ] || { echo "SKIP: $adapter (not present)"; continue; }
   bash adapters/$adapter/install.sh --dry-run > /tmp/$adapter.out 2>&1 \
     && pass "adapters/$adapter/install.sh --dry-run" \
     || fail "adapters/$adapter/install.sh --dry-run"


### PR DESCRIPTION
## What
- Extend KNOWN_ADAPTERS in lint-frontmatter.yml: claude-code, cursor, codex, generic → + hermes, vscode. Previously any SKILL.md declaring supports:[hermes] would fail lint (verified by simulation; currently dormant because no skill declares them yet).
- Add hermes to the adapter dry-run smoke loop in ci.yml AND tests/smoke.sh (third inline copy found per review).
- Both loops guarded with [ -d adapters/ ] || SKIP so this lands cleanly on main before #118 merges. Guards are self-removing once #118 is on main.

## Verification
- tests/smoke.sh on main-state tree: 19 passed / 0 failed, hermes SKIPs cleanly.
- Same suite on a tree with adapters/hermes present: 20/20 PASS.
- bash -n syntax checks pass.

## Review
Approved with amendments by @dev (A1: patch all inline copies; ordering decision: exists-guard over merge-order inversion). Follow-up task to strip guards recorded.