### PR TITLE
feat: goal skill — persistent cross-tool project objective + /coco-goal command

### DIFF
--- a/commands/INDEX.md
+++ b/commands/INDEX.md
@@ -2,7 +2,13 @@
 
 Auto-generated. Run `python3 scripts/build-index.py` to refresh.
 
-**Total: 38 commands across 6 namespaces.**
+**Total: 39 commands across 7 namespaces.**
+
+## coco
+
+| Slash | Description |
+|-------|-------------|
+| [`/coco:goal`](coco/goal.md) | Set, check, or complete the persistent project goal stored in .goal.md. Trigger as /coco-goal or /coco:goal. |
 
 ## design
 

--- a/commands/coco/goal.md
+++ b/commands/coco/goal.md
@@ -1,0 +1,27 @@
+---
+allowed-tools: Read, Write, Edit, Glob
+argument-hint: "<objective> | status | done"
+description: Set, check, or complete the persistent project goal stored in .goal.md. Trigger as /coco-goal or /coco:goal.
+---
+
+# Coco Goal
+
+Manage the persistent project goal in `.goal.md` at the repository root. Full
+conventions: the \`goal\` skill. Arguments: **$ARGUMENTS**
+
+## Routing
+
+- Empty arguments or `status` — read `.goal.md` and report the objective,
+  status, and latest progress entries. No file means no goal is set.
+- Any other text — treat it as a new objective. If an `active` goal already
+  exists, show it and ask whether to complete, pause, or replace it; never
+  silently replace. Otherwise write `.goal.md` with `status: active` and
+  today's date.
+- `done` — set `status: done` only if the objective has actually been
+  achieved; verify before writing.
+
+## Rules
+
+- One active goal per repository. The file is the source of truth.
+- Append progress notes after each work session; never rewrite past entries.
+- Only create a goal when explicitly asked; ordinary tasks are not goals.

--- a/docs/by-domain/meta.md
+++ b/docs/by-domain/meta.md
@@ -2,7 +2,7 @@
 
 Auto-generated view. Filtered to `domain: meta` skills.
 
-**6 skills.**
+**7 skills.**
 
 | Skill | Description |
 |-------|-------------|
@@ -10,5 +10,6 @@ Auto-generated view. Filtered to `domain: meta` skills.
 | [coco-cli](../../skills/coco-cli/SKILL.md) | Install, update, version-check, or uninstall the Coco open-source AI workflow framework via its CLI (cocosuperintelligence, run with npx). Use when setting up Coco on a machine, pulling the latest int |
 | [coco-loop](../../skills/coco-loop/SKILL.md) | Start a safe, governed autonomous loop from a plain-language goal. Use when the user says /coco-loop, "run an autonomous loop", "keep my build green for N hours", "work on X autonomously for a while", |
 | [find-skills](../../skills/find-skills/SKILL.md) | Helps users discover and install agent skills when they ask questions like "how do I do X", "find a skill for X", "is there a skill that can...", or express interest in extending capabilities. This sk |
+| [goal](../../skills/goal/SKILL.md) | Persistent project goal that survives across sessions and tools. Use when someone asks to "set a goal", "what is my goal", "goal status", "keep working on X until done", "resume the goal", or wants wo |
 | [skill-creator](../../skills/skill-creator/SKILL.md) | Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends Claude's capabilities with specialized knowledge, workfl |
 | [writing-skills](../../skills/writing-skills/SKILL.md) | Use when creating new skills, editing existing skills, or verifying skills work before deployment |

--- a/skills/INDEX.md
+++ b/skills/INDEX.md
@@ -2,7 +2,7 @@
 
 Auto-generated. Run `python3 scripts/build-index.py` to refresh.
 
-**Total: 185 skills** — 70 core, 115 across 7 bundles.
+**Total: 186 skills** — 71 core, 115 across 7 bundles.
 
 ## Design (15)
 
@@ -67,7 +67,7 @@ Auto-generated. Run `python3 scripts/build-index.py` to refresh.
 | [workflow-routing](workflow-routing/SKILL.md) | Use at the start of any task to route between Superpowers skills and GSD commands based on project state, task scope, and context signals. Fires before other sk |
 | [writing-plans](writing-plans/SKILL.md) | Use when you have a spec or requirements for a multi-step task, before touching code |
 
-## Meta (6)
+## Meta (7)
 
 | Skill | Description |
 |-------|-------------|
@@ -75,6 +75,7 @@ Auto-generated. Run `python3 scripts/build-index.py` to refresh.
 | [coco-cli](coco-cli/SKILL.md) | Install, update, version-check, or uninstall the Coco open-source AI workflow framework via its CLI (cocosuperintelligence, run with npx). Use when setting up C |
 | [coco-loop](coco-loop/SKILL.md) | Start a safe, governed autonomous loop from a plain-language goal. Use when the user says /coco-loop, "run an autonomous loop", "keep my build green for N hours |
 | [find-skills](find-skills/SKILL.md) | Helps users discover and install agent skills when they ask questions like "how do I do X", "find a skill for X", "is there a skill that can...", or express int |
+| [goal](goal/SKILL.md) | Persistent project goal that survives across sessions and tools. Use when someone asks to "set a goal", "what is my goal", "goal status", "keep working on X unt |
 | [skill-creator](skill-creator/SKILL.md) | Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends Claude's capabil |
 | [writing-skills](writing-skills/SKILL.md) | Use when creating new skills, editing existing skills, or verifying skills work before deployment |
 

--- a/skills/goal/SKILL.md
+++ b/skills/goal/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: goal
+description: Persistent project goal that survives across sessions and tools. Use when someone asks to "set a goal", "what is my goal", "goal status", "keep working on X until done", "resume the goal", or wants work to continue across sessions until an objective is achieved. File-backed (.goal.md at project root); shared by every Coco-installed tool working in that repository.
+domain: meta
+---
+
+# Goal — persistent project objective
+
+A goal is a single objective the agent keeps pursuing across turns and
+sessions until it is marked done. Inspired by Prime Agent's thread goal:
+state lives outside any one conversation, so any tool with this skill
+installed (Claude Code, Cursor, Codex, ...) picks up where another left off.
+
+## State file
+
+One file per project: `.goal.md` in the repository root. Human-readable and
+human-editable on purpose — pause, resume, edit, and clear are controlled by
+the user editing the file directly.
+
+```markdown
+---
+objective: Ship release notes for v2.3
+status: active        # active | paused | done
+created: 2026-08-22
+---
+
+## Progress
+- 2026-08-22 14:02 — drafted changelog from git log
+```
+
+## API
+
+- **get** — read `.goal.md`. No file means no goal is set. Report the
+  objective, status, and latest progress entries when asked about goal status.
+- **create(objective)** — write `.goal.md` with `status: active` and today's
+  date. If an `active` goal already exists, do NOT silently replace it; show
+  it and ask whether to complete, pause, or replace. Only create a goal when
+  the user explicitly asks for a persistent goal; do not infer goals from
+  ordinary tasks.
+- **update(note)** — append one dated line to `## Progress` after each
+  meaningful work session toward the goal. Keep notes short and factual.
+- **complete()** — set `status: done`. Only when the objective has actually
+  been achieved and no required work remains — not because the session is
+  ending or momentum ran out.
+
+## Session behavior
+
+At the start of a session in a repo containing `.goal.md`:
+
+- `status: active` — surface the objective to the user and continue working
+  toward it before starting unrelated work. Append a progress note when you
+  stop.
+- `status: paused` — mention it exists; resume only if the user asks.
+- `status: done` — leave it as history; offer to archive or replace.
+
+## Rules
+
+- One active goal per repository. The file is the source of truth — never keep
+  goal state only in conversation memory.
+- Never delete or rewrite past progress lines; append.
+- Completion must reflect reality. An agent that marks a half-finished goal
+  done defeats the entire mechanism.


### PR DESCRIPTION
## What

Ports Prime Agent's thread-goal concept into a tool-agnostic Coco skill plus a slash command.

## The skill (`skills/goal/SKILL.md`)

A single active objective per repository, persisted in `.goal.md` at the project root so it survives across sessions **and across tools** — Claude Code can set a goal that Codex or Cursor resumes later.

Mirrors the original API and discipline rules:

- `get` / `create` / `update` (progress notes) / `complete`
- create only when the user explicitly asks for a persistent goal; never infer from ordinary tasks
- complete only when truly achieved
- pause/clear are user-controlled by editing the file directly
- session-start behavior: surface an active goal before unrelated work

## The command (`commands/coco/goal.md`, new `coco` namespace)

Dispatcher routing `status` / objective text / `done` to the same file conventions. Renders as `/coco:goal` in Claude Code; triggers as plain `/coco-goal` text elsewhere.

## Verification

- `tests/smoke.sh`: 19/19 pass on this branch
- `scripts/build-index.py` regenerated (186 skills · 39 commands)
- Manually installed via existing adapters: symlinked into `~/.claude/skills/goal` and `~/.cursor/skills/goal`; also verified loadable by pi (`~/.pi/agent/skills`) and hermes (`~/.hermes/skills`) local-skill loaders

## Notes

- State file is human-readable markdown with YAML frontmatter — no new dependencies, no code to maintain.
- Codex/AGENTS.md tools pick skills up per-project via `adapters/codex/install.sh`.