### PR TITLE
site: 185/280 count-attribution line (card t_395840ce)

### DIFF
--- a/index.html
+++ b/index.html
@@ -339,6 +339,7 @@ video{display:block;width:100%;height:auto}
         <h2>CoCo turns your editor into an engineering department.</h2>
         <p class="body" style="max-width:56ch">389 experts deliberate. Then 185 skills ship
           the decision.</p>
+        <p class="fine" style="max-width:56ch">Counts per the coco repo README (github.com/coco-research/coco): 185 skills, 280 commands.</p>
         <div class="links" style="margin-top:20px;display:flex;gap:22px;flex-wrap:wrap">
           <button type="button" class="arrow" id="film-trigger" data-film-trigger data-video="assets/site/coco-ads-launch.mp4" data-poster="assets/site/coco-ads-launch-poster.jpg" style="background:none;border:0;cursor:pointer;font-family:inherit;padding:0;color:var(--link)">Watch the film (20s)</button>
           <a class="arrow" href="/coco/">Read the full story</a>


### PR DESCRIPTION
## What

Adds one line to the homepage flagship strip, directly under the count sentence ("389 experts deliberate. Then 185 skills ship the decision."):

> Counts per the coco repo README (github.com/coco-research/coco): 185 skills, 280 commands.

Verbatim from kanban card t_395840ce (Isha's handoff per Mira's ruling 2026-09-01). Styled with the existing `.fine` muted class; no other changes.

## Source of record (receipt)

`~/coco-research/README.md` (origin github.com/coco-research/coco), **line 14**: "...then **185 skills**, **280 commands**, and disk-persistent state..." — re-verified by Nia today against the local checkout of this same repo's README.

Corroborating rows, same file: line 23 badge `commands-280`; lines 219–220 (185 Skills / 280 Slash Commands); lines 238, 686. Do **not** cite `~/coco/README.md` (different repo, different counts 59/68).

## Constraints honored (strategy §9 + Mira's ruling)

- Exactly two numbers: 185 and 280. No third number added.
- No derivation prose on the site — "70 Core + 115 Bundle" / "38 Core + 242 Generated" splits stay README-only (grep of index.html: 0 hits).
- Counts remain attached to CoCo SI only — the CoCo Hermes tile (#product-hermes) is untouched and count-free.
- External-copy freeze respected: this PR ships only after Mira signs; not merged before gate is green.

## Sign-off lane

- [ ] Mira — copy sign-off (sentence is fixed verbatim per card; signing covers placement)
- [ ] Pike — [site] review (single-line HTML addition to index.html)
- [ ] Rijul — merge

Closes/reports to kanban card **t_395840ce**.