### PR TITLE
feat(ci): asset-count single source of truth (docs/asset-counts.json + drift gate)

### DIFF
--- a/.claude-plugin.json
+++ b/.claude-plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "coco",
   "displayName": "Coco",
-  "description": "An entire team. Wherever your AI lives. This install delivers 68 skills, 37 commands and 10 agents. System bundles are opt-in via `install.sh --systems <name>`, and enabling every bundle reaches 179 skills, 279 commands and 34 agents for project orchestration, knowledge tracking, and multi-agent pipelines. Open-core, vendor-neutral.",
+  "description": "An entire team. Wherever your AI lives. This install delivers 70 skills, 38 commands and 10 agents. System bundles are opt-in via `install.sh --systems <name>`, and enabling every bundle reaches 185 skills, 280 commands and 34 agents for project orchestration, knowledge tracking, and multi-agent pipelines. Open-core, vendor-neutral.",
   "version": "1.2.0",
   "author": "Coco Inc",
   "license": "SEE LICENSE IN LICENSE",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,9 @@ jobs:
           fi
           echo "INDEX files up to date."
 
+      - name: Verify shipped asset counts match generated truth
+        run: bash tests/check-asset-counts.sh
+
       - name: Bundle install gate (every advertised bundle must change the install plan)
         run: |
           # Each adapter manifest declares supports_systems. This gate makes that declaration

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Open-core (MIT core · proprietary Super Intelligence) · installs in 90 seconds
 
 [![License: Open-core](https://img.shields.io/badge/License-Open--core-yellow.svg?style=for-the-badge)](LICENSE)
 [![Version](https://img.shields.io/badge/version-1.2.0-blue?style=for-the-badge)](CHANGELOG.md)
-[![Skills](https://img.shields.io/badge/skills-149-emerald?style=for-the-badge)](skills/)
+[![Skills](https://img.shields.io/badge/skills-185-emerald?style=for-the-badge)](skills/)
 [![Commands](https://img.shields.io/badge/commands-280-indigo?style=for-the-badge)](commands/)
 [![Personas](https://img.shields.io/badge/personas-389-violet?style=for-the-badge)](systems/superintelligence/)
 [![CI](https://img.shields.io/github/actions/workflow/status/coco-research/coco/ci.yml?branch=main&style=for-the-badge&label=CI)](https://github.com/coco-research/coco/actions)
@@ -225,7 +225,7 @@ A standard install equips your workspace with a lightweight core; full activatio
 </table>
 
 <div align="center">
-  <sub><strong>Core install:</strong> 130 active assets (68 Skills, 37 Commands, 10 Agents, 15 Rules)</sub><br>
+  <sub><strong>Core install:</strong> 133 active assets (70 Skills, 38 Commands, 10 Agents, 15 Rules)</sub><br>
   <sub><strong>Orchestration bundles:</strong> <strong>+68 GSD skills</strong> · <strong>+24 GSD agents</strong> · <strong>+6 Brain skills</strong> · <strong>+9 Super Intelligence skills</strong> · <strong>+242 SI commands</strong> · <strong>3 Workflows</strong></sub>
 </div>
 
@@ -694,7 +694,7 @@ npx cocosuperintelligence update
 <tr><td><strong>Telemetry / SaaS</strong></td><td>None — 100% local files</td></tr>
 </table>
 
-<sub>Core install ships 68 skills + 37 commands + 10 agents + 15 rules (130 active assets). The totals above reflect a full install with every bundle (<code>bash install.sh --systems gsd,brain,cognee,hyperframes,superintelligence</code>). Super Intelligence slash commands are generated locally at install time from the team registries — no command files are transmitted or stored remotely.</sub>
+<sub>Core install ships 70 skills + 38 commands + 10 agents + 15 rules (133 active assets). The totals above reflect a full install with every bundle (<code>bash install.sh --systems gsd,brain,cognee,hyperframes,superintelligence</code>). Super Intelligence slash commands are generated locally at install time from the team registries — no command files are transmitted or stored remotely.</sub>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -682,7 +682,7 @@ npx cocosuperintelligence update
 <table>
 <tr><td><strong>Spec Version</strong></td><td>1.2.0</td></tr>
 <tr><td><strong>License</strong></td><td>Open-core — <a href="LICENSE">MIT</a> core; Super Intelligence is <a href="systems/superintelligence/LICENSE">proprietary</a></td></tr>
-<tr><td><strong>Total Skills</strong></td><td>149 with all bundles installed (66 Core + 68 GSD + 6 Brain + 9 Super Intelligence)</td></tr>
+<tr><td><strong>Total Skills</strong></td><td>185 with all bundles installed (70 Core + 115 Bundle)</td></tr>
 <tr><td><strong>Slash Commands</strong></td><td>280 with all bundles — 38 Core (shipped) + 242 Super Intelligence (225 per-team + 17 cross-team, generated at install)</td></tr>
 <tr><td><strong>Specialized Agents</strong></td><td>34 (10 Core + 24 GSD Bundle)</td></tr>
 <tr><td><strong>Expert Personas</strong></td><td>389 across 9 departments and 70 cells</td></tr>

--- a/docs/asset-counts.json
+++ b/docs/asset-counts.json
@@ -1,7 +1,19 @@
 {
   "schema": 1,
-  "skills": { "total": 185, "core": 70, "bundle": 115 },
-  "commands": { "shipped": 38, "generated_si": 242, "customer_facing": 280, "namespaces": 6 },
-  "agents": { "total": 34, "core": 10 },
+  "skills": {
+    "total": 185,
+    "core": 70,
+    "bundle": 115
+  },
+  "commands": {
+    "shipped": 38,
+    "generated_si": 242,
+    "customer_facing": 280,
+    "namespaces": 6
+  },
+  "agents": {
+    "total": 34,
+    "core": 10
+  },
   "rules": 15
 }

--- a/docs/asset-counts.json
+++ b/docs/asset-counts.json
@@ -1,0 +1,17 @@
+{
+  "schema": 1,
+  "skills": {
+    "total": 185,
+    "core": 70,
+    "bundle": 115
+  },
+  "commands": {
+    "total": 38,
+    "namespaces": 6
+  },
+  "agents": {
+    "total": 34,
+    "core": 10
+  },
+  "rules": 15
+}

--- a/docs/asset-counts.json
+++ b/docs/asset-counts.json
@@ -1,17 +1,7 @@
 {
   "schema": 1,
-  "skills": {
-    "total": 185,
-    "core": 70,
-    "bundle": 115
-  },
-  "commands": {
-    "total": 38,
-    "namespaces": 6
-  },
-  "agents": {
-    "total": 34,
-    "core": 10
-  },
+  "skills": { "total": 185, "core": 70, "bundle": 115 },
+  "commands": { "shipped": 38, "generated_si": 242, "customer_facing": 280, "namespaces": 6 },
+  "agents": { "total": 34, "core": 10 },
   "rules": 15
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cocosuperintelligence",
   "version": "1.2.0",
-  "description": "CoCo Super Intelligence — summon an advisory board of 389 world-class minds inside your AI coding session. A vendor-neutral orchestration layer for Claude Code, Cursor, and Codex: 179 skills, 279 commands, 34 agents, and disk-persistent state. 100% local, no telemetry. Open-core: MIT core, proprietary Super Intelligence.",
+  "description": "CoCo Super Intelligence \u2014 summon an advisory board of 389 world-class minds inside your AI coding session. A vendor-neutral orchestration layer for Claude Code, Cursor, and Codex: 185 skills, 38 commands, 34 agents, and disk-persistent state. 100% local, no telemetry. Open-core: MIT core, proprietary Super Intelligence.",
   "bin": {
     "coco": "bin/coco.js"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cocosuperintelligence",
   "version": "1.2.0",
-  "description": "CoCo Super Intelligence \u2014 summon an advisory board of 389 world-class minds inside your AI coding session. A vendor-neutral orchestration layer for Claude Code, Cursor, and Codex: 185 skills, 38 commands, 34 agents, and disk-persistent state. 100% local, no telemetry. Open-core: MIT core, proprietary Super Intelligence.",
+  "description": "CoCo Super Intelligence \u2014 summon an advisory board of 389 world-class minds inside your AI coding session. A vendor-neutral orchestration layer for Claude Code, Cursor, and Codex: 185 skills, 280 commands, 34 agents, and disk-persistent state. 100% local, no telemetry. Open-core: MIT core, proprietary Super Intelligence.",
   "bin": {
     "coco": "bin/coco.js"
   },

--- a/scripts/build-index.py
+++ b/scripts/build-index.py
@@ -25,6 +25,7 @@ If you add a fifth shape, add it to SKILL_SOURCES below, and check the printed t
 against `find . -name 'SKILL.md' -not -path './.git/*' | wc -l`.
 """
 
+import json
 import os
 import sys
 import pathlib
@@ -353,6 +354,33 @@ def write_by_domain_views(skills):
         print(f'Wrote {out.relative_to(ROOT)}')
 
 
+def write_asset_counts(skills, commands, agents):
+    """Emit docs/asset-counts.json — the single source of truth for asset counts.
+
+    The README badge, package.json description, and prose have drifted apart three
+    times (149 vs 179 vs the real number). This file is generated from the same walk
+    that builds the indexes, so it is correct by construction. A CI gate asserts the
+    badge and package.json agree with it.
+    """
+    core_skills = [s for s in skills if 'bundle' not in s]
+    bundle_skills = [s for s in skills if 'bundle' in s]
+    core_agents = [a for a in agents if 'bundle' not in a]
+    counts = {
+        'schema': 1,
+        'skills': {
+            'total': len(skills),
+            'core': len(core_skills),
+            'bundle': len(bundle_skills),
+        },
+        'commands': {'total': len(commands), 'namespaces': len({c['namespace'] for c in commands})},
+        'agents': {'total': len(agents), 'core': len(core_agents)},
+        'rules': len(list((ROOT / 'rules' / 'cursor-mdc').glob('*.mdc'))),
+    }
+    out = ROOT / 'docs' / 'asset-counts.json'
+    out.write_text(json.dumps(counts, indent=2) + '\n')
+    print(f'Wrote {out.relative_to(ROOT)}')
+
+
 def main():
     skills = collect_skills()
     commands = collect_commands()
@@ -363,6 +391,7 @@ def main():
     write_agents_index(agents)
     write_systems_index(skills, agents)
     write_by_domain_views(skills)
+    write_asset_counts(skills, commands, agents)
     print(f'\nDone. Skills: {len(skills)} · Commands: {len(commands)} · '
           f'Agents: {len(agents)}')
 

--- a/scripts/build-index.py
+++ b/scripts/build-index.py
@@ -354,17 +354,71 @@ def write_by_domain_views(skills):
         print(f'Wrote {out.relative_to(ROOT)}')
 
 
+
+def count_generated_si_commands():
+    """/SI-* commands generated at install from team registries. Not in-repo files.
+
+    Public command total = shipped files + this number.
+    Mira (2026-08-29): customer-facing commands = 280 (38 shipped + 242 generated).
+    38 is a labeled SSoT field (shipped files), not the public total. Do not invent
+    a third number.
+
+    Counted from live inputs, not a hardcoded 242:
+      built teams in systems/superintelligence/registry.json
+      x per-team surface in ai/scripts/build_commands.py
+      + meta family in scripts/build_meta_commands.py (SI.md + SI-Orchestrate + verbs)
+
+    Ponytail: if those generators add a new verb class, this import still tracks
+    because it reads ACTION/IDENTITY/ROSTER/MAINTENANCE and VERBS live.
+    """
+    import importlib.util
+
+    meta_path = ROOT / 'systems' / 'superintelligence' / 'registry.json'
+    n_built = 0
+    if meta_path.exists():
+        teams = json.loads(meta_path.read_text()).get('teams', {})
+        entries = teams.values() if isinstance(teams, dict) else teams
+        n_built = sum(1 for t in entries if isinstance(t, dict) and t.get('built'))
+
+    per_team = 0
+    gen_path = ROOT / 'systems' / 'superintelligence' / 'ai' / 'scripts' / 'build_commands.py'
+    if gen_path.exists():
+        spec = importlib.util.spec_from_file_location('si_build_commands', gen_path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        per_team = (
+            2  # dispatcher + Orchestrate
+            + len(mod.ACTION_VERBS)
+            + len(mod.IDENTITY_VERBS)
+            + len(mod.ROSTER_VERBS)
+            + len(mod.MAINTENANCE_VERBS)
+        )
+
+    meta_family = 0
+    meta_gen = ROOT / 'systems' / 'superintelligence' / 'scripts' / 'build_meta_commands.py'
+    if meta_gen.exists():
+        spec = importlib.util.spec_from_file_location('si_build_meta_commands', meta_gen)
+        mmod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mmod)
+        meta_family = 2 + len(mmod.VERBS)  # SI.md + SI-Orchestrate.md + verbs
+
+    return n_built * per_team + meta_family
+
+
 def write_asset_counts(skills, commands, agents):
     """Emit docs/asset-counts.json — the single source of truth for asset counts.
 
-    The README badge, package.json description, and prose have drifted apart three
-    times (149 vs 179 vs the real number). This file is generated from the same walk
-    that builds the indexes, so it is correct by construction. A CI gate asserts the
-    badge and package.json agree with it.
+    Two command layers (do not collapse them):
+      commands.shipped   — in-repo command files (collect_commands)
+      commands.generated_si — /SI-* generated at install
+      commands.customer_facing — public total = shipped + generated
+    README / package.json public claims must use commands.customer_facing, never shipped.
     """
     core_skills = [s for s in skills if 'bundle' not in s]
     bundle_skills = [s for s in skills if 'bundle' in s]
     core_agents = [a for a in agents if 'bundle' not in a]
+    shipped = len(commands)
+    generated = count_generated_si_commands()
     counts = {
         'schema': 1,
         'skills': {
@@ -372,13 +426,19 @@ def write_asset_counts(skills, commands, agents):
             'core': len(core_skills),
             'bundle': len(bundle_skills),
         },
-        'commands': {'total': len(commands), 'namespaces': len({c['namespace'] for c in commands})},
+        'commands': {
+            'shipped': shipped,
+            'generated_si': generated,
+            'customer_facing': shipped + generated,
+            'namespaces': len({c['namespace'] for c in commands}),
+        },
         'agents': {'total': len(agents), 'core': len(core_agents)},
         'rules': len(list((ROOT / 'rules' / 'cursor-mdc').glob('*.mdc'))),
     }
     out = ROOT / 'docs' / 'asset-counts.json'
     out.write_text(json.dumps(counts, indent=2) + '\n')
     print(f'Wrote {out.relative_to(ROOT)}')
+
 
 
 def main():

--- a/tests/check-asset-counts.sh
+++ b/tests/check-asset-counts.sh
@@ -2,9 +2,16 @@
 # Guard: shipped asset counts must agree with the generated truth.
 #
 # docs/asset-counts.json is produced by scripts/build-index.py from a full walk of
-# the tree, so it is correct by construction. This gate fails when any *shipped*
+# the tree, so it is correct by construction. This gate fails when any *public*
 # count — README badge, package.json description, README prose tables — drifts
-# from it. Run from repo root: bash tests/check-asset-counts.sh
+# from it.
+#
+# Command layers (Mira, 2026-08-29):
+#   commands.shipped   = in-repo command files (labeled field, not the public total)
+#   commands.generated_si = /SI-* commands generated at install from team registries
+#   commands.customer_facing = public total = shipped + generated_si (280 = 38 + 242)
+# Do not stamp the public command count to commands.shipped.
+# Run from repo root: bash tests/check-asset-counts.sh
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
@@ -18,11 +25,19 @@ if [ ! -f docs/asset-counts.json ]; then
 fi
 
 SKILLS=$(python3 -c "import json;print(json.load(open('docs/asset-counts.json'))['skills']['total'])")
-COMMANDS=$(python3 -c "import json;print(json.load(open('docs/asset-counts.json'))['commands']['total'])")
+COMMANDS=$(python3 -c "import json;print(json.load(open('docs/asset-counts.json'))['commands']['customer_facing'])")
+SHIPPED=$(python3 -c "import json;print(json.load(open('docs/asset-counts.json'))['commands']['shipped'])")
+GENERATED=$(python3 -c "import json;print(json.load(open('docs/asset-counts.json'))['commands']['generated_si'])")
 AGENTS=$(python3 -c "import json;print(json.load(open('docs/asset-counts.json'))['agents']['total'])")
 
 echo "=== truth: docs/asset-counts.json ==="
-echo "  skills=$SKILLS commands=$COMMANDS agents=$AGENTS"
+echo "  skills=$SKILLS commands.customer_facing=$COMMANDS (public) shipped=$SHIPPED generated=$GENERATED agents=$AGENTS"
+
+if [ "$COMMANDS" != "$((SHIPPED + GENERATED))" ]; then
+  fail_ "commands.customer_facing ($COMMANDS) != shipped ($SHIPPED) + generated ($GENERATED)"
+else
+  pass "commands.customer_facing == shipped + generated"
+fi
 
 echo ""
 echo "=== README badge ==="
@@ -37,36 +52,45 @@ else
   pass "no numeric skills badge found (nothing to check)"
 fi
 
+BADGE_COMMANDS=$(grep -oE 'shields\.io/badge/commands-[0-9]+' README.md | grep -oE '[0-9]+$' | head -1 || true)
+if [ -n "$BADGE_COMMANDS" ]; then
+  if [ "$BADGE_COMMANDS" = "$COMMANDS" ]; then
+    pass "commands badge ($BADGE_COMMANDS) matches public total"
+  else
+    fail_ "README commands badge says $BADGE_COMMANDS, public total is $COMMANDS (do not stamp shipped=$SHIPPED as public)"
+  fi
+else
+  pass "no numeric commands badge found (nothing to check)"
+fi
+
 echo ""
 echo "=== package.json description ==="
 PKG_DESC=$(python3 -c "import json;print(json.load(open('package.json'))['description'])")
-for n in $(printf '%s' "$PKG_DESC" | grep -oE '[0-9]+ (skills|commands|agents)' | grep -oE '^[0-9]+'); do :; done
-# Check each "<N> <word>" claim in the description against the JSON.
 while read -r n word; do
   [ -n "$n" ] || continue
   case "$word" in
     skills)   [ "$n" = "$SKILLS" ]   || fail_ "package.json claims $n skills, truth is $SKILLS" ;;
-    commands) [ "$n" = "$COMMANDS" ] || fail_ "package.json claims $n commands, truth is $COMMANDS" ;;
+    commands)
+      if [ "$n" = "$COMMANDS" ]; then
+        :
+      elif [ "$n" = "$SHIPPED" ] && [ "$SHIPPED" != "$COMMANDS" ]; then
+        fail_ "package.json stamps public commands to shipped files ($n); public total is $COMMANDS"
+      else
+        fail_ "package.json claims $n commands, public total is $COMMANDS"
+      fi
+      ;;
     agents)   [ "$n" = "$AGENTS" ]   || fail_ "package.json claims $n agents, truth is $AGENTS" ;;
   esac
-done <<EOF
+done <<CLAIMS
 $(printf '%s' "$PKG_DESC" | grep -oE '[0-9]+ (skills|commands|agents)' || true)
-EOF
+CLAIMS
 grep -qE '[0-9]+ (skills|commands|agents)' <<<"$PKG_DESC" \
-  && pass "package.json count claims all match" \
+  && pass "package.json count claims all match public totals" \
   || pass "package.json makes no count claims (fine)"
 
 echo ""
 echo "=== README prose asset table ==="
-# The <td><h3>N</h3>...<sub>Skills</sub></td> block. Extract pairs and compare.
-PROSE_SKILLS=$(python3 - "$SKILLS" <<'PY'
-import re, sys
-text = open('README.md').read()
-truth = sys.argv[1]
-m = re.search(r'<h3>(\d+)</h3><sub>Skills</sub>', text)
-print(m.group(1) if m else '')
-PY
-)
+PROSE_SKILLS=$(python3 -c "import re; t=open('README.md').read(); m=re.search(r'<h3>(\\d+)</h3><sub>Skills</sub>', t); print(m.group(1) if m else '')")
 if [ -n "$PROSE_SKILLS" ]; then
   [ "$PROSE_SKILLS" = "$SKILLS" ] && pass "prose Skills cell matches" \
     || fail_ "README prose Skills cell says $PROSE_SKILLS, truth is $SKILLS"
@@ -74,11 +98,33 @@ else
   pass "no prose Skills cell found (nothing to check)"
 fi
 
+PROSE_COMMANDS=$(python3 -c "import re; t=open('README.md').read(); m=re.search(r'<h3>(\\d+)</h3><sub>Slash Commands</sub>', t); print(m.group(1) if m else '')")
+if [ -n "$PROSE_COMMANDS" ]; then
+  [ "$PROSE_COMMANDS" = "$COMMANDS" ] && pass "prose Slash Commands cell matches public total" \
+    || fail_ "README prose Slash Commands cell says $PROSE_COMMANDS, public total is $COMMANDS"
+else
+  pass "no prose Slash Commands cell found (nothing to check)"
+fi
+
+
+echo ""
+echo "=== .claude-plugin.json description ==="
+if [ -f .claude-plugin.json ]; then
+  if python3 tests/check-plugin-counts.py; then
+    pass "plugin json customer-facing counts match"
+  else
+    fail_ "plugin json customer-facing counts mismatch"
+  fi
+else
+  pass "no .claude-plugin.json (nothing to check)"
+fi
+
 echo ""
 echo "=== Summary ==="
 if [ "$fail" -eq 0 ]; then
-  echo "  all shipped counts agree with docs/asset-counts.json"
+  echo "  all shipped public counts agree with docs/asset-counts.json"
   exit 0
 fi
-echo "  fix by regenerating indexes AND updating README/package.json to match"
+echo "  fix by regenerating indexes AND updating README/package.json to match public totals"
+echo "  (commands.shipped is a labeled field; do not use it as the public command count)"
 exit 1

--- a/tests/check-asset-counts.sh
+++ b/tests/check-asset-counts.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Guard: shipped asset counts must agree with the generated truth.
+#
+# docs/asset-counts.json is produced by scripts/build-index.py from a full walk of
+# the tree, so it is correct by construction. This gate fails when any *shipped*
+# count — README badge, package.json description, README prose tables — drifts
+# from it. Run from repo root: bash tests/check-asset-counts.sh
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+fail=0
+fail_() { echo "  FAIL: $1"; fail=1; }
+pass() { echo "  PASS: $1"; }
+
+if [ ! -f docs/asset-counts.json ]; then
+  echo "docs/asset-counts.json missing — run python3 scripts/build-index.py"
+  exit 1
+fi
+
+SKILLS=$(python3 -c "import json;print(json.load(open('docs/asset-counts.json'))['skills']['total'])")
+COMMANDS=$(python3 -c "import json;print(json.load(open('docs/asset-counts.json'))['commands']['total'])")
+AGENTS=$(python3 -c "import json;print(json.load(open('docs/asset-counts.json'))['agents']['total'])")
+
+echo "=== truth: docs/asset-counts.json ==="
+echo "  skills=$SKILLS commands=$COMMANDS agents=$AGENTS"
+
+echo ""
+echo "=== README badge ==="
+BADGE_SKILLS=$(grep -oE 'shields\.io/badge/skills-[0-9]+' README.md | grep -oE '[0-9]+$' | head -1 || true)
+if [ -n "$BADGE_SKILLS" ]; then
+  if [ "$BADGE_SKILLS" = "$SKILLS" ]; then
+    pass "skills badge ($BADGE_SKILLS) matches"
+  else
+    fail_ "README skills badge says $BADGE_SKILLS, disk truth is $SKILLS"
+  fi
+else
+  pass "no numeric skills badge found (nothing to check)"
+fi
+
+echo ""
+echo "=== package.json description ==="
+PKG_DESC=$(python3 -c "import json;print(json.load(open('package.json'))['description'])")
+for n in $(printf '%s' "$PKG_DESC" | grep -oE '[0-9]+ (skills|commands|agents)' | grep -oE '^[0-9]+'); do :; done
+# Check each "<N> <word>" claim in the description against the JSON.
+while read -r n word; do
+  [ -n "$n" ] || continue
+  case "$word" in
+    skills)   [ "$n" = "$SKILLS" ]   || fail_ "package.json claims $n skills, truth is $SKILLS" ;;
+    commands) [ "$n" = "$COMMANDS" ] || fail_ "package.json claims $n commands, truth is $COMMANDS" ;;
+    agents)   [ "$n" = "$AGENTS" ]   || fail_ "package.json claims $n agents, truth is $AGENTS" ;;
+  esac
+done <<EOF
+$(printf '%s' "$PKG_DESC" | grep -oE '[0-9]+ (skills|commands|agents)' || true)
+EOF
+grep -qE '[0-9]+ (skills|commands|agents)' <<<"$PKG_DESC" \
+  && pass "package.json count claims all match" \
+  || pass "package.json makes no count claims (fine)"
+
+echo ""
+echo "=== README prose asset table ==="
+# The <td><h3>N</h3>...<sub>Skills</sub></td> block. Extract pairs and compare.
+PROSE_SKILLS=$(python3 - "$SKILLS" <<'PY'
+import re, sys
+text = open('README.md').read()
+truth = sys.argv[1]
+m = re.search(r'<h3>(\d+)</h3><sub>Skills</sub>', text)
+print(m.group(1) if m else '')
+PY
+)
+if [ -n "$PROSE_SKILLS" ]; then
+  [ "$PROSE_SKILLS" = "$SKILLS" ] && pass "prose Skills cell matches" \
+    || fail_ "README prose Skills cell says $PROSE_SKILLS, truth is $SKILLS"
+else
+  pass "no prose Skills cell found (nothing to check)"
+fi
+
+echo ""
+echo "=== Summary ==="
+if [ "$fail" -eq 0 ]; then
+  echo "  all shipped counts agree with docs/asset-counts.json"
+  exit 0
+fi
+echo "  fix by regenerating indexes AND updating README/package.json to match"
+exit 1

--- a/tests/check-asset-counts.sh
+++ b/tests/check-asset-counts.sh
@@ -107,6 +107,27 @@ else
 fi
 
 
+
+echo ""
+echo "=== README Technical Specifications Total Skills ==="
+SPEC_SKILLS=$(python3 -c "import re; t=open('README.md').read(); m=re.search(r'<tr><td><strong>Total Skills</strong></td><td>(\\d+)', t); print(m.group(1) if m else '')")
+if [ -n "$SPEC_SKILLS" ]; then
+  if [ "$SPEC_SKILLS" = "$SKILLS" ]; then
+    pass "spec Total Skills ($SPEC_SKILLS) matches"
+  else
+    fail_ "README spec Total Skills says $SPEC_SKILLS, customer-facing is $SKILLS (do not leave a third skills number)"
+  fi
+else
+  pass "no spec Total Skills row (nothing to check)"
+fi
+# Catch the exact drift class Pike found: a leftover 149 that is not skills.total.
+LEFTOVER_149=$(grep -nE '\b149\b' README.md || true)
+if [ -n "$LEFTOVER_149" ] && [ "$SKILLS" != "149" ]; then
+  fail_ "README still contains 149 (third skills number); customer-facing is $SKILLS: $LEFTOVER_149"
+else
+  pass "no leftover 149 in README"
+fi
+
 echo ""
 echo "=== .claude-plugin.json description ==="
 if [ -f .claude-plugin.json ]; then

--- a/tests/check-plugin-counts.py
+++ b/tests/check-plugin-counts.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Assert .claude-plugin.json last skills/commands claims match customer-facing SSoT."""
+import json, re, sys
+counts = json.load(open('docs/asset-counts.json'))
+skills = str(counts['skills']['total'])
+commands = str(counts['commands']['customer_facing'])
+shipped = str(counts['commands']['shipped'])
+desc = json.load(open('.claude-plugin.json'))['description']
+pairs = re.findall(r'(\d+) (skills|commands|agents)', desc)
+last = {}
+for n, w in pairs:
+    last[w] = n
+if last.get('commands') == shipped and shipped != commands:
+    print(f'FAIL: plugin stamps public commands to shipped files ({shipped}); customer_facing is {commands}')
+    sys.exit(1)
+if last.get('skills') != skills:
+    print(f'FAIL: plugin last skills claim {last.get("skills")}, customer-facing is {skills}')
+    sys.exit(1)
+if last.get('commands') != commands:
+    print(f'FAIL: plugin last commands claim {last.get("commands")}, customer_facing is {commands}')
+    sys.exit(1)
+print(f'PASS: plugin customer-facing skills={skills} commands={commands}')


### PR DESCRIPTION
## Problem
Shipped surfaces disagreed on skill/command counts (README badge 149 vs hero 185 vs package.json 179/279 vs spec table 149). `docs/asset-counts.json` was missing.

## Merge bar (Mira, 2026-08-29)
Customer-facing commands = 38 shipped files + 242 `/SI-*` generated at install = **280**. Do not invent a third number. Do not stamp public commands from a walk of `commands/*.md` (that is 38, not the public figure).
Skills customer-facing = **185** (70 core + 115 bundle). Do not leave 149 as a third skills number.

SSoT labeled fields in `docs/asset-counts.json`:
- `skills.total` = 185 (core 70 + bundle 115)
- `commands.shipped` = 38 (`commands/*/*.md`)
- `commands.generated_si` = 242 (generated at install, not in repo)
- `commands.customer_facing` = 280 (sum; package.json, `.claude-plugin.json`, and README badges/spec)

## Fix
- Generator emits the two command layers from the tree walk + SI registry/generators.
- CI gate fails if public surfaces stamp 38 as the command total, or if README spec Total Skills (or leftover 149) disagrees with skills.total.
- package.json / plugin / README badges / spec table: **185 skills, 280 commands**. README 280 stays.

## Out of scope
GitHub About stays with Nia until Ryan's GitHub sign-in. Website copy is Nia's. Ryan is the review; coco-research cannot self-approve.
