### PR TITLE
feat(agent-self-eval): add post-run quality scoring skill and /self-eval command

### DIFF
--- a/.github/workflows/lint-frontmatter.yml
+++ b/.github/workflows/lint-frontmatter.yml
@@ -36,7 +36,12 @@ jobs:
 
           REQUIRED_FIELDS = ['name', 'description']
           OPTIONAL_DOMAINS = ['foundational', 'pm', 'engineering', 'design', 'ops', 'meta']
-          KNOWN_ADAPTERS = ['claude-code', 'cursor', 'codex', 'generic']
+          # Keep in sync with adapters/*/manifest.json. The editor adapters that are
+          # landing in their own pull requests are listed so a skill may declare
+          # support for them in the same release; a name that is not an adapter at
+          # all is still rejected.
+          KNOWN_ADAPTERS = ['claude-code', 'cursor', 'codex', 'generic',
+                            'windsurf', 'zed', 'cline', 'roo-code', 'amazon-q']
 
           errors = []
           checked = 0

--- a/commands/INDEX.md
+++ b/commands/INDEX.md
@@ -2,7 +2,7 @@
 
 Auto-generated. Run `python3 scripts/build-index.py` to refresh.
 
-**Total: 38 commands across 6 namespaces.**
+**Total: 39 commands across 6 namespaces.**
 
 ## design
 
@@ -70,4 +70,5 @@ Auto-generated. Run `python3 scripts/build-index.py` to refresh.
 | [`/util:architecture-review`](util/architecture-review.md) | Comprehensive architecture review with design patterns analysis and improvement recommendations |
 | [`/util:create-architecture-documentation`](util/create-architecture-documentation.md) | Generate comprehensive architecture documentation with diagrams, ADRs, and interactive visualization |
 | [`/util:refactor-code`](util/refactor-code.md) |  |
+| [`/util:self-eval`](util/self-eval.md) | Run post-output self-evaluation scoring on correctness, clarity, actionability, and conciseness |
 | [`/util:ss`](util/ss.md) | View the latest N screenshots from Desktop (default 1) |

--- a/commands/util/self-eval.md
+++ b/commands/util/self-eval.md
@@ -1,0 +1,31 @@
+---
+description: "Run post-output self-evaluation scoring on correctness, clarity, actionability, and conciseness"
+allowed-tools:
+  - Read
+  - Bash
+  - Glob
+  - Grep
+---
+
+# /self-eval — Agent Output Quality Scoring
+
+Evaluate the most recent agent output or deliverable across four quality axes.
+
+## Usage
+```
+/self-eval              # Evaluate last output in current session
+/self-eval --file <path>  # Evaluate specific file/deliverable
+/self-eval --team         # Evaluate last /team pipeline output
+```
+
+## What It Does
+1. Collects original request + final output + verification evidence
+2. Scores each axis (correctness, clarity, actionability, conciseness) 1-5
+3. Generates improvement instincts for the learning system
+4. Flags scores ≤2 on correctness for automatic re-execution offer
+
+## When to Run
+- After any `/team:*` command completes
+- After `/gsd-execute-phase` finishes
+- When user asks "how did that go?" or "evaluate this"
+- Before marking a phase as complete in GSD workflows

--- a/docs/by-domain/meta.md
+++ b/docs/by-domain/meta.md
@@ -2,10 +2,11 @@
 
 Auto-generated view. Filtered to `domain: meta` skills.
 
-**6 skills.**
+**7 skills.**
 
 | Skill | Description |
 |-------|-------------|
+| [agent-self-eval](../../skills/agent-self-eval/SKILL.md) | Post-run self-evaluation system that scores agent output on correctness, clarity, actionability, and conciseness. Use after /team runs, skill executions, or when explicitly asked to evaluate output qu |
 | [cli-anything](../../skills/cli-anything/SKILL.md) | Wrap any command-line tool into a JSON-emitting agent skill. Use when you want to make a CLI reliably callable and parseable by an AI agent — introspect its --help, define a structured-output (--json) |
 | [coco-cli](../../skills/coco-cli/SKILL.md) | Install, update, version-check, or uninstall the Coco open-source AI workflow framework via its CLI (cocosuperintelligence, run with npx). Use when setting up Coco on a machine, pulling the latest int |
 | [coco-loop](../../skills/coco-loop/SKILL.md) | Start a safe, governed autonomous loop from a plain-language goal. Use when the user says /coco-loop, "run an autonomous loop", "keep my build green for N hours", "work on X autonomously for a while", |

--- a/skills/INDEX.md
+++ b/skills/INDEX.md
@@ -2,7 +2,7 @@
 
 Auto-generated. Run `python3 scripts/build-index.py` to refresh.
 
-**Total: 185 skills** — 70 core, 115 across 7 bundles.
+**Total: 186 skills** — 71 core, 115 across 7 bundles.
 
 ## Design (15)
 
@@ -67,10 +67,11 @@ Auto-generated. Run `python3 scripts/build-index.py` to refresh.
 | [workflow-routing](workflow-routing/SKILL.md) | Use at the start of any task to route between Superpowers skills and GSD commands based on project state, task scope, and context signals. Fires before other sk |
 | [writing-plans](writing-plans/SKILL.md) | Use when you have a spec or requirements for a multi-step task, before touching code |
 
-## Meta (6)
+## Meta (7)
 
 | Skill | Description |
 |-------|-------------|
+| [agent-self-eval](agent-self-eval/SKILL.md) | Post-run self-evaluation system that scores agent output on correctness, clarity, actionability, and conciseness. Use after /team runs, skill executions, or whe |
 | [cli-anything](cli-anything/SKILL.md) | Wrap any command-line tool into a JSON-emitting agent skill. Use when you want to make a CLI reliably callable and parseable by an AI agent — introspect its --h |
 | [coco-cli](coco-cli/SKILL.md) | Install, update, version-check, or uninstall the Coco open-source AI workflow framework via its CLI (cocosuperintelligence, run with npx). Use when setting up C |
 | [coco-loop](coco-loop/SKILL.md) | Start a safe, governed autonomous loop from a plain-language goal. Use when the user says /coco-loop, "run an autonomous loop", "keep my build green for N hours |

--- a/skills/agent-self-eval/SKILL.md
+++ b/skills/agent-self-eval/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: agent-self-eval
+description: "Post-run self-evaluation system that scores agent output on correctness, clarity, actionability, and conciseness. Use after /team runs, skill executions, or when explicitly asked to evaluate output quality."
+domain: meta
+supports: [claude-code, cursor, codex, generic, windsurf, zed, cline, roo-code, amazon-q]
+version: 0.1.0
+tags: [evaluation, quality, scoring, feedback]
+---
+
+@agents/PROMPT-DEFENSE.md
+
+# Agent Self-Evaluation
+
+Score your own output (or another agent's output) across four axes to identify quality gaps and feed improvements into the learning system.
+
+## When to Use
+- After completing a `/team:*` pipeline run
+- After generating a deliverable (PRD, architecture doc, code review)
+- When user asks "how did I do?" or "evaluate this output"
+- Automatically at end of `/gsd-execute-phase` for quality tracking
+
+## Evaluation Axes
+
+| Axis | Question | Failure Signals |
+|------|----------|-----------------|
+| **Correctness** | Is the output factually accurate and technically sound? | Wrong APIs, broken references, hallucinated facts, logic errors |
+| **Clarity** | Is the explanation understandable and well-structured? | Confusing structure, undefined jargon, missing context, rambling |
+| **Actionability** | Can the user act on the output immediately? | Vague suggestions, missing steps, no verification path |
+| **Conciseness** | Did it use the minimum tokens needed? | Redundancy, over-explanation, filler content, restating the question |
+
+## Scoring Scale
+```
+5 — Exceptional: no reasonable improvement possible
+4 — Good: minor nits only, no substantive gaps
+3 — Adequate: meets request but has notable weakness on ≥1 axis
+2 — Weak: clear gap affecting usability or correctness
+1 — Poor: fundamentally misses request or contains significant errors
+```
+
+## The Evidence Rule
+Every score below 5 MUST cite specific evidence. A score of 3 cannot just say "could be better" — it must say exactly what is missing or wrong. **"Show the gap, don't just name it."**
+
+## Procedure
+
+### Step 1: Collect Raw Material
+Gather:
+- Original user request
+- Final output/deliverable
+- Tool outputs verifying correctness (test results, exit codes, lint)
+- User feedback received during task (corrections, "try again")
+
+### Step 2: Score Each Axis Independently
+Rate 1-5 with mandatory evidence for scores <5.
+
+### Step 3: Generate Eval Report
+```
+SELF-EVALUATION REPORT
+======================
+Task: {brief description}
+Overall: {weighted average}/5
+
+CORRECTNESS: {score}/5
+  Evidence: {specific finding or "No issues found"}
+
+CLARITY: {score}/5
+  Evidence: {specific finding or "No issues found"}
+
+ACTIONABILITY: {score}/5
+  Evidence: {specific finding or "No issues found"}
+
+CONCISENESS: {score}/5
+  Evidence: {specific finding or "No issues found"}
+
+IMPROVEMENT INSTINCTS:
+- {trigger} → {action} (confidence: {0.3-0.9})
+```
+
+### Step 4: Feed Learning System
+If learning system is active (PR-27+), auto-generate instinct YAML from findings:
+```yaml
+---
+id: eval-{task-slug}-{axis-lowercase}
+trigger: "when {task type}"
+action: "{specific improvement}"
+confidence: 0.6
+domain: quality
+source: self-eval
+scope: project
+---
+```
+
+## Integration Points
+- `/team:verify` invokes self-eval on Layer 2 output before Layer 3 review
+- `/gsd-execute-phase` runs self-eval per subagent, aggregates in SUMMARY.md
+- High-confidence eval instincts (≥0.8) auto-update team-toolkit.md quality notes
+- Low scores (≤2) on correctness trigger automatic re-execution offer


### PR DESCRIPTION
Adds skills/agent-self-eval/SKILL.md for agent self-evaluation and commands/util/self-eval.md as the /self-eval slash command.