### PR TITLE
fix(brain): replace inline code generation with stdin-based chroma_worker

### DIFF
--- a/systems/INDEX.md
+++ b/systems/INDEX.md
@@ -10,7 +10,6 @@ Bundles under `systems/` are opt-in via `install.sh --systems <name>`. Directori
 | cognee | `systems/cognee/` | 3 | 0 | 0 | 4 |
 | gsd | `systems/gsd/` | 68 | 24 | 0 | 93 |
 | hyperframes | `systems/hyperframes/` | 20 | 0 | 0 | 928 |
-| learning | `systems/learning/` | 0 | 0 | 0 | 0 |
 | m0 | `systems/m0/` | 4 | 0 | 0 | 9 |
 | superintelligence | `systems/superintelligence/` | 9 | 0 | 0 | 1159 |
 | team | `systems/team/` | 0 | 0 | 0 | 2 |
@@ -20,4 +19,4 @@ Bundles under `systems/` are opt-in via `install.sh --systems <name>`. Directori
 | generic | `adapters/generic/` | 0 | 0 | 0 | 3 |
 | vscode | `adapters/vscode/` | 0 | 0 | 0 | 3 |
 
-> **Advertised as a bundle but installs no artifacts:** `learning`, `team`. These directories hold documentation only, so passing them to `--systems` has no effect.
+> **Advertised as a bundle but installs no artifacts:** `team`. These directories hold documentation only, so passing them to `--systems` has no effect.

--- a/systems/INDEX.md
+++ b/systems/INDEX.md
@@ -6,10 +6,11 @@ Bundles under `systems/` are opt-in via `install.sh --systems <name>`. Directori
 
 | Bundle | Location | Skills | Agents | Commands | Files |
 |--------|----------|-------:|-------:|---------:|------:|
-| brain | `systems/brain/` | 6 | 0 | 0 | 18 |
+| brain | `systems/brain/` | 6 | 0 | 0 | 19 |
 | cognee | `systems/cognee/` | 3 | 0 | 0 | 4 |
 | gsd | `systems/gsd/` | 68 | 24 | 0 | 93 |
 | hyperframes | `systems/hyperframes/` | 20 | 0 | 0 | 928 |
+| learning | `systems/learning/` | 0 | 0 | 0 | 0 |
 | m0 | `systems/m0/` | 4 | 0 | 0 | 9 |
 | superintelligence | `systems/superintelligence/` | 9 | 0 | 0 | 1159 |
 | team | `systems/team/` | 0 | 0 | 0 | 2 |
@@ -19,4 +20,4 @@ Bundles under `systems/` are opt-in via `install.sh --systems <name>`. Directori
 | generic | `adapters/generic/` | 0 | 0 | 0 | 3 |
 | vscode | `adapters/vscode/` | 0 | 0 | 0 | 3 |
 
-> **Advertised as a bundle but installs no artifacts:** `team`. These directories hold documentation only, so passing them to `--systems` has no effect.
+> **Advertised as a bundle but installs no artifacts:** `learning`, `team`. These directories hold documentation only, so passing them to `--systems` has no effect.

--- a/systems/brain/skills/brain/scripts/brain/chroma_worker.py
+++ b/systems/brain/skills/brain/scripts/brain/chroma_worker.py
@@ -1,0 +1,58 @@
+"""ChromaDB worker — reads JSON from stdin, performs upsert, writes JSON to stdout.
+
+Replaces inline f-string code generation in memory_bridge.py.
+Usage: echo '{"op":"upsert","items":[...]}' | python3 chroma_worker.py
+"""
+import json
+import sys
+
+def main():
+    try:
+        data = json.loads(sys.stdin.read())
+    except json.JSONDecodeError as e:
+        print(json.dumps({"status": "error", "message": f"invalid JSON: {e}"}))
+        sys.exit(1)
+
+    op = data.get("op")
+    palace_path = data.get("palace_path")
+    collection_name = data.get("collection_name")
+
+    if not palace_path or not collection_name:
+        print(json.dumps({"status": "error", "message": "missing palace_path or collection_name"}))
+        sys.exit(1)
+
+    try:
+        import chromadb
+        client = chromadb.PersistentClient(path=palace_path)
+        col = client.get_collection(collection_name)
+
+        if op == "upsert":
+            items = data.get("items", [])
+            ids = [item["id"] for item in items]
+            documents = [item["text"] for item in items]
+            metadatas = [item["metadata"] for item in items]
+            col.upsert(ids=ids, documents=documents, metadatas=metadatas)
+            print(json.dumps({"status": "ok", "upserted": len(ids)}))
+
+        elif op == "get_ids":
+            where = data.get("where", {})
+            limit = data.get("limit", 10000)
+            results = col.get(where=where, limit=limit)
+            print(json.dumps({"status": "ok", "ids": results["ids"]}))
+
+        elif op == "stats":
+            project_wing = data.get("project_wing", "")
+            total = col.count()
+            project_ids = col.get(where={"wing": project_wing}, limit=10000)["ids"] if project_wing else []
+            print(json.dumps({"status": "ok", "total": total, "project": len(project_ids)}))
+
+        else:
+            print(json.dumps({"status": "error", "message": f"unknown op: {op}"}))
+            sys.exit(1)
+
+    except Exception as e:
+        print(json.dumps({"status": "error", "message": str(e)[:500]}))
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/systems/brain/skills/brain/scripts/brain/memory_bridge.py
+++ b/systems/brain/skills/brain/scripts/brain/memory_bridge.py
@@ -77,30 +77,38 @@ def _run_chromadb_op(script: str) -> dict | None:
 
 
 def _upsert_drawer_via_subprocess(text: str, wing: str, room: str) -> str | None:
-    """Write one drawer to ChromaDB via subprocess. Returns drawer_id on success."""
+    """Write one drawer to ChromaDB via chroma_worker (stdin JSON). Returns drawer_id on success."""
     drawer_id = _drawer_id(wing, room, text)
     timestamp = _now_iso()
-    # Escape text for safe embedding in Python string
-    escaped_text = json.dumps(text)
-    escaped_meta = json.dumps({
-        "wing": wing, "room": room,
-        "source_file": "brain-sync", "filed_at": timestamp,
+    payload = json.dumps({
+        "op": "upsert",
+        "palace_path": MEMPALACE_PATH,
+        "collection_name": COLLECTION_NAME,
+        "items": [{
+            "id": drawer_id,
+            "text": text,
+            "metadata": {
+                "wing": wing, "room": room,
+                "source_file": "brain-sync", "filed_at": timestamp,
+            },
+        }],
     })
-    script = f"""
-import json, chromadb
-client = chromadb.PersistentClient(path={json.dumps(MEMPALACE_PATH)})
-col = client.get_collection({json.dumps(COLLECTION_NAME)})
-col.upsert(
-    ids=[{json.dumps(drawer_id)}],
-    documents=[{escaped_text}],
-    metadatas=[json.loads({json.dumps(escaped_meta)})],
-)
-print(json.dumps({{"id": {json.dumps(drawer_id)}, "status": "ok"}}))
-"""
-    result = _run_chromadb_op(script)
-    if result and result.get("status") == "ok":
-        return result.get("id")
-    return None
+    try:
+        worker_path = os.path.join(os.path.dirname(__file__), "chroma_worker.py")
+        result = subprocess.run(
+            [MEMPALACE_PYTHON, worker_path],
+            input=payload, capture_output=True, text=True, timeout=30,
+        )
+        if result.returncode != 0:
+            log.warning("memory_bridge: chroma_worker failed — %s", result.stderr[:200])
+            return None
+        data = json.loads(result.stdout)
+        if data.get("status") == "ok":
+            return drawer_id
+        return None
+    except Exception as exc:
+        log.warning("memory_bridge: chroma_worker subprocess error — %s", exc)
+        return None
 
 
 def _batch_upsert_drawers(items: list[dict]) -> int:
@@ -133,30 +141,25 @@ def _batch_upsert_drawers(items: list[dict]) -> int:
         })
 
     # Serialize as JSON so the subprocess script never has raw strings embedded
-    ids_json = json.dumps(ids)
-    documents_json = json.dumps(documents)
-    metadatas_json = json.dumps(metadatas)
     count = len(ids)
 
-    script = f"""
-import json, chromadb
-client = chromadb.PersistentClient(path={json.dumps(MEMPALACE_PATH)})
-col = client.get_collection({json.dumps(COLLECTION_NAME)})
-ids = json.loads({json.dumps(ids_json)})
-documents = json.loads({json.dumps(documents_json)})
-metadatas = json.loads({json.dumps(metadatas_json)})
-col.upsert(ids=ids, documents=documents, metadatas=metadatas)
-print(json.dumps({{"upserted": len(ids), "status": "ok"}}))
-"""
+    payload = json.dumps({
+        "op": "upsert",
+        "palace_path": MEMPALACE_PATH,
+        "collection_name": COLLECTION_NAME,
+        "items": [
+            {"id": ids[i], "text": documents[i], "metadata": metadatas[i]}
+            for i in range(count)
+        ],
+    })
     try:
+        worker_path = os.path.join(os.path.dirname(__file__), "chroma_worker.py")
         result = subprocess.run(
-            [MEMPALACE_PYTHON, "-c", script],
-            capture_output=True, text=True, timeout=60,
+            [MEMPALACE_PYTHON, worker_path],
+            input=payload, capture_output=True, text=True, timeout=60,
         )
         if result.returncode != 0:
-            log.warning(
-                "memory_bridge: batch upsert failed — %s", result.stderr[:200]
-            )
+            log.warning("memory_bridge: batch upsert failed — %s", result.stderr[:200])
             return 0
         data = json.loads(result.stdout)
         if data.get("status") == "ok":
@@ -714,14 +717,27 @@ def verify_sync(db_path: Path, project_slug: str) -> dict:
     result["expected"] = len(expected_ids)
 
     # --- Step 3: fetch all MemPalace drawer IDs for this project wing (ONE subprocess) ---
-    script = f"""
-import json, chromadb
-client = chromadb.PersistentClient(path={json.dumps(MEMPALACE_PATH)})
-col = client.get_collection({json.dumps(COLLECTION_NAME)})
-results = col.get(where={{"wing": {json.dumps(project_slug)}}}, limit=10000)
-print(json.dumps(results["ids"]))
-"""
-    actual_ids_raw = _run_chromadb_op(script)
+    payload = json.dumps({
+        "op": "get_ids",
+        "palace_path": MEMPALACE_PATH,
+        "collection_name": COLLECTION_NAME,
+        "where": {"wing": project_slug},
+        "limit": 10000,
+    })
+    try:
+        worker_path = os.path.join(os.path.dirname(__file__), "chroma_worker.py")
+        result_proc = subprocess.run(
+            [MEMPALACE_PYTHON, worker_path],
+            input=payload, capture_output=True, text=True, timeout=30,
+        )
+        if result_proc.returncode != 0:
+            log.warning("memory_bridge: get_ids failed — %s", result_proc.stderr[:200])
+            actual_ids_raw = None
+        else:
+            actual_ids_raw = json.loads(result_proc.stdout).get("ids")
+    except Exception as exc:
+        log.warning("memory_bridge: get_ids subprocess error — %s", exc)
+        actual_ids_raw = None
     if actual_ids_raw is None:
         log.warning("verify_sync: could not query MemPalace for project '%s'", project_slug)
         # Return partial result with expected count but zeros for actual
@@ -803,15 +819,26 @@ def health_check(db_path: Path, project_slug: str) -> dict:
         )
 
     # --- mempalace section (ONE subprocess for total + project counts) ---
-    mempalace_script = f"""
-import json, chromadb
-client = chromadb.PersistentClient(path={json.dumps(MEMPALACE_PATH)})
-col = client.get_collection({json.dumps(COLLECTION_NAME)})
-total = col.count()
-project = len(col.get(where={{"wing": {json.dumps(project_slug)}}}, limit=10000)["ids"])
-print(json.dumps({{"total": total, "project": project}}))
-"""
-    mempalace_stats = _run_chromadb_op(mempalace_script)
+    health_payload = json.dumps({
+        "op": "stats",
+        "palace_path": MEMPALACE_PATH,
+        "collection_name": COLLECTION_NAME,
+        "project_wing": project_slug,
+    })
+    try:
+        worker_path = os.path.join(os.path.dirname(__file__), "chroma_worker.py")
+        health_proc = subprocess.run(
+            [MEMPALACE_PYTHON, worker_path],
+            input=health_payload, capture_output=True, text=True, timeout=30,
+        )
+        if health_proc.returncode != 0:
+            log.warning("memory_bridge: stats failed — %s", health_proc.stderr[:200])
+            mempalace_stats = None
+        else:
+            mempalace_stats = json.loads(health_proc.stdout)
+    except Exception as exc:
+        log.warning("memory_bridge: stats subprocess error — %s", exc)
+        mempalace_stats = None
     if mempalace_stats is not None:
         report["mempalace"]["available"] = True
         report["mempalace"]["total_drawers"] = mempalace_stats.get("total", 0)


### PR DESCRIPTION
## Summary
- Adds `chroma_worker.py`: subprocess worker that reads JSON from stdin for ChromaDB operations (upsert, get_ids, stats)
- Updates `memory_bridge.py`: all 4 f-string script generation sites replaced with subprocess calls piping JSON to chroma_worker
- Eliminates arbitrary code execution risk from dynamically generated Python strings

## Security Impact
Previously, memory_bridge.py constructed Python code as f-strings and executed them via subprocess. This created an injection vector if any input contained unexpected characters. The new approach uses structured JSON over stdin, making injection impossible.