### PR TITLE
fix(installer): add target prefix validation to prevent symlink traversal

### DIFF
--- a/adapters/claude-code/install.sh
+++ b/adapters/claude-code/install.sh
@@ -44,6 +44,11 @@ link_dir() {
   fi
   # A dangling symlink is removed and relinked. These accumulate whenever the repo moves.
   [[ -L "$dst" ]] && run rm "$dst"
+  # Security: refuse to create symlinks outside TARGET_HOME
+  case "$dst" in
+    "$TARGET_HOME"/*) ;;
+    *) echo "REFUSE: target $dst is outside $TARGET_HOME" >&2; return 1 ;;
+  esac
   run mkdir -p "$(dirname "$dst")"
   run ln -sf "$src" "$dst"
   echo "Linked: $dst -> $src"

--- a/systems/INDEX.md
+++ b/systems/INDEX.md
@@ -10,7 +10,6 @@ Bundles under `systems/` are opt-in via `install.sh --systems <name>`. Directori
 | cognee | `systems/cognee/` | 3 | 0 | 0 | 4 |
 | gsd | `systems/gsd/` | 68 | 24 | 0 | 93 |
 | hyperframes | `systems/hyperframes/` | 20 | 0 | 0 | 928 |
-| learning | `systems/learning/` | 0 | 0 | 0 | 0 |
 | m0 | `systems/m0/` | 4 | 0 | 0 | 9 |
 | superintelligence | `systems/superintelligence/` | 9 | 0 | 0 | 1159 |
 | team | `systems/team/` | 0 | 0 | 0 | 2 |
@@ -20,4 +19,4 @@ Bundles under `systems/` are opt-in via `install.sh --systems <name>`. Directori
 | generic | `adapters/generic/` | 0 | 0 | 0 | 3 |
 | vscode | `adapters/vscode/` | 0 | 0 | 0 | 3 |
 
-> **Advertised as a bundle but installs no artifacts:** `learning`, `team`. These directories hold documentation only, so passing them to `--systems` has no effect.
+> **Advertised as a bundle but installs no artifacts:** `team`. These directories hold documentation only, so passing them to `--systems` has no effect.

--- a/systems/INDEX.md
+++ b/systems/INDEX.md
@@ -10,6 +10,7 @@ Bundles under `systems/` are opt-in via `install.sh --systems <name>`. Directori
 | cognee | `systems/cognee/` | 3 | 0 | 0 | 4 |
 | gsd | `systems/gsd/` | 68 | 24 | 0 | 93 |
 | hyperframes | `systems/hyperframes/` | 20 | 0 | 0 | 928 |
+| learning | `systems/learning/` | 0 | 0 | 0 | 0 |
 | m0 | `systems/m0/` | 4 | 0 | 0 | 9 |
 | superintelligence | `systems/superintelligence/` | 9 | 0 | 0 | 1159 |
 | team | `systems/team/` | 0 | 0 | 0 | 2 |
@@ -19,4 +20,4 @@ Bundles under `systems/` are opt-in via `install.sh --systems <name>`. Directori
 | generic | `adapters/generic/` | 0 | 0 | 0 | 3 |
 | vscode | `adapters/vscode/` | 0 | 0 | 0 | 3 |
 
-> **Advertised as a bundle but installs no artifacts:** `team`. These directories hold documentation only, so passing them to `--systems` has no effect.
+> **Advertised as a bundle but installs no artifacts:** `learning`, `team`. These directories hold documentation only, so passing them to `--systems` has no effect.


### PR DESCRIPTION
## Summary
- Adds case check in `link_dir()` within `adapters/claude-code/install.sh` to refuse creating symlinks outside $TARGET_HOME
- Prevents path traversal attacks where a malicious or misconfigured destination could escape the intended installation directory

## Security Impact
Without this check, a crafted adapter manifest or environment variable could cause the installer to write symlinks to arbitrary filesystem locations. This guard ensures all symlink targets remain within the Claude Code home directory.