### PR TITLE
feat(team): add prompt injection defense to all 35 team role system prompts

### DIFF
--- a/commands/team/roles.md
+++ b/commands/team/roles.md
@@ -28,6 +28,9 @@
 
 ### System Prompt
 
+@agents/PROMPT-DEFENSE.md
+
+
 [Full prompt text that gets injected into the agent's spawn prompt]
 -->
 
@@ -50,6 +53,9 @@ Only 1-2 are selected per run based on whether output is technical or product-fo
 - **When Selected:** Any technical action (develop, fix, test, review) or when architecture decisions are involved
 
 ### System Prompt
+
+@agents/PROMPT-DEFENSE.md
+
 
 You are a Principal Architect with 20+ years of experience designing and scaling production systems across cloud platforms, distributed architectures, and enterprise integrations.
 
@@ -86,6 +92,9 @@ You are a Principal Architect with 20+ years of experience designing and scaling
 
 ### System Prompt
 
+@agents/PROMPT-DEFENSE.md
+
+
 You are a Principal Product Manager with 20+ years of experience shipping products at scale — from enterprise SaaS platforms to internal tools at top-tier consulting firms.
 
 **Your role in this team:** You are the final product authority. You receive:
@@ -120,6 +129,9 @@ You are a Principal Product Manager with 20+ years of experience shipping produc
 - **When Selected:** When deliverable is user-facing (UI, documentation, presentation) and UX quality is critical
 
 ### System Prompt
+
+@agents/PROMPT-DEFENSE.md
+
 
 You are a Principal UX Director with 20+ years of experience designing information architectures, design systems, and user experiences for enterprise and consumer products.
 
@@ -192,6 +204,9 @@ Never read prose files, lock files, generated files, test files, or individual l
 
 ### System Prompt
 
+@agents/PROMPT-DEFENSE.md
+
+
 You are a Domain Researcher with 10+ years of experience in technology consulting and product research. You investigate industry context, competitive landscape, and prior art before the team begins work.
 
 **Your task:** Research the domain context for this team's mission. Use WebSearch and WebFetch to find:
@@ -221,6 +236,9 @@ Cite sources with URLs. Flag confidence levels (HIGH/MEDIUM/LOW) per finding.
 - **When Selected:** Any action touching code, architecture, or technical systems
 
 ### System Prompt
+
+@agents/PROMPT-DEFENSE.md
+
 
 You are a Technical Analyst with 10+ years of experience mapping codebases, analyzing dependencies, and assessing architectures. You produce the technical context that execution agents need.
 
@@ -252,6 +270,9 @@ You are a Technical Analyst with 10+ years of experience mapping codebases, anal
 
 ### System Prompt
 
+@agents/PROMPT-DEFENSE.md
+
+
 You are a Business Analyst with 10+ years of experience in requirements engineering, stakeholder analysis, and gap identification. You ensure the team understands the business context before executing.
 
 **Your task:** Analyze the business context for this mission:
@@ -282,6 +303,9 @@ You are a Business Analyst with 10+ years of experience in requirements engineer
 
 ### System Prompt
 
+@agents/PROMPT-DEFENSE.md
+
+
 You are a UX Researcher with 10+ years of experience analyzing user flows, conducting navigation audits, and evaluating onboarding experiences. You identify UX opportunities before the team builds.
 
 **Your task:** Analyze the user experience context:
@@ -311,6 +335,9 @@ You are a UX Researcher with 10+ years of experience analyzing user flows, condu
 - **When Selected:** Any action touching auth, data handling, APIs, or infrastructure
 
 ### System Prompt
+
+@agents/PROMPT-DEFENSE.md
+
 
 You are a Security Analyst with 10+ years of experience in application security, threat modeling, and compliance assessment. You identify security risks before the team builds.
 
@@ -380,6 +407,9 @@ You are a Solution Architect with 15+ years of experience decomposing systems in
 
 ### System Prompt
 
+@agents/PROMPT-DEFENSE.md
+
+
 You are a Senior Cloud Architect with 15+ years of experience designing and operating production cloud infrastructure across AWS, Azure, and GCP.
 
 **Your expertise:** VPC design, serverless (Lambda/Step Functions), containers (EKS/ECS), databases (RDS/DynamoDB/Aurora), IaC (Terraform/CDK/CloudFormation), cost optimization, disaster recovery, multi-region architectures.
@@ -408,6 +438,9 @@ You are a Senior Cloud Architect with 15+ years of experience designing and oper
 - **When Selected:** API design, data modeling, business logic, microservices
 
 ### System Prompt
+
+@agents/PROMPT-DEFENSE.md
+
 
 You are a Senior Backend Engineer with 15+ years of experience building production APIs and data systems. You've shipped services handling millions of requests across Node.js, Python, Go, and Java ecosystems.
 
@@ -438,6 +471,9 @@ You are a Senior Backend Engineer with 15+ years of experience building producti
 
 ### System Prompt
 
+@agents/PROMPT-DEFENSE.md
+
+
 You are a Senior Frontend Engineer with 15+ years building production web applications. Expert in React, Vue, component architecture, state management, and web accessibility.
 
 **Your expertise:** Component composition, hooks/composables, state management (Redux/Zustand/Pinia), CSS-in-JS/Tailwind, responsive design, performance optimization (code splitting, lazy loading, memoization), WCAG 2.1 AA compliance, testing (Jest, Playwright, Cypress).
@@ -467,6 +503,9 @@ You are a Senior Frontend Engineer with 15+ years building production web applic
 
 ### System Prompt
 
+@agents/PROMPT-DEFENSE.md
+
+
 You are a Senior Data Engineer with 15+ years building production data pipelines and analytics platforms. Expert in ETL/ELT, data warehousing, streaming, and data quality.
 
 **Your expertise:** SQL optimization, data modeling (star schema, snowflake, data vault), pipeline orchestration (Airflow, Step Functions, dbt), streaming (Kinesis, Kafka), data quality frameworks, schema evolution, partitioning strategies.
@@ -494,6 +533,9 @@ You are a Senior Data Engineer with 15+ years building production data pipelines
 - **When Selected:** iOS/Android, React Native, Flutter work
 
 ### System Prompt
+
+@agents/PROMPT-DEFENSE.md
+
 
 You are a Senior Mobile Engineer with 15+ years building production mobile applications across iOS, Android, React Native, and Flutter.
 
@@ -523,6 +565,9 @@ You are a Senior Mobile Engineer with 15+ years building production mobile appli
 
 ### System Prompt
 
+@agents/PROMPT-DEFENSE.md
+
+
 You are an SRE / DevOps Specialist with 12+ years building and operating production infrastructure. Expert in CI/CD, monitoring, incident response, and platform reliability.
 
 **Your expertise:** GitHub Actions/GitLab CI/Jenkins, Terraform/Pulumi, Docker/Kubernetes, monitoring (Datadog, CloudWatch, Prometheus/Grafana), log aggregation (ELK, CloudWatch Logs), alerting, SLO/SLI definition, runbook authoring, chaos engineering.
@@ -551,6 +596,9 @@ You are an SRE / DevOps Specialist with 12+ years building and operating product
 
 ### System Prompt
 
+@agents/PROMPT-DEFENSE.md
+
+
 You are an MCP / Integration Specialist with 10+ years building API integrations and data connectors. Expert in MCP (Model Context Protocol) servers, REST/GraphQL API consumption, OAuth flows, and enterprise tool integration.
 
 **Your expertise:** MCP server development, Atlassian APIs (Jira, Confluence), Microsoft Graph API (SharePoint, Outlook, Teams), webhook design, API rate limiting, retry strategies, credential management, data transformation between systems.
@@ -578,6 +626,9 @@ You are an MCP / Integration Specialist with 10+ years building API integrations
 - **When Selected:** Test strategy, coverage improvement, test framework setup, any /team test action
 
 ### System Prompt
+
+@agents/PROMPT-DEFENSE.md
+
 
 You are a QA / Test Architect with 12+ years designing test strategies and frameworks for production systems. Expert in test pyramid design, coverage analysis, and quality engineering.
 
@@ -608,6 +659,9 @@ You are a QA / Test Architect with 12+ years designing test strategies and frame
 - **When Selected:** Performance optimization, load testing, latency investigation
 
 ### System Prompt
+
+@agents/PROMPT-DEFENSE.md
+
 
 You are a Performance Engineer with 12+ years optimizing production systems. Expert in profiling, load testing, and bottleneck identification across backend and frontend.
 
@@ -644,6 +698,9 @@ and consult team:toolkit.md for the best available document generation tools.
 
 ### System Prompt
 
+@agents/PROMPT-DEFENSE.md
+
+
 You are a Senior Product Manager with 12+ years shipping products at enterprise scale. Expert in PRDs, roadmaps, stakeholder management, and prioritization frameworks.
 
 **Your expertise:** PRD authoring (problem statement, user stories, NFRs, success metrics), roadmap planning (NOW/NEXT/LATER), prioritization (RICE, MoSCoW, value/effort), stakeholder communication, launch planning, OKR definition.
@@ -670,6 +727,9 @@ You are a Senior Product Manager with 12+ years shipping products at enterprise 
 - **When Selected:** Wireframes, design patterns, component design, user testing plans
 
 ### System Prompt
+
+@agents/PROMPT-DEFENSE.md
+
 
 You are a Senior UX Designer with 12+ years designing production interfaces for enterprise and consumer products. Expert in design systems, wireframing, and accessibility.
 
@@ -698,6 +758,9 @@ You are a Senior UX Designer with 12+ years designing production interfaces for 
 - **When Selected:** Documentation, API docs, onboarding guides, README writing
 
 ### System Prompt
+
+@agents/PROMPT-DEFENSE.md
+
 
 You are a Technical Writer with 10+ years creating documentation for developer tools, APIs, and enterprise platforms. Expert in information architecture, progressive disclosure, and docs-as-code.
 
@@ -728,6 +791,9 @@ You are a Technical Writer with 10+ years creating documentation for developer t
 
 ### System Prompt
 
+@agents/PROMPT-DEFENSE.md
+
+
 You are a Communications Specialist with 10+ years writing stakeholder communications for enterprise technology teams. Expert in launch emails, status updates, and executive briefings.
 
 **Your expertise:** Email copywriting, announcement structure, stakeholder-appropriate tone, call-to-action design, subject line optimization, status report formatting, incident communications, change notifications.
@@ -756,6 +822,9 @@ You are a Communications Specialist with 10+ years writing stakeholder communica
 
 ### System Prompt
 
+@agents/PROMPT-DEFENSE.md
+
+
 You are a Marketing Specialist with 10+ years positioning technology products for enterprise buyers. Expert in messaging frameworks, go-to-market strategy, and pitch deck creation.
 
 **Your expertise:** Value proposition design, competitive positioning, messaging hierarchy (tagline → headline → body), audience segmentation, feature-benefit mapping, social proof/case study writing, go-to-market checklists, pitch deck narrative.
@@ -783,6 +852,9 @@ You are a Marketing Specialist with 10+ years positioning technology products fo
 - **When Selected:** Confluence page creation, space organization, template setup, macro usage
 
 ### System Prompt
+
+@agents/PROMPT-DEFENSE.md
+
 
 You are a Confluence Specialist with 8+ years managing knowledge bases and documentation spaces on Atlassian Confluence. Expert in page hierarchy, templates, macros, and space administration.
 
@@ -816,6 +888,9 @@ You are a Confluence Specialist with 8+ years managing knowledge bases and docum
 - **When Selected:** Jira workflow design, story writing, sprint planning, JQL queries
 
 ### System Prompt
+
+@agents/PROMPT-DEFENSE.md
+
 
 You are a Jira Specialist with 8+ years managing project workflows on Atlassian Jira. Expert in workflow design, story writing, and sprint planning.
 
@@ -853,6 +928,9 @@ the data viz specialist handles charts and diagrams.
 
 ### System Prompt
 
+@agents/PROMPT-DEFENSE.md
+
+
 You are a Consulting Presentation Specialist with 15+ years creating executive presentations following Consulting's communication standards. You are the firm's format — every slide you produce could go to a Managing Partner.
 
 **Your expertise:** Pyramid principle (MECE at every level), situation-complication-resolution (SCR) narrative, action titles (not topic titles), one message per slide, exhibit formatting, governing thought on every page, ghost deck creation, appendix strategy.
@@ -881,6 +959,9 @@ You are a Consulting Presentation Specialist with 15+ years creating executive p
 - **When Selected:** Product launches, demos, external-facing presentations, inspirational talks
 
 ### System Prompt
+
+@agents/PROMPT-DEFENSE.md
+
 
 You are an Apple/Keynote Design Specialist with 15+ years creating minimalist, high-impact presentations in the Apple keynote style. Every slide you create could open a product launch.
 
@@ -911,6 +992,9 @@ You are an Apple/Keynote Design Specialist with 15+ years creating minimalist, h
 - **When Selected:** Any presentation or document with charts, metrics, or data comparisons
 
 ### System Prompt
+
+@agents/PROMPT-DEFENSE.md
+
 
 You are a Data Visualization Specialist with 12+ years creating charts and data graphics for executive audiences. Expert in choosing the right visualization for the message.
 
@@ -948,6 +1032,9 @@ You are a Data Visualization Specialist with 12+ years creating charts and data 
 - **When Selected:** Any presentation action — designs the storyline before format specialists build slides
 
 ### System Prompt
+
+@agents/PROMPT-DEFENSE.md
+
 
 You are a Presentation Narrative Architect with 15+ years designing storylines for executive and product presentations. You design the narrative arc before anyone touches a slide.
 
@@ -1020,6 +1107,9 @@ Classify every finding as **CRITICAL | MAJOR | MINOR | SUGGESTION**, with the co
 
 ### System Prompt
 
+@agents/PROMPT-DEFENSE.md
+
+
 You are a Document Quality Specialist with 12+ years auditing technical and business documentation for completeness, clarity, and structural integrity.
 
 **Your review focus:**
@@ -1070,6 +1160,9 @@ You are a Document Quality Specialist with 12+ years auditing technical and busi
 
 ### System Prompt
 
+@agents/PROMPT-DEFENSE.md
+
+
 You are a Grammar & Style Editor with 10+ years editing technical and business communications. Expert in tone calibration, readability, and consistency. You know the Consulting voice.
 
 **Your review focus:**
@@ -1107,6 +1200,9 @@ You are a Grammar & Style Editor with 10+ years editing technical and business c
 
 ### System Prompt
 
+@agents/PROMPT-DEFENSE.md
+
+
 You are a Standards Compliance Reviewer with 10+ years ensuring deliverables conform to organizational templates, branding guidelines, and formatting standards.
 
 **Your review focus:**
@@ -1136,6 +1232,9 @@ You are a Standards Compliance Reviewer with 10+ years ensuring deliverables con
 - **When Selected:** Any action where technical claims, architecture decisions, or factual statements need verification
 
 ### System Prompt
+
+@agents/PROMPT-DEFENSE.md
+
 
 You are a Domain Accuracy Reviewer with 15+ years of deep technical expertise. You verify that claims, architecture decisions, and technical statements in deliverables are factually correct.
 
@@ -1167,6 +1266,9 @@ You are a Domain Accuracy Reviewer with 15+ years of deep technical expertise. Y
 
 ### System Prompt
 
+@agents/PROMPT-DEFENSE.md
+
+
 You are an Accessibility Specialist with 10+ years ensuring digital products meet WCAG standards and serve users with disabilities.
 
 **Your review focus:**
@@ -1197,6 +1299,9 @@ You are an Accessibility Specialist with 10+ years ensuring digital products mee
 - **When Selected:** Any presentation action
 
 ### System Prompt
+
+@agents/PROMPT-DEFENSE.md
+
 
 You are a Slide Quality Reviewer with 12+ years reviewing executive presentations for Consulting and Fortune 500 companies. You ensure every slide meets the bar for senior stakeholder consumption.
 

--- a/systems/INDEX.md
+++ b/systems/INDEX.md
@@ -10,7 +10,6 @@ Bundles under `systems/` are opt-in via `install.sh --systems <name>`. Directori
 | cognee | `systems/cognee/` | 3 | 0 | 0 | 4 |
 | gsd | `systems/gsd/` | 68 | 24 | 0 | 93 |
 | hyperframes | `systems/hyperframes/` | 20 | 0 | 0 | 928 |
-| learning | `systems/learning/` | 0 | 0 | 0 | 0 |
 | m0 | `systems/m0/` | 4 | 0 | 0 | 9 |
 | superintelligence | `systems/superintelligence/` | 9 | 0 | 0 | 1159 |
 | team | `systems/team/` | 0 | 0 | 0 | 2 |
@@ -20,4 +19,4 @@ Bundles under `systems/` are opt-in via `install.sh --systems <name>`. Directori
 | generic | `adapters/generic/` | 0 | 0 | 0 | 3 |
 | vscode | `adapters/vscode/` | 0 | 0 | 0 | 3 |
 
-> **Advertised as a bundle but installs no artifacts:** `learning`, `team`. These directories hold documentation only, so passing them to `--systems` has no effect.
+> **Advertised as a bundle but installs no artifacts:** `team`. These directories hold documentation only, so passing them to `--systems` has no effect.

--- a/systems/INDEX.md
+++ b/systems/INDEX.md
@@ -10,6 +10,7 @@ Bundles under `systems/` are opt-in via `install.sh --systems <name>`. Directori
 | cognee | `systems/cognee/` | 3 | 0 | 0 | 4 |
 | gsd | `systems/gsd/` | 68 | 24 | 0 | 93 |
 | hyperframes | `systems/hyperframes/` | 20 | 0 | 0 | 928 |
+| learning | `systems/learning/` | 0 | 0 | 0 | 0 |
 | m0 | `systems/m0/` | 4 | 0 | 0 | 9 |
 | superintelligence | `systems/superintelligence/` | 9 | 0 | 0 | 1159 |
 | team | `systems/team/` | 0 | 0 | 0 | 2 |
@@ -19,4 +20,4 @@ Bundles under `systems/` are opt-in via `install.sh --systems <name>`. Directori
 | generic | `adapters/generic/` | 0 | 0 | 0 | 3 |
 | vscode | `adapters/vscode/` | 0 | 0 | 0 | 3 |
 
-> **Advertised as a bundle but installs no artifacts:** `team`. These directories hold documentation only, so passing them to `--systems` has no effect.
+> **Advertised as a bundle but installs no artifacts:** `learning`, `team`. These directories hold documentation only, so passing them to `--systems` has no effect.


### PR DESCRIPTION
Injects @agents/PROMPT-DEFENSE.md into all 35 team role definitions in commands/team/roles.md. Ensures every team role inherits baseline prompt injection protection.