### PR TITLE
feat(mcp): add MCP server catalog with 8 connector configurations

### DIFF
--- a/mcps/catalog.md
+++ b/mcps/catalog.md
@@ -1,0 +1,47 @@
+# MCP Server Catalog
+> Curated list of Model Context Protocol servers compatible with Coco
+
+## How to Use
+Each server file in `mcps/servers/` contains installation instructions, configuration examples, and integration notes specific to Coco's workflow system. Copy the relevant JSON block into your IDE's MCP settings file.
+
+## Available Servers
+
+| Server | File | Primary Use Case | Priority |
+|--------|------|------------------|----------|
+| Filesystem | [filesystem.md](servers/filesystem.md) | Sandboxed file access for agents | HIGH |
+| PostgreSQL | [postgres.md](servers/postgres.md) | Database queries and schema inspection | HIGH |
+| GitHub | [github.md](servers/github.md) | PR creation, issue tracking, repo management | HIGH |
+| Atlassian | [atlassian.md](servers/atlassian.md) | Jira + Confluence integration | HIGH |
+| Slack | [slack.md](servers/slack.md) | Team communication and notifications | MEDIUM |
+| Notion | [notion.md](servers/notion.md) | Knowledge base and database sync | MEDIUM |
+| Linear | [linear.md](servers/linear.md) | Issue tracking and project management | MEDIUM |
+| Supabase | [supabase.md](servers/supabase.md) | Backend-as-a-service DB and auth | MEDIUM |
+
+## Configuration Locations by Adapter
+
+| Adapter | MCP Config Path |
+|---------|-----------------|
+| Claude Code | `~/.claude/settings.json` → `mcpServers` |
+| Cursor | `.cursor/mcp.json` (project) or `~/.cursor/mcp.json` (global) |
+| Windsurf | `~/.codeium/windsurf/mcp.json` |
+| VS Code (Continue) | `~/.continue/config.json` → `models[].mcpServers` |
+| Cline | `~/.cline/mcp_settings.json` |
+| Roo Code | `~/.roo-code/mcp_settings.json` |
+| Amazon Q | `~/.aws/amazon-q/mcp.json` |
+| Zed | `~/.config/zed/settings.json` → `experimental.mcpServers` |
+| Aider | `.aider.conf.yml` → not native; use AGENTS.md references |
+| GitHub Copilot CLI | Not supported natively; use AGENTS.md |
+
+## Security Best Practices
+1. **Never commit credentials** — use environment variables or secret managers
+2. **Use minimum permissions** — fine-grained tokens, read-only DB users, scoped API keys
+3. **Audit regularly** — review access logs and rotate keys on schedule
+4. **Sandbox filesystem access** — always specify allowed directories explicitly
+5. **Prefer OAuth over API keys** when the service supports it
+
+## Adding New Servers
+To add a new MCP server to this catalog:
+1. Create `mcps/servers/<name>.md` following the existing template
+2. Add an entry to the table above
+3. Test configuration with at least one adapter
+4. Submit as a standalone PR

--- a/mcps/servers/atlassian.md
+++ b/mcps/servers/atlassian.md
@@ -1,0 +1,53 @@
+# MCP Server: Atlassian (Jira + Confluence)
+> Project management and knowledge base integration for AI agents via Model Context Protocol
+
+## Installation
+```bash
+npm install -g mcp-atlassian
+```
+
+## Configuration
+Add to your IDE's MCP settings:
+
+```json
+{
+  "mcpServers": {
+    "atlassian": {
+      "command": "npx",
+      "args": ["-y", "mcp-atlassian"],
+      "env": {
+        "ATLASSIAN_URL": "https://your-domain.atlassian.net",
+        "ATLASSIAN_USERNAME": "your-email@example.com",
+        "ATLASSIAN_API_TOKEN": "your-api-token"
+      }
+    }
+  }
+}
+```
+
+## Tools Provided
+| Tool | Description |
+|------|-------------|
+| `jira_get_issue` | Get Jira issue details |
+| `jira_search` | Search issues using JQL |
+| `jira_create_issue` | Create a new Jira issue |
+| `jira_update_issue` | Update issue fields, status, assignee |
+| `jira_list_projects` | List available projects |
+| `confluence_get_page` | Get Confluence page content |
+| `confluence_search` | Search Confluence pages |
+| `confluence_create_page` | Create a new Confluence page |
+| `confluence_update_page` | Update existing page content |
+| `confluence_list_spaces` | List available spaces |
+
+## Integration with Coco
+The Atlassian MCP server enhances Coco's PM and documentation workflows:
+- `/pmstudio-sync-init` can monitor Jira issues alongside email for project updates
+- Team roles (Jira Specialist, Confluence Specialist) can use MCP tools directly
+- Brain DB decisions can reference Jira issue keys for traceability
+- `/team:document` can publish deliverables to Confluence automatically
+
+## Security Notes
+- Generate API tokens from Atlassian account settings — never use passwords
+- Store credentials in environment variables or secret managers
+- Use OAuth 2.0 when available for better security
+- Restrict API token permissions to required scopes only

--- a/mcps/servers/filesystem.md
+++ b/mcps/servers/filesystem.md
@@ -1,0 +1,58 @@
+# MCP Server: Filesystem
+> Sandboxed file access for AI agents via Model Context Protocol
+
+## Installation
+```bash
+npm install -g @modelcontextprotocol/server-filesystem
+```
+
+## Configuration
+Add to your IDE's MCP settings (e.g., `~/.claude/settings.json`, `.cursor/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/path/to/allowed/directory"
+      ]
+    }
+  }
+}
+```
+
+## Allowed Directories
+Specify one or more directories the server can access:
+```json
+"args": [
+  "-y",
+  "@modelcontextprotocol/server-filesystem",
+  "/home/user/projects",
+  "/tmp/workspace"
+]
+```
+
+## Tools Provided
+| Tool | Description |
+|------|-------------|
+| `read_file` | Read file contents |
+| `write_file` | Write/create files |
+| `list_directory` | List directory contents |
+| `search_files` | Search for files by pattern |
+| `get_file_info` | Get file metadata (size, modified, etc.) |
+| `move_file` | Move/rename files |
+
+## Security Notes
+- Server runs in sandboxed mode — only specified directories are accessible
+- No path traversal outside allowed directories
+- Read-only mode available via `--readonly` flag
+- Use with Coco's Brain system for persistent project knowledge storage
+
+## Integration with Coco
+The filesystem MCP server complements Coco's Brain DB by providing:
+- Direct file read/write for document generation skills
+- Project directory scanning for `/brain-rescan`
+- Template file access for PRD and architecture workflows

--- a/mcps/servers/github.md
+++ b/mcps/servers/github.md
@@ -1,0 +1,51 @@
+# MCP Server: GitHub
+> PR creation, issue tracking, and repository management for AI agents via Model Context Protocol
+
+## Installation
+```bash
+npm install -g @modelcontextprotocol/server-github
+```
+
+## Configuration
+Add to your IDE's MCP settings with a personal access token:
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_your_token_here"
+      }
+    }
+  }
+}
+```
+
+## Tools Provided
+| Tool | Description |
+|------|-------------|
+| `create_issue` | Create a new issue in a repository |
+| `list_issues` | List issues with filters (state, labels, assignee) |
+| `get_issue` | Get details of a specific issue |
+| `create_pull_request` | Create a new pull request |
+| `list_pull_requests` | List open/closed PRs |
+| `get_pull_request` | Get PR details including diff and reviews |
+| `search_repositories` | Search across GitHub repositories |
+| `get_file_contents` | Read file contents from a repository |
+| `create_branch` | Create a new branch |
+| `list_commits` | List commits on a branch or path |
+
+## Integration with Coco
+The GitHub MCP server integrates with Coco's workflow system:
+- `/gsd-ship` can create PRs directly via MCP instead of CLI
+- `/team:research` can search repositories for prior art
+- Brain DB entities can be linked to GitHub issues and PRs
+- Code review agents can fetch PR diffs for analysis
+
+## Security Notes
+- Use fine-grained tokens with minimum required permissions
+- Never commit tokens to version control — use env vars or secret managers
+- Restrict token scope to specific repositories when possible
+- Rotate tokens regularly and audit usage logs

--- a/mcps/servers/linear.md
+++ b/mcps/servers/linear.md
@@ -1,0 +1,50 @@
+# MCP Server: Linear
+> Issue tracking and project management for AI agents via Model Context Protocol
+
+## Installation
+```bash
+npm install -g @anthropic/mcp-server-linear
+```
+
+## Configuration
+Add to your IDE's MCP settings with a Linear API Key:
+
+```json
+{
+  "mcpServers": {
+    "linear": {
+      "command": "npx",
+      "args": ["-y", "@anthropic/mcp-server-linear"],
+      "env": {
+        "LINEAR_API_KEY": "lin_api_your_key_here"
+      }
+    }
+  }
+}
+```
+
+## Tools Provided
+| Tool | Description |
+|------|-------------|
+| `get_issue` | Get issue details by ID or identifier |
+| `search_issues` | Search issues with filters |
+| `create_issue` | Create a new issue |
+| `update_issue` | Update issue status, assignee, priority |
+| `list_teams` | List teams in the workspace |
+| `list_projects` | List active projects |
+| `get_project` | Get project details and progress |
+| `create_comment` | Add comment to an issue |
+| `list_cycles` | List current and past cycles |
+
+## Integration with Coco
+The Linear MCP server integrates with Coco's task and team workflows:
+- Brain DB tasks can sync bidirectionally with Linear issues
+- `/gsd-add-todo` can create Linear issues directly
+- Team feedback entries can be linked to Linear issue identifiers
+- Sprint planning agents can query cycle velocity and capacity
+
+## Security Notes
+- Generate API keys from Linear settings → API → Personal API Keys
+- Use team-scoped keys when possible instead of workspace-wide keys
+- Never commit keys — use environment variables or secret managers
+- Audit key usage in Linear admin settings

--- a/mcps/servers/notion.md
+++ b/mcps/servers/notion.md
@@ -1,0 +1,48 @@
+# MCP Server: Notion
+> Knowledge base and database integration for AI agents via Model Context Protocol
+
+## Installation
+```bash
+npm install -g @anthropic/mcp-server-notion
+```
+
+## Configuration
+Add to your IDE's MCP settings with a Notion Integration Token:
+
+```json
+{
+  "mcpServers": {
+    "notion": {
+      "command": "npx",
+      "args": ["-y", "@anthropic/mcp-server-notion"],
+      "env": {
+        "NOTION_API_KEY": "secret_your_integration_token"
+      }
+    }
+  }
+}
+```
+
+## Tools Provided
+| Tool | Description |
+|------|-------------|
+| `search` | Search pages and databases |
+| `get_page` | Get page content and properties |
+| `create_page` | Create a new page in a database or as child |
+| `update_page` | Update page properties |
+| `query_database` | Query database with filters and sorts |
+| `get_block_children` | Get nested block content |
+| `append_block_children` | Add content blocks to a page |
+
+## Integration with Coco
+The Notion MCP server complements Coco's documentation and PM workflows:
+- `/team:document` can publish deliverables to Notion databases
+- Brain DB entities can sync to Notion people/team databases
+- PRD generation can pull requirements from Notion specs
+- Meeting notes can be auto-created as Notion pages
+
+## Security Notes
+- Create internal integrations with minimum required capabilities
+- Share only specific pages/databases with the integration
+- Never commit API keys — use environment variables
+- Review integration access in Notion workspace settings

--- a/mcps/servers/postgres.md
+++ b/mcps/servers/postgres.md
@@ -1,0 +1,62 @@
+# MCP Server: PostgreSQL
+> Database queries and schema inspection for AI agents via Model Context Protocol
+
+## Installation
+```bash
+npm install -g @modelcontextprotocol/server-postgres
+```
+
+## Configuration
+Add to your IDE's MCP settings:
+
+```json
+{
+  "mcpServers": {
+    "postgres": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-postgres",
+        "postgresql://user:password@localhost:5432/mydb"
+      ]
+    }
+  }
+}
+```
+
+## Environment Variable (Recommended)
+Avoid hardcoding credentials by using an environment variable:
+```json
+{
+  "mcpServers": {
+    "postgres": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-postgres"],
+      "env": {
+        "DATABASE_URL": "postgresql://user:password@localhost:5432/mydb"
+      }
+    }
+  }
+}
+```
+
+## Tools Provided
+| Tool | Description |
+|------|-------------|
+| `query` | Execute SQL queries (SELECT, INSERT, UPDATE, DELETE) |
+| `list_tables` | List all tables in the database |
+| `describe_table` | Get column names, types, and constraints for a table |
+| `list_schemas` | List all schemas in the database |
+
+## Integration with Coco Brain
+The Postgres MCP server can complement Coco's SQLite-based Brain DB by:
+- Querying production databases for entity data during `/brain-rescan`
+- Validating Brain DB decisions against live schema constraints
+- Extracting relationships from foreign key constraints
+- Syncing task status from project management tables
+
+## Security Notes
+- Use read-only database users when possible
+- Never store credentials in MCP config files — use env vars or secret managers
+- Restrict network access to the database host
+- Audit query logs for unexpected patterns

--- a/mcps/servers/slack.md
+++ b/mcps/servers/slack.md
@@ -1,0 +1,50 @@
+# MCP Server: Slack
+> Team communication and channel management for AI agents via Model Context Protocol
+
+## Installation
+```bash
+npm install -g @anthropic/mcp-server-slack
+```
+
+## Configuration
+Add to your IDE's MCP settings with a Slack Bot Token:
+
+```json
+{
+  "mcpServers": {
+    "slack": {
+      "command": "npx",
+      "args": ["-y", "@anthropic/mcp-server-slack"],
+      "env": {
+        "SLACK_BOT_TOKEN": "xoxb-your-bot-token",
+        "SLACK_TEAM_ID": "T01234567"
+      }
+    }
+  }
+}
+```
+
+## Tools Provided
+| Tool | Description |
+|------|-------------|
+| `send_message` | Send a message to a channel or DM |
+| `list_channels` | List available channels |
+| `get_channel_history` | Get recent messages from a channel |
+| `search_messages` | Search across workspace messages |
+| `create_channel` | Create a new channel |
+| `invite_to_channel` | Invite users to a channel |
+| `set_topic` | Set channel topic |
+| `add_reaction` | Add emoji reaction to a message |
+
+## Integration with Coco
+The Slack MCP server enhances Coco's team communication workflows:
+- `/team:communicate` can post updates directly to Slack channels
+- `/pmstudio-sync-init` can monitor Slack channels alongside email for project signals
+- Brain DB events can be created from Slack thread discussions
+- Incident response plans can auto-notify on-call channels
+
+## Security Notes
+- Use Bot Tokens (xoxb-) not User Tokens (xoxp-) for server integrations
+- Restrict bot permissions to minimum required scopes
+- Never commit tokens — use environment variables or secret managers
+- Audit bot activity logs regularly

--- a/mcps/servers/supabase.md
+++ b/mcps/servers/supabase.md
@@ -1,0 +1,50 @@
+# MCP Server: Supabase
+> Backend-as-a-service database and auth integration for AI agents via Model Context Protocol
+
+## Installation
+```bash
+npm install -g @anthropic/mcp-server-supabase
+```
+
+## Configuration
+Add to your IDE's MCP settings:
+
+```json
+{
+  "mcpServers": {
+    "supabase": {
+      "command": "npx",
+      "args": ["-y", "@anthropic/mcp-server-supabase"],
+      "env": {
+        "SUPABASE_URL": "https://your-project.supabase.co",
+        "SUPABASE_SERVICE_ROLE_KEY": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+      }
+    }
+  }
+}
+```
+
+## Tools Provided
+| Tool | Description |
+|------|-------------|
+| `query` | Execute SQL queries via PostgREST |
+| `list_tables` | List all tables in the schema |
+| `describe_table` | Get column definitions and types |
+| `insert_row` | Insert a row into a table |
+| `update_rows` | Update rows matching a filter |
+| `delete_rows` | Delete rows matching a filter |
+| `list_functions` | List edge functions |
+| `invoke_function` | Invoke an edge function |
+
+## Integration with Coco
+The Supabase MCP server enhances Coco's full-stack development workflows:
+- Database architects can inspect and modify schemas directly
+- `/team:develop` agents can seed test data via MCP
+- Brain DB can sync user/team entities from Supabase Auth
+- Code verification can validate against live schema constraints
+
+## Security Notes
+- Prefer service role key only for admin operations; use anon key for read-only
+- Enable Row Level Security (RLS) on all tables
+- Never expose service role keys in client-side code
+- Rotate keys regularly and audit access logs in Supabase dashboard

--- a/systems/INDEX.md
+++ b/systems/INDEX.md
@@ -10,7 +10,6 @@ Bundles under `systems/` are opt-in via `install.sh --systems <name>`. Directori
 | cognee | `systems/cognee/` | 3 | 0 | 0 | 4 |
 | gsd | `systems/gsd/` | 68 | 24 | 0 | 93 |
 | hyperframes | `systems/hyperframes/` | 20 | 0 | 0 | 928 |
-| learning | `systems/learning/` | 0 | 0 | 0 | 0 |
 | m0 | `systems/m0/` | 4 | 0 | 0 | 9 |
 | superintelligence | `systems/superintelligence/` | 9 | 0 | 0 | 1159 |
 | team | `systems/team/` | 0 | 0 | 0 | 2 |
@@ -20,4 +19,4 @@ Bundles under `systems/` are opt-in via `install.sh --systems <name>`. Directori
 | generic | `adapters/generic/` | 0 | 0 | 0 | 3 |
 | vscode | `adapters/vscode/` | 0 | 0 | 0 | 3 |
 
-> **Advertised as a bundle but installs no artifacts:** `learning`, `team`. These directories hold documentation only, so passing them to `--systems` has no effect.
+> **Advertised as a bundle but installs no artifacts:** `team`. These directories hold documentation only, so passing them to `--systems` has no effect.

--- a/systems/INDEX.md
+++ b/systems/INDEX.md
@@ -10,6 +10,7 @@ Bundles under `systems/` are opt-in via `install.sh --systems <name>`. Directori
 | cognee | `systems/cognee/` | 3 | 0 | 0 | 4 |
 | gsd | `systems/gsd/` | 68 | 24 | 0 | 93 |
 | hyperframes | `systems/hyperframes/` | 20 | 0 | 0 | 928 |
+| learning | `systems/learning/` | 0 | 0 | 0 | 0 |
 | m0 | `systems/m0/` | 4 | 0 | 0 | 9 |
 | superintelligence | `systems/superintelligence/` | 9 | 0 | 0 | 1159 |
 | team | `systems/team/` | 0 | 0 | 0 | 2 |
@@ -19,4 +20,4 @@ Bundles under `systems/` are opt-in via `install.sh --systems <name>`. Directori
 | generic | `adapters/generic/` | 0 | 0 | 0 | 3 |
 | vscode | `adapters/vscode/` | 0 | 0 | 0 | 3 |
 
-> **Advertised as a bundle but installs no artifacts:** `team`. These directories hold documentation only, so passing them to `--systems` has no effect.
+> **Advertised as a bundle but installs no artifacts:** `learning`, `team`. These directories hold documentation only, so passing them to `--systems` has no effect.


### PR DESCRIPTION
Adds mcps/catalog.md as central index and 8 MCP server configs: filesystem, postgres, github, atlassian, slack, notion, linear, supabase.