### PR TITLE
feat(cursor): --systems superintelligence writes SI commands to ~/.cursor/commands

### DIFF
--- a/adapters/cursor/install.sh
+++ b/adapters/cursor/install.sh
@@ -4,16 +4,20 @@
 # Usage:
 #   bash adapters/cursor/install.sh
 #   bash adapters/cursor/install.sh --dry-run
+#   bash adapters/cursor/install.sh --systems superintelligence
+#   bash adapters/cursor/install.sh --systems gsd,brain,superintelligence
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 TARGET_HOME="${CURSOR_HOME:-$HOME/.cursor}"
 DRY_RUN=0
+SYSTEMS=()
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --dry-run) DRY_RUN=1 ;;
+    --systems) shift; IFS=',' read -ra SYSTEMS <<< "${1:-}" ;;
     --help|-h) grep '^#' "$0" | sed 's/^# \?//'; exit 0 ;;
     *) echo "Unknown flag: $1" >&2; exit 1 ;;
   esac
@@ -72,9 +76,52 @@ prune_unusable_command_links() {
   done
 }
 
+link_system() {
+  local sys=$1
+  local sys_dir="$REPO_ROOT/systems/$sys"
+  [[ -d "$sys_dir" ]] || { echo "Unknown system: $sys" >&2; exit 1; }
+  if [[ -d "$sys_dir/skills" ]]; then
+    for s in "$sys_dir/skills"/*/; do
+      name=$(basename "$s")
+      link_dir "$s" "$TARGET_HOME/skills/$name"
+    done
+  fi
+  if [[ -d "$sys_dir/commands" ]]; then
+    for c in "$sys_dir/commands"/*.md; do
+      [[ -f "$c" ]] || continue
+      name=$(basename "$c")
+      link_dir "$c" "$TARGET_HOME/commands/$name"
+    done
+  fi
+  # Superintelligence: SI-* commands are generated from per-team registries, not shipped as files.
+  # Written into $TARGET_HOME/commands (CURSOR_HOME, default ~/.cursor/commands) — the same
+  # family claude-code writes to ~/.claude/commands. Do not route Cursor users through the
+  # claude-code adapter to get these files.
+  if [[ -f "$sys_dir/ai/scripts/build_commands.py" ]]; then
+    run mkdir -p "$TARGET_HOME/commands"
+    if [[ $DRY_RUN -eq 1 ]]; then
+      echo "DRY: env COCO_SI_COMMANDS_DIR=$TARGET_HOME/commands python3 $sys_dir/ai/scripts/build_commands.py"
+      if [[ -f "$sys_dir/scripts/build_meta_commands.py" ]]; then
+        echo "DRY: env COCO_SI_COMMANDS_DIR=$TARGET_HOME/commands python3 $sys_dir/scripts/build_meta_commands.py"
+      fi
+      echo "DRY: would generate SI-* commands into $TARGET_HOME/commands"
+    elif command -v python3 >/dev/null 2>&1; then
+      env COCO_SI_COMMANDS_DIR="$TARGET_HOME/commands" python3 "$sys_dir/ai/scripts/build_commands.py"
+      if [[ -f "$sys_dir/scripts/build_meta_commands.py" ]]; then
+        env COCO_SI_COMMANDS_DIR="$TARGET_HOME/commands" python3 "$sys_dir/scripts/build_meta_commands.py"
+      fi
+      echo "Generated SI-* commands (per-team + meta-orchestrator) into $TARGET_HOME/commands"
+    else
+      echo "python3 not found; cannot generate SI-* commands into $TARGET_HOME/commands" >&2
+      exit 1
+    fi
+  fi
+}
+
 echo "Coco · Cursor adapter"
 echo "Source: $REPO_ROOT"
 echo "Target: $TARGET_HOME"
+[[ $DRY_RUN -eq 1 ]] && echo "(dry-run mode)"
 
 # Skills
 for skill in "$REPO_ROOT/skills"/*/; do
@@ -119,6 +166,10 @@ for ns in "$REPO_ROOT/commands"/*/; do
   done
 done
 echo "Commands: $cmd_count linked into $TARGET_HOME/commands"
+
+for sys in "${SYSTEMS[@]:-}"; do
+  [[ -n "$sys" ]] && link_system "$sys"
+done
 
 if [[ $STALE_COUNT -gt 0 ]]; then
   echo

--- a/adapters/cursor/manifest.json
+++ b/adapters/cursor/manifest.json
@@ -10,9 +10,17 @@
   "transforms": [
     "symlink mdc rule files (earlier versions copied them, which made re-runs non-idempotent)",
     "flatten commands/<ns>/<name>.md to <ns>:<name>.md because Cursor does not recurse into subdirectories of ~/.cursor/commands",
-    "prune command symlinks pointing outside the current repo, which dangle after the repo is moved"
+    "prune command symlinks pointing outside the current repo, which dangle after the repo is moved",
+    "accept --systems and generate SI-* commands into ~/.cursor/commands (COCO_SI_COMMANDS_DIR), matching claude-code"
   ],
-  "supports_systems": [],
+  "supports_systems": [
+    "gsd",
+    "brain",
+    "cognee",
+    "hyperframes",
+    "superintelligence",
+    "m0"
+  ],
   "domains": [
     "foundational",
     "pm",

--- a/docs/install.md
+++ b/docs/install.md
@@ -22,7 +22,7 @@ Per-adapter detail. For the 30-second version, see [`README.md`](../README.md).
 |------|--------|
 | `--dry-run` | Print what would happen, don't write |
 | `--help` | Show usage |
-| `--systems gsd,brain` | Install one or more system bundles. Accepted by the claude-code, vscode, codex and generic adapters; the cursor adapter does not accept this flag |
+| `--systems gsd,brain` | Install one or more system bundles. Accepted by every adapter, including cursor (`~/.cursor/commands` for generated SI-* files) |
 
 ---
 
@@ -53,14 +53,19 @@ You should see symlinks pointing back into the cloned repo.
 
 ```bash
 bash adapters/cursor/install.sh
+bash adapters/cursor/install.sh --systems superintelligence
+# equivalent flagship path:
+# bash install.sh --adapter cursor --systems superintelligence
 ```
 
 Wires:
 - `skills/<name>/` → `~/.cursor/skills/<name>/`
 - `rules/cursor-mdc/*.mdc` → `~/.cursor/rules/*.mdc`
 - `adapters/cursor/skills/*` → `~/.cursor/skills/*` (Cursor-specific helpers)
+- `commands/<ns>/<name>.md` → `~/.cursor/commands/<ns>:<name>.md`
+- `--systems superintelligence` generates SI-* command files (including `SI-Decide.md`) into `~/.cursor/commands` via `COCO_SI_COMMANDS_DIR`. Same generators as claude-code; Cursor is not a claude-code install in disguise.
 
-Verify in Cursor: open command palette, search for skill names.
+Verify: `ls ~/.cursor/commands/SI-Decide.md`
 
 ---
 

--- a/tests/cursor-si-commands.sh
+++ b/tests/cursor-si-commands.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Cursor --systems superintelligence must write SI-Decide.md into CURSOR_HOME/commands.
+# Repro: adapters/cursor/install.sh used to reject --systems (Unknown flag / exit 1).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+h=$(mktemp -d)
+trap 'rm -rf "$h"' EXIT
+CURSOR_HOME="$h" bash adapters/cursor/install.sh --systems superintelligence
+if [[ ! -f "$h/commands/SI-Decide.md" ]]; then
+  echo "FAIL: expected $h/commands/SI-Decide.md after --systems superintelligence"
+  ls -la "$h/commands" | head
+  exit 1
+fi
+# When both homes exist, --adapter cursor must still target Cursor, not ~/.claude.
+claude=$(mktemp -d)
+trap 'rm -rf "$h" "$claude"' EXIT
+HOME_TMP=$(mktemp -d)
+mkdir -p "$HOME_TMP/.cursor" "$HOME_TMP/.claude/skills"
+# Direct adapter path (what root install.sh --adapter cursor forwards):
+CURSOR_HOME="$h/cursor-both" bash adapters/cursor/install.sh --systems superintelligence
+if [[ ! -f "$h/cursor-both/commands/SI-Decide.md" ]]; then
+  echo "FAIL: --adapter cursor path did not write SI-Decide.md into CURSOR_HOME"
+  exit 1
+fi
+echo "PASS: SI-Decide.md written to CURSOR_HOME/commands"

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -33,6 +33,17 @@ for adapter in claude-code cursor vscode codex generic; do
     || fail "adapters/$adapter/install.sh --dry-run"
 done
 
+bash adapters/cursor/install.sh --dry-run --systems superintelligence > /tmp/cursor-systems.out 2>&1 \
+  && pass "cursor install.sh --dry-run --systems superintelligence" \
+  || fail "cursor install.sh --dry-run --systems superintelligence"
+
+echo ""
+echo "=== Smoke test: cursor --systems superintelligence ==="
+# Repro: cursor install.sh used to reject --systems (Unknown flag / exit 1), so the
+# README flagship command died whenever ~/.cursor existed. Must write SI-Decide.md
+# into CURSOR_HOME/commands, not ~/.claude/commands.
+bash tests/cursor-si-commands.sh && pass "cursor --systems superintelligence writes SI-Decide.md" || fail "cursor --systems superintelligence did not write SI-Decide.md"
+
 echo ""
 echo "=== Smoke test: root install.sh ==="
 bash install.sh --list > /tmp/list.out 2>&1 && pass "install.sh --list runs" || fail "install.sh --list failed"


### PR DESCRIPTION
## Problem
`adapters/cursor/install.sh` accepted only `--dry-run`/`--help`. Any other flag was `Unknown flag` / exit 1. Auto-detect picks `cursor` when `~/.cursor` exists, so the README flagship command `bash install.sh --systems superintelligence` died before any adapter that supports `--systems` ran. Cursor users were generating SI files by hand (or being sent through the claude-code adapter).

## SUCCEEDS-WHEN (Annu)
- `bash install.sh --adapter cursor --systems superintelligence` exits 0 and writes SI command files (including `SI-Decide.md`) into `~/.cursor/commands` (overridable via `CURSOR_HOME`)
- `bash install.sh --systems superintelligence` must not fail solely because `~/.cursor` exists
- When both `~/.cursor` and `~/.claude` exist, `--adapter cursor --systems superintelligence` still targets Cursor

## Fix
- Cursor adapter parses `--systems` and generates SI-* with `COCO_SI_COMMANDS_DIR=$CURSOR_HOME/commands` (same generators as claude-code, different target)
- `supports_systems` lists the same bundles as the other adapters so the CI bundle gate is honest
- `tests/cursor-si-commands.sh` (run from smoke) asserts `SI-Decide.md` is written under `CURSOR_HOME`

Not folded into #122. Site copy untouched. Local-first; no telemetry.

## Test plan
- [ ] CI `lint-and-test` (bundle gate + smoke cursor SI step)
- [ ] `CURSOR_HOME=/tmp/c bash adapters/cursor/install.sh --systems superintelligence` → `/tmp/c/commands/SI-Decide.md`
- [ ] `bash install.sh --adapter cursor --systems superintelligence` still writes Cursor, not `~/.claude`