### PR TITLE
feat(adapter): add Amazon Q Developer adapter with rules and agents support

### DIFF
--- a/adapters/amazon-q/install.sh
+++ b/adapters/amazon-q/install.sh
@@ -3,7 +3,7 @@
 #
 # Usage:
 #   bash adapters/amazon-q/install.sh
-#   bash adapters/amazon-q/install.sh --systems gsd,brain
+#   bash adapters/amazon-q/install.sh --systems gsd
 #   bash adapters/amazon-q/install.sh --dry-run
 
 set -euo pipefail
@@ -65,7 +65,10 @@ for agent in "$REPO_ROOT/agents"/*.md; do
 done
 
 # Systems bundles
-for sys in "${SYSTEMS[@]}"; do
+# Only bundles that ship agents/ can be wired by this adapter; it has no skills
+# support, so brain (skills only) and team (no installable artifacts) are not advertised.
+for sys in "${SYSTEMS[@]:-}"; do
+  [[ -n "$sys" ]] || continue
   sys_dir="$REPO_ROOT/systems/$sys"
   [[ -d "$sys_dir" ]] || { echo "Unknown system: $sys" >&2; continue; }
   if [[ -d "$sys_dir/agents" ]]; then

--- a/adapters/amazon-q/install.sh
+++ b/adapters/amazon-q/install.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Amazon Q Developer adapter — wires Coco artifacts into ~/.aws/amazon-q/
+#
+# Usage:
+#   bash adapters/amazon-q/install.sh
+#   bash adapters/amazon-q/install.sh --systems gsd,brain
+#   bash adapters/amazon-q/install.sh --dry-run
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TARGET_HOME="${AMAZON_Q_HOME:-$HOME/.aws/amazon-q}"
+DRY_RUN=0
+SYSTEMS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1 ;;
+    --systems) shift; IFS=',' read -ra SYSTEMS <<< "$1" ;;
+    --help|-h) grep '^#' "$0" | sed 's/^# \?//'; exit 0 ;;
+    *) echo "Unknown flag: $1" >&2; exit 1 ;;
+  esac
+  shift
+done
+
+run() { [[ $DRY_RUN -eq 1 ]] && echo "DRY: $*" || "$@"; }
+
+link_dir() {
+  local src=$1 dst=$2
+  case "$dst" in
+    "$TARGET_HOME"/*) ;;
+    *) echo "REFUSE: $dst is outside $TARGET_HOME — skipping"; return ;;
+  esac
+  [[ -e "$dst" && ! -L "$dst" ]] && { echo "Skip (exists, not symlink): $dst"; return; }
+  [[ -L "$dst" ]] && run rm "$dst"
+  run mkdir -p "$(dirname "$dst")"
+  run ln -sf "$src" "$dst"
+  echo "Linked: $dst -> $src"
+}
+
+echo "Coco · Amazon Q Developer adapter"
+echo "Source: $REPO_ROOT"
+echo "Target: $TARGET_HOME"
+
+# Rules
+if [[ -d "$REPO_ROOT/rules" ]]; then
+  run mkdir -p "$TARGET_HOME/rules"
+  for rule in "$REPO_ROOT/rules"/*.md; do
+    [[ -f "$rule" ]] || continue
+    name=$(basename "$rule")
+    if [[ $DRY_RUN -eq 1 ]]; then
+      echo "DRY: cp $rule $TARGET_HOME/rules/$name"
+    else
+      cp "$rule" "$TARGET_HOME/rules/$name"
+      echo "Copied: $TARGET_HOME/rules/$name"
+    fi
+  done
+fi
+
+# Agents
+for agent in "$REPO_ROOT/agents"/*.md; do
+  [[ -f "$agent" ]] || continue
+  name=$(basename "$agent")
+  link_dir "$agent" "$TARGET_HOME/agents/$name"
+done
+
+# Systems bundles
+for sys in "${SYSTEMS[@]}"; do
+  sys_dir="$REPO_ROOT/systems/$sys"
+  [[ -d "$sys_dir" ]] || { echo "Unknown system: $sys" >&2; continue; }
+  if [[ -d "$sys_dir/agents" ]]; then
+    for a in "$sys_dir/agents"/*.md; do
+      [[ -f "$a" ]] || continue
+      name=$(basename "$a")
+      link_dir "$a" "$TARGET_HOME/agents/$name"
+    done
+  fi
+done
+
+echo "Done."

--- a/adapters/amazon-q/manifest.json
+++ b/adapters/amazon-q/manifest.json
@@ -1,0 +1,12 @@
+{
+  "name": "amazon-q",
+  "version": "0.1.0",
+  "description": "Wires Coco artifacts into ~/.aws/amazon-q/ for Amazon Q Developer with rules and agent context",
+  "targets": {
+    "rules": "~/.aws/amazon-q/rules",
+    "agents": "~/.aws/amazon-q/agents"
+  },
+  "transforms": ["copy markdown rules for Amazon Q compatibility"],
+  "supports_systems": ["gsd", "brain", "team"],
+  "domains": ["foundational", "pm", "engineering", "design", "ops", "meta"]
+}

--- a/adapters/amazon-q/manifest.json
+++ b/adapters/amazon-q/manifest.json
@@ -7,6 +7,6 @@
     "agents": "~/.aws/amazon-q/agents"
   },
   "transforms": ["copy markdown rules for Amazon Q compatibility"],
-  "supports_systems": ["gsd", "brain", "team"],
+  "supports_systems": ["gsd"],
   "domains": ["foundational", "pm", "engineering", "design", "ops", "meta"]
 }

--- a/systems/INDEX.md
+++ b/systems/INDEX.md
@@ -10,13 +10,15 @@ Bundles under `systems/` are opt-in via `install.sh --systems <name>`. Directori
 | cognee | `systems/cognee/` | 3 | 0 | 0 | 4 |
 | gsd | `systems/gsd/` | 68 | 24 | 0 | 93 |
 | hyperframes | `systems/hyperframes/` | 20 | 0 | 0 | 928 |
+| learning | `systems/learning/` | 0 | 0 | 0 | 0 |
 | m0 | `systems/m0/` | 4 | 0 | 0 | 9 |
 | superintelligence | `systems/superintelligence/` | 9 | 0 | 0 | 1159 |
 | team | `systems/team/` | 0 | 0 | 0 | 2 |
+| amazon-q | `adapters/amazon-q/` | 0 | 0 | 0 | 2 |
 | claude-code | `adapters/claude-code/` | 0 | 0 | 0 | 3 |
 | codex | `adapters/codex/` | 0 | 0 | 0 | 3 |
 | cursor | `adapters/cursor/` | 5 | 0 | 0 | 8 |
 | generic | `adapters/generic/` | 0 | 0 | 0 | 3 |
 | vscode | `adapters/vscode/` | 0 | 0 | 0 | 3 |
 
-> **Advertised as a bundle but installs no artifacts:** `team`. These directories hold documentation only, so passing them to `--systems` has no effect.
+> **Advertised as a bundle but installs no artifacts:** `learning`, `team`. These directories hold documentation only, so passing them to `--systems` has no effect.

--- a/systems/INDEX.md
+++ b/systems/INDEX.md
@@ -10,7 +10,6 @@ Bundles under `systems/` are opt-in via `install.sh --systems <name>`. Directori
 | cognee | `systems/cognee/` | 3 | 0 | 0 | 4 |
 | gsd | `systems/gsd/` | 68 | 24 | 0 | 93 |
 | hyperframes | `systems/hyperframes/` | 20 | 0 | 0 | 928 |
-| learning | `systems/learning/` | 0 | 0 | 0 | 0 |
 | m0 | `systems/m0/` | 4 | 0 | 0 | 9 |
 | superintelligence | `systems/superintelligence/` | 9 | 0 | 0 | 1159 |
 | team | `systems/team/` | 0 | 0 | 0 | 2 |
@@ -21,4 +20,4 @@ Bundles under `systems/` are opt-in via `install.sh --systems <name>`. Directori
 | generic | `adapters/generic/` | 0 | 0 | 0 | 3 |
 | vscode | `adapters/vscode/` | 0 | 0 | 0 | 3 |
 
-> **Advertised as a bundle but installs no artifacts:** `learning`, `team`. These directories hold documentation only, so passing them to `--systems` has no effect.
+> **Advertised as a bundle but installs no artifacts:** `team`. These directories hold documentation only, so passing them to `--systems` has no effect.


### PR DESCRIPTION
Adds adapters/amazon-q/install.sh and manifest.json for Amazon Q Developer integration targeting ~/.aws/amazon-q/.