### PR TITLE
[site] hide Platform and PDF from public catalog

### DIFF
--- a/coco/index.html
+++ b/coco/index.html
@@ -218,7 +218,6 @@ video{display:block;width:100%;height:auto}
         <ul>
           <li><a href="/#product-coco"><span class="name">CoCo</span><span class="stage">Flagship &middot; available now</span></a></li>
           <li><a href="/#product-m0"><span class="name">CoCo M0</span><span class="stage">In development</span></a></li>
-          <li><a href="/#product-platform"><span class="name">CoCo Platform</span><span class="stage">In development</span></a></li>
           <li><a href="/#product-cococode"><span class="name">CoCo Code</span><span class="stage">In development</span></a></li>
         </ul>
       </div>
@@ -233,7 +232,6 @@ video{display:block;width:100%;height:auto}
         <ul>
           <li><a href="/#product-voice"><span class="name">CoCo Voice</span><span class="stage">Available now &middot; v0.9.4</span></a></li>
           <li><a href="/#product-storydeck"><span class="name">StoryDeck</span><span class="stage">Available now &middot; v1.3.0</span></a></li>
-          <li><a href="/#product-pdf"><span class="name">CoCo PDF</span><span class="stage">In development</span></a></li>
           <li><a href="/#product-teach"><span class="name">CoCo Teach</span><span class="stage">In development</span></a></li>
         </ul>
       </div>

--- a/index.html
+++ b/index.html
@@ -4,15 +4,15 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>CoCo Research: governed AI, built in the open</title>
-<meta name="description" content="One flagship framework, and fourteen more things around it, each shown at its real stage.">
+<meta name="description" content="One flagship framework, and twelve more things around it, each shown at its real stage.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://cocoresearch.org/">
 <meta property="og:title" content="CoCo Research: governed AI, built in the open">
-<meta property="og:description" content="One flagship framework, and fourteen more things around it, each shown at its real stage.">
+<meta property="og:description" content="One flagship framework, and twelve more things around it, each shown at its real stage.">
 <meta property="og:image" content="https://cocoresearch.org/assets/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="CoCo Research: governed AI, built in the open">
-<meta name="twitter:description" content="One flagship framework, and fourteen more things around it, each shown at its real stage.">
+<meta name="twitter:description" content="One flagship framework, and twelve more things around it, each shown at its real stage.">
 <meta name="twitter:image" content="https://cocoresearch.org/assets/og-image.png">
 <style>
 /* ============================================================================
@@ -272,7 +272,6 @@ video{display:block;width:100%;height:auto}
         <ul>
           <li><a href="/#product-coco"><span class="name">CoCo</span><span class="stage">Flagship &middot; available now</span></a></li>
           <li><a href="/#product-m0"><span class="name">CoCo M0</span><span class="stage">In development</span></a></li>
-          <li><a href="/#product-platform"><span class="name">CoCo Platform</span><span class="stage">In development</span></a></li>
           <li><a href="/#product-cococode"><span class="name">CoCo Code</span><span class="stage">In development</span></a></li>
         </ul>
       </div>
@@ -287,7 +286,6 @@ video{display:block;width:100%;height:auto}
         <ul>
           <li><a href="/#product-voice"><span class="name">CoCo Voice</span><span class="stage">Available now &middot; v0.9.4</span></a></li>
           <li><a href="/#product-storydeck"><span class="name">StoryDeck</span><span class="stage">Available now &middot; v1.3.0</span></a></li>
-          <li><a href="/#product-pdf"><span class="name">CoCo PDF</span><span class="stage">In development</span></a></li>
           <li><a href="/#product-teach"><span class="name">CoCo Teach</span><span class="stage">In development</span></a></li>
         </ul>
       </div>
@@ -317,7 +315,7 @@ video{display:block;width:100%;height:auto}
   <div class="wrap">
     <p class="eyebrow reveal">CoCo Research</p>
     <h1 class="reveal">Governed AI,<br>built in the open.</h1>
-    <p class="sub reveal">One flagship framework, and fourteen more things around it, each shown at its real stage.</p>
+    <p class="sub reveal">One flagship framework, and twelve more things around it, each shown at its real stage.</p>
     <div class="cta reveal">
       <a class="btn" href="/coco/">Explore CoCo, the flagship</a>
       <a class="arrow" href="#products">See every product</a>
@@ -354,7 +352,7 @@ video{display:block;width:100%;height:auto}
   <div class="wrap center">
     <h2 class="reveal">What stays the same across every product.</h2>
     <p class="body reveal" style="margin:0 auto;text-align:center">
-      Fifteen things, at fifteen different stages of finished, built by a regulated-risk
+      Thirteen things, at thirteen different stages of finished, built by a regulated-risk
       product leader open-sourcing the agentic AI he designs by day. Four rules hold across
       all of them regardless, and shipping without hand-waving about what still doesn't work
       is one of them.
@@ -379,18 +377,18 @@ video{display:block;width:100%;height:auto}
 <!-- ================= PRODUCTS ================= -->
 <section id="products" class="tint">
   <div class="wrap center">
-    <h2 class="reveal">Fifteen things. Each at its real stage.</h2>
+    <h2 class="reveal">Thirteen things. Each at its real stage.</h2>
     <p class="body reveal" style="margin:0 auto;text-align:center">
-      CoCo, above, is the flagship. Fourteen more things are built around it. Some you can
+      CoCo, above, is the flagship. Twelve more things are built around it. Some you can
       download right now. Some are still in development, and are marked that way rather
       than dressed up. Where a product has no screenshot here, it is because it has not
       been built far enough to have one.
     </p>
 
     <div class="tabs reveal" role="tablist" aria-label="CoCo Research products">
-      <button class="tab" role="tab" id="tab-framework" aria-controls="panel-framework" aria-selected="true">The framework<span class="count">4</span></button>
+      <button class="tab" role="tab" id="tab-framework" aria-controls="panel-framework" aria-selected="true">The framework<span class="count">3</span></button>
       <button class="tab" role="tab" id="tab-connect" aria-controls="panel-connect" aria-selected="false" tabindex="-1">CoCo Connect</button>
-      <button class="tab" role="tab" id="tab-apps" aria-controls="panel-apps" aria-selected="false" tabindex="-1">Desktop apps<span class="count">4</span></button>
+      <button class="tab" role="tab" id="tab-apps" aria-controls="panel-apps" aria-selected="false" tabindex="-1">Desktop apps<span class="count">3</span></button>
       <button class="tab" role="tab" id="tab-research" aria-controls="panel-research" aria-selected="false" tabindex="-1">Research<span class="count">6</span></button>
     </div>
 
@@ -424,14 +422,6 @@ video{display:block;width:100%;height:auto}
             yourself twice. It is what makes the rest feel like one product rather than a
             folder of tools. The write path works today; the daemon and its tools are still
             landing.</p>
-        </div>
-        <div class="tile" id="product-platform">
-          <span class="chip soon">In development</span>
-          <p class="lbl">CoCo Platform</p>
-          <span class="fine stage-note">Running locally, not yet packaged</span>
-          <p>A control plane that exposes CoCo's memory, decisions, and verification to any
-            editor speaking the Model Context Protocol. It runs here every day as a local
-            server. What it does not have yet is an installer anyone else could use.</p>
         </div>
         <div class="tile" id="product-cococode">
           <span class="chip soon">In development</span>
@@ -514,16 +504,6 @@ video{display:block;width:100%;height:auto}
       </div>
 
       <div class="grid cards">
-        <div class="tile" id="product-pdf">
-          <span class="chip soon">In development</span>
-          <p class="lbl">CoCo PDF</p>
-          <span class="fine stage-note">Built, not yet public</span>
-          <p>A desktop PDF editor for the everyday jobs: merge, sign, compress, OCR, redact.
-            Files never leave the machine. It wraps the excellent
-            <a href="https://github.com/Stirling-Tools/Stirling-PDF">Stirling&nbsp;PDF</a> in a
-            native shell rather than reinventing it, and credit for the engine belongs upstream.
-            A build exists; the repository is still private.</p>
-        </div>
         <div class="tile" id="product-teach">
           <span class="chip soon">In development</span>
           <p class="lbl">CoCo Teach</p>


### PR DESCRIPTION
## Summary
- Remove CoCo Platform and CoCo PDF from the public catalog (products overlay + homepage tiles). Platform is not public; PDF is unpromoted.
- Update count copy so the page does not still say fifteen/fourteen after those two are gone (thirteen things, twelve more; framework tab 3; desktop-apps tab 3).
- No flagship CTA change, no install-command change, no README/logo/skill edits.

## Test plan
- [ ] Overlay has no CoCo Platform or CoCo PDF
- [ ] Homepage tiles have no `#product-platform` or `#product-pdf`
- [ ] Remaining products still listed
- [ ] Count copy matches 13 public items
- Pike reviews. Mira signs off copy.