### PR TITLE
feat(adapter): add Windsurf (Codeium) adapter with skills, rules, agents, and systems support

### DIFF
--- a/adapters/windsurf/install.sh
+++ b/adapters/windsurf/install.sh
@@ -72,7 +72,8 @@ for agent in "$REPO_ROOT/agents"/*.md; do
 done
 
 # Systems bundles
-for sys in "${SYSTEMS[@]}"; do
+for sys in "${SYSTEMS[@]:-}"; do
+  [[ -n "$sys" ]] || continue
   sys_dir="$REPO_ROOT/systems/$sys"
   [[ -d "$sys_dir" ]] || { echo "Unknown system: $sys" >&2; continue; }
   if [[ -d "$sys_dir/skills" ]]; then

--- a/adapters/windsurf/install.sh
+++ b/adapters/windsurf/install.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Windsurf (Codeium) adapter — wires Coco artifacts into ~/.codeium/windsurf/
+#
+# Usage:
+#   bash adapters/windsurf/install.sh
+#   bash adapters/windsurf/install.sh --systems gsd,brain
+#   bash adapters/windsurf/install.sh --dry-run
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TARGET_HOME="${WINDSURF_HOME:-$HOME/.codeium/windsurf}"
+DRY_RUN=0
+SYSTEMS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1 ;;
+    --systems) shift; IFS=',' read -ra SYSTEMS <<< "$1" ;;
+    --help|-h) grep '^#' "$0" | sed 's/^# \?//'; exit 0 ;;
+    *) echo "Unknown flag: $1" >&2; exit 1 ;;
+  esac
+  shift
+done
+
+run() { [[ $DRY_RUN -eq 1 ]] && echo "DRY: $*" || "$@"; }
+
+link_dir() {
+  local src=$1 dst=$2
+  # Safety: refuse to remove anything outside TARGET_HOME
+  case "$dst" in
+    "$TARGET_HOME"/*) ;;
+    *) echo "REFUSE: $dst is outside $TARGET_HOME — skipping"; return ;;
+  esac
+  [[ -e "$dst" && ! -L "$dst" ]] && { echo "Skip (exists, not symlink): $dst"; return; }
+  [[ -L "$dst" ]] && run rm "$dst"
+  run mkdir -p "$(dirname "$dst")"
+  run ln -sf "$src" "$dst"
+  echo "Linked: $dst -> $src"
+}
+
+echo "Coco · Windsurf adapter"
+echo "Source: $REPO_ROOT"
+echo "Target: $TARGET_HOME"
+
+# Skills
+for skill in "$REPO_ROOT/skills"/*/; do
+  name=$(basename "$skill")
+  link_dir "$skill" "$TARGET_HOME/skills/$name"
+done
+
+# Rules (copy .mdc files for Windsurf compatibility)
+if [[ -d "$REPO_ROOT/rules/cursor-mdc" ]]; then
+  run mkdir -p "$TARGET_HOME/rules"
+  for mdc in "$REPO_ROOT/rules/cursor-mdc"/*.mdc; do
+    [[ -f "$mdc" ]] || continue
+    name=$(basename "$mdc")
+    if [[ $DRY_RUN -eq 1 ]]; then
+      echo "DRY: cp $mdc $TARGET_HOME/rules/$name"
+    else
+      cp "$mdc" "$TARGET_HOME/rules/$name"
+      echo "Copied: $TARGET_HOME/rules/$name"
+    fi
+  done
+fi
+
+# Agents
+for agent in "$REPO_ROOT/agents"/*.md; do
+  [[ -f "$agent" ]] || continue
+  name=$(basename "$agent")
+  link_dir "$agent" "$TARGET_HOME/agents/$name"
+done
+
+# Systems bundles
+for sys in "${SYSTEMS[@]}"; do
+  sys_dir="$REPO_ROOT/systems/$sys"
+  [[ -d "$sys_dir" ]] || { echo "Unknown system: $sys" >&2; continue; }
+  if [[ -d "$sys_dir/skills" ]]; then
+    for s in "$sys_dir/skills"/*/; do
+      name=$(basename "$s")
+      link_dir "$s" "$TARGET_HOME/skills/$name"
+    done
+  fi
+  if [[ -d "$sys_dir/agents" ]]; then
+    for a in "$sys_dir/agents"/*.md; do
+      [[ -f "$a" ]] || continue
+      name=$(basename "$a")
+      link_dir "$a" "$TARGET_HOME/agents/$name"
+    done
+  fi
+done
+
+echo "Done."

--- a/adapters/windsurf/manifest.json
+++ b/adapters/windsurf/manifest.json
@@ -1,0 +1,12 @@
+{
+  "name": "windsurf",
+  "version": "0.1.0",
+  "description": "Wires Coco artifacts into ~/.codeium/windsurf/ for Windsurf (Codeium) IDE",
+  "targets": {
+    "skills": "~/.codeium/windsurf/skills",
+    "rules": "~/.codeium/windsurf/rules"
+  },
+  "transforms": ["copy mdc files for Windsurf compatibility"],
+  "supports_systems": ["gsd", "brain", "team"],
+  "domains": ["foundational", "pm", "engineering", "design", "ops", "meta"]
+}

--- a/adapters/windsurf/manifest.json
+++ b/adapters/windsurf/manifest.json
@@ -7,6 +7,6 @@
     "rules": "~/.codeium/windsurf/rules"
   },
   "transforms": ["copy mdc files for Windsurf compatibility"],
-  "supports_systems": ["gsd", "brain", "team"],
+  "supports_systems": ["gsd", "brain"],
   "domains": ["foundational", "pm", "engineering", "design", "ops", "meta"]
 }

--- a/systems/INDEX.md
+++ b/systems/INDEX.md
@@ -10,6 +10,7 @@ Bundles under `systems/` are opt-in via `install.sh --systems <name>`. Directori
 | cognee | `systems/cognee/` | 3 | 0 | 0 | 4 |
 | gsd | `systems/gsd/` | 68 | 24 | 0 | 93 |
 | hyperframes | `systems/hyperframes/` | 20 | 0 | 0 | 928 |
+| learning | `systems/learning/` | 0 | 0 | 0 | 0 |
 | m0 | `systems/m0/` | 4 | 0 | 0 | 9 |
 | superintelligence | `systems/superintelligence/` | 9 | 0 | 0 | 1159 |
 | team | `systems/team/` | 0 | 0 | 0 | 2 |
@@ -18,5 +19,6 @@ Bundles under `systems/` are opt-in via `install.sh --systems <name>`. Directori
 | cursor | `adapters/cursor/` | 5 | 0 | 0 | 8 |
 | generic | `adapters/generic/` | 0 | 0 | 0 | 3 |
 | vscode | `adapters/vscode/` | 0 | 0 | 0 | 3 |
+| windsurf | `adapters/windsurf/` | 0 | 0 | 0 | 2 |
 
-> **Advertised as a bundle but installs no artifacts:** `team`. These directories hold documentation only, so passing them to `--systems` has no effect.
+> **Advertised as a bundle but installs no artifacts:** `learning`, `team`. These directories hold documentation only, so passing them to `--systems` has no effect.

--- a/systems/INDEX.md
+++ b/systems/INDEX.md
@@ -10,7 +10,6 @@ Bundles under `systems/` are opt-in via `install.sh --systems <name>`. Directori
 | cognee | `systems/cognee/` | 3 | 0 | 0 | 4 |
 | gsd | `systems/gsd/` | 68 | 24 | 0 | 93 |
 | hyperframes | `systems/hyperframes/` | 20 | 0 | 0 | 928 |
-| learning | `systems/learning/` | 0 | 0 | 0 | 0 |
 | m0 | `systems/m0/` | 4 | 0 | 0 | 9 |
 | superintelligence | `systems/superintelligence/` | 9 | 0 | 0 | 1159 |
 | team | `systems/team/` | 0 | 0 | 0 | 2 |
@@ -21,4 +20,4 @@ Bundles under `systems/` are opt-in via `install.sh --systems <name>`. Directori
 | vscode | `adapters/vscode/` | 0 | 0 | 0 | 3 |
 | windsurf | `adapters/windsurf/` | 0 | 0 | 0 | 2 |
 
-> **Advertised as a bundle but installs no artifacts:** `learning`, `team`. These directories hold documentation only, so passing them to `--systems` has no effect.
+> **Advertised as a bundle but installs no artifacts:** `team`. These directories hold documentation only, so passing them to `--systems` has no effect.


### PR DESCRIPTION
Adds adapters/windsurf/install.sh and manifest.json for Windsurf (Codeium) integration targeting ~/.codeium/windsurf/.