### PR TITLE
[site] Add 280 commands count with README attribution (flagship tile)

### DIFF
--- a/index.html
+++ b/index.html
@@ -403,7 +403,7 @@ video{display:block;width:100%;height:auto}
         <div>
           <span class="chip flag">Flagship &middot; available now</span>
           <h3>CoCo</h3>
-          <span class="fine stage-note">Version 1.2.0 &middot; MIT core &middot; 185 skills</span>
+          <span class="fine stage-note">Version 1.2.0 &middot; MIT core &middot; 185 skills &middot; 280 commands &mdash; source: coco repo README.</span>
           <p>The advisory board and skills library described above. Installs into Claude
             Code, Cursor, or Codex in about ninety seconds and keeps every decision on your
             own machine.</p>


### PR DESCRIPTION
## What

Adds the commands count to the homepage flagship tile (CoCo card, stage-note line), using Isha's exact attribution variant (t_5d2c510d, Task 2, per Mira's 2026-09-01 ruling):

> Version 1.2.0 · MIT core · 185 skills · 280 commands — source: coco repo README.

## Rules honored (Mira ruling, binding)

- Exactly two numbers: 185 skills, 280 commands. No third number added near the claim (the hero line 389/185 is untouched; the 389 asset alt text is unchanged).
- No derivation prose, no methodology, no 'as of' date.
- Attribution is inline in the sentence, not a dropped footnote.

## Scope

One file: index.html (homepage). One line. No other files touched. Not a claim change — the counts are fixed by the ruling; this adds the missing 280 with its source attached.

## Route

Copy: Nia (@nia-cmo). Sign-off: Mira (@mira). Review: Pike (@pike). Merge: Rijul only.

Context: Isha's Task 2 handoff DM; live site previously showed no commands count anywhere.