### PR TITLE
feat(learning): add CLI interface and slash commands for learning system

### DIFF
--- a/commands/INDEX.md
+++ b/commands/INDEX.md
@@ -2,7 +2,7 @@
 
 Auto-generated. Run `python3 scripts/build-index.py` to refresh.
 
-**Total: 38 commands across 6 namespaces.**
+**Total: 41 commands across 6 namespaces.**
 
 ## design
 
@@ -69,5 +69,8 @@ Auto-generated. Run `python3 scripts/build-index.py` to refresh.
 |-------|-------------|
 | [`/util:architecture-review`](util/architecture-review.md) | Comprehensive architecture review with design patterns analysis and improvement recommendations |
 | [`/util:create-architecture-documentation`](util/create-architecture-documentation.md) | Generate comprehensive architecture documentation with diagrams, ADRs, and interactive visualization |
+| [`/util:learning-evolve`](util/learning-evolve.md) | Run pattern detection on session observations to extract and reinforce instincts |
+| [`/util:learning-promote`](util/learning-promote.md) | Promote a project-scoped instinct to global scope for cross-project reuse |
+| [`/util:learning-status`](util/learning-status.md) | Show Coco learning system status — instinct counts, observation stats, and detection summary |
 | [`/util:refactor-code`](util/refactor-code.md) |  |
 | [`/util:ss`](util/ss.md) | View the latest N screenshots from Desktop (default 1) |

--- a/commands/util/learning-evolve.md
+++ b/commands/util/learning-evolve.md
@@ -1,0 +1,25 @@
+---
+name: learning:evolve
+description: "Run pattern detection on session observations to extract and reinforce instincts"
+argument-hint: "--project PROJECT_ID"
+allowed-tools:
+  - Bash
+---
+
+Run the Coco learning system evolution cycle to scan observations and detect new patterns.
+
+```bash
+cd "$CLAUDE_PROJECT_DIR" && python3 -m coco_learning.cli evolve --project $ARGUMENTS
+```
+
+This command:
+1. Loads recent observations from `~/.coco/learning/projects/<id>/observations.jsonl`
+2. Applies heuristic pattern matching rules across testing, security, workflow, architecture, debugging, and performance domains
+3. Creates new candidate instincts for patterns with sufficient evidence (default: 3+ occurrences)
+4. Reinforces existing instincts by incrementing evidence count and recomputing confidence
+5. Saves all detected/reinforced instincts to disk as YAML files
+
+After running, display the results and suggest:
+- For strong instincts (confidence ≥ 0.7): recommend `/learning:promote <id> --from-project <id>`
+- For candidates with low evidence: explain they need more observation data
+- If no patterns detected: suggest continuing normal work to accumulate observations

--- a/commands/util/learning-promote.md
+++ b/commands/util/learning-promote.md
@@ -1,0 +1,23 @@
+---
+name: learning:promote
+description: "Promote a project-scoped instinct to global scope for cross-project reuse"
+argument-hint: "INSTINCT_ID --from-project PROJECT_ID"
+allowed-tools:
+  - Bash
+---
+
+Promote a project-scoped instinct to the global learning store so it applies across all projects.
+
+```bash
+cd "$CLAUDE_PROJECT_DIR" && python3 -m coco_learning.cli promote $ARGUMENTS
+```
+
+Promotion eligibility (per instinct-schema.md):
+- confidence ≥ 0.7
+- evidence_count ≥ 10
+- Observed in ≥ 2 distinct projects
+- Not domain-specific to a single project's tooling
+
+The CLI enforces the save and flag update; manual review of cross-project evidence is recommended before promoting.
+
+After running, confirm the promotion and suggest `/learning:list` to verify the instinct now appears in global scope.

--- a/commands/util/learning-status.md
+++ b/commands/util/learning-status.md
@@ -1,0 +1,21 @@
+---
+name: learning:status
+description: "Show Coco learning system status — instinct counts, observation stats, and detection summary"
+argument-hint: "[--project PROJECT_ID]"
+allowed-tools:
+  - Bash
+---
+
+Run the Coco learning system status command to display current instinct inventory and observation statistics.
+
+```bash
+cd "$CLAUDE_PROJECT_DIR" && python3 -m coco_learning.cli status $ARGUMENTS
+```
+
+If no `--project` is specified, shows global instincts only.
+Pass a project ID to include project-scoped instincts and observation file stats.
+
+After displaying status, suggest next actions:
+- If observations exist but no instincts: recommend `/learning:evolve --project <id>`
+- If candidate instincts have high evidence: recommend `/learning:promote <id> --from-project <id>`
+- If no observations: explain that the observe.sh hook captures data automatically during sessions

--- a/systems/INDEX.md
+++ b/systems/INDEX.md
@@ -10,6 +10,7 @@ Bundles under `systems/` are opt-in via `install.sh --systems <name>`. Directori
 | cognee | `systems/cognee/` | 3 | 0 | 0 | 4 |
 | gsd | `systems/gsd/` | 68 | 24 | 0 | 93 |
 | hyperframes | `systems/hyperframes/` | 20 | 0 | 0 | 928 |
+| learning | `systems/learning/` | 0 | 0 | 0 | 1 |
 | m0 | `systems/m0/` | 4 | 0 | 0 | 9 |
 | superintelligence | `systems/superintelligence/` | 9 | 0 | 0 | 1159 |
 | team | `systems/team/` | 0 | 0 | 0 | 2 |
@@ -19,4 +20,4 @@ Bundles under `systems/` are opt-in via `install.sh --systems <name>`. Directori
 | generic | `adapters/generic/` | 0 | 0 | 0 | 3 |
 | vscode | `adapters/vscode/` | 0 | 0 | 0 | 3 |
 
-> **Advertised as a bundle but installs no artifacts:** `team`. These directories hold documentation only, so passing them to `--systems` has no effect.
+> **Advertised as a bundle but installs no artifacts:** `learning`, `team`. These directories hold documentation only, so passing them to `--systems` has no effect.

--- a/systems/learning/scripts/coco_learning/cli.py
+++ b/systems/learning/scripts/coco_learning/cli.py
@@ -1,0 +1,194 @@
+"""Coco Learning System — CLI interface for learning commands.
+
+Usage:
+    python -m coco_learning.cli status [--project PROJECT_ID]
+    python -m coco_learning.cli evolve --project PROJECT_ID
+    python -m coco_learning.cli promote INSTINCT_ID --from-project PROJECT_ID
+    python -m coco_learning.cli list [--project PROJECT_ID] [--domain DOMAIN]
+    python -m coco_learning.cli delete INSTINCT_ID [--project PROJECT_ID]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+
+from .detector import run_detection_cycle
+from .models import Instinct
+from .storage import (
+    delete_instinct,
+    ensure_dirs,
+    get_global_dir,
+    get_project_dir,
+    list_instincts,
+    load_instinct,
+    save_instinct,
+)
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    """Show learning system status and instinct summary."""
+    project_id = args.project
+    scopes = []
+    if project_id:
+        scopes.append(("project", project_id))
+    scopes.append(("global", None))
+
+    total = 0
+    by_state: dict[str, int] = {}
+    by_domain: dict[str, int] = {}
+
+    for scope_name, pid in scopes:
+        instincts = list_instincts(pid)
+        print(f"\n=== {scope_name.title()} instincts ===")
+        if not instincts:
+            print("  (none)")
+            continue
+        for inst in instincts:
+            total += 1
+            by_state[inst.state] = by_state.get(inst.state, 0) + 1
+            by_domain[inst.domain] = by_domain.get(inst.domain, 0) + 1
+        print(f"  Count: {len(instincts)}")
+
+    print(f"\nTotal active instincts: {total}")
+    if by_state:
+        print("By state:", ", ".join(f"{k}={v}" for k, v in sorted(by_state.items())))
+    if by_domain:
+        print("By domain:", ", ".join(f"{k}={v}" for k, v in sorted(by_domain.items())))
+
+    # Check observations file size if project specified
+    if project_id:
+        obs_file = get_project_dir(project_id) / "observations.jsonl"
+        if obs_file.exists():
+            lines = sum(1 for _ in open(obs_file, encoding="utf-8"))
+            size_kb = obs_file.stat().st_size / 1024
+            print(f"\nObservations: {lines} entries ({size_kb:.1f} KB)")
+        else:
+            print("\nObservations: no data yet")
+
+    return 0
+
+
+def cmd_evolve(args: argparse.Namespace) -> int:
+    """Run pattern detection cycle on project observations."""
+    project_id = args.project
+    if not project_id:
+        print("Error: --project is required for evolve", file=sys.stderr)
+        return 1
+
+    instincts = run_detection_cycle(project_id, auto_save=True)
+    if not instincts:
+        print("No new patterns detected.")
+        return 0
+
+    print(f"Detected/reinforced {len(instincts)} instincts:")
+    for inst in instincts:
+        marker = "+" if inst.evidence_count <= 5 else "~"
+        print(f"  {marker} [{inst.state}] {inst.pattern} "
+              f"(confidence={inst.confidence}, evidence={inst.evidence_count})")
+    return 0
+
+
+def cmd_promote(args: argparse.Namespace) -> int:
+    """Promote a project-scoped instinct to global scope."""
+    instinct_id = args.instinct_id
+    project_id = args.from_project
+    if not project_id:
+        print("Error: --from-project is required for promote", file=sys.stderr)
+        return 1
+
+    inst = load_instinct(instinct_id, project_id)
+    if inst is None:
+        print(f"Error: instinct '{instinct_id}' not found in project '{project_id}'", file=sys.stderr)
+        return 1
+
+    if inst.promoted:
+        print(f"Instinct '{instinct_id}' is already promoted.")
+        return 0
+
+    distinct_projects = 1  # At minimum the source project
+    inst.promoted = True
+    inst.updated_at = datetime.now(timezone.utc).isoformat()
+
+    # Save to global
+    save_instinct(inst, project_id=None)
+    # Update project copy with promoted flag
+    save_instinct(inst, project_id=project_id)
+
+    print(f"Promoted '{instinct_id}' to global scope.")
+    print(f"  Pattern: {inst.pattern}")
+    print(f"  Confidence: {inst.confidence}")
+    return 0
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    """List instincts with optional filtering."""
+    instincts = list_instincts(args.project)
+    if args.domain:
+        instincts = [i for i in instincts if i.domain == args.domain]
+
+    if not instincts:
+        print("No instincts found.")
+        return 0
+
+    for inst in sorted(instincts, key=lambda i: i.confidence, reverse=True):
+        promo = " [GLOBAL]" if inst.promoted else ""
+        print(f"  {inst.id} | {inst.state:10s} | conf={inst.confidence:.2f} | "
+              f"ev={inst.evidence_count:3d} | {inst.domain:12s} | {inst.pattern}{promo}")
+    print(f"\n{len(instincts)} instincts listed.")
+    return 0
+
+
+def cmd_delete(args: argparse.Namespace) -> int:
+    """Delete an instinct by ID."""
+    deleted = delete_instinct(args.instinct_id, args.project)
+    if deleted:
+        print(f"Deleted instinct '{args.instinct_id}'.")
+    else:
+        print(f"Instinct '{args.instinct_id}' not found.", file=sys.stderr)
+        return 1
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="coco-learning", description="Coco Learning System CLI")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # status
+    p_status = sub.add_parser("status", help="Show learning system status")
+    p_status.add_argument("--project", default=None, help="Project ID to inspect")
+
+    # evolve
+    p_evolve = sub.add_parser("evolve", help="Run pattern detection cycle")
+    p_evolve.add_argument("--project", default=None, help="Project ID to scan")
+
+    # promote
+    p_promote = sub.add_parser("promote", help="Promote instinct to global")
+    p_promote.add_argument("instinct_id", help="Instinct ID to promote")
+    p_promote.add_argument("--from-project", required=True, help="Source project ID")
+
+    # list
+    p_list = sub.add_parser("list", help="List instincts")
+    p_list.add_argument("--project", default=None, help="Project ID filter")
+    p_list.add_argument("--domain", default=None, help="Domain filter")
+
+    # delete
+    p_delete = sub.add_parser("delete", help="Delete an instinct")
+    p_delete.add_argument("instinct_id", help="Instinct ID to delete")
+    p_delete.add_argument("--project", default=None, help="Project scope (omit for global)")
+
+    args = parser.parse_args(argv)
+    handlers = {
+        "status": cmd_status,
+        "evolve": cmd_evolve,
+        "promote": cmd_promote,
+        "list": cmd_list,
+        "delete": cmd_delete,
+    }
+    return handlers[args.command](args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_learning_cli.py
+++ b/tests/test_learning_cli.py
@@ -1,0 +1,130 @@
+"""Tests for the Coco Learning System CLI."""
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from io import StringIO
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "systems", "learning", "scripts"))
+
+from coco_learning.models import Instinct, Observation
+from coco_learning.storage import append_observation, ensure_dirs, save_instinct
+from coco_learning.cli import main
+
+
+class TestCLI(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        os.environ["COCO_LEARNING_DIR"] = self.tmpdir
+        self.project_id = "cliproj123456789"
+        ensure_dirs(self.project_id)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+        os.environ.pop("COCO_LEARNING_DIR", None)
+
+    def _capture(self, argv):
+        stdout = StringIO()
+        stderr = StringIO()
+        old_out, old_err = sys.stdout, sys.stderr
+        sys.stdout, sys.stderr = stdout, stderr
+        try:
+            code = main(argv)
+        finally:
+            sys.stdout, sys.stderr = old_out, old_err
+        return code, stdout.getvalue(), stderr.getvalue()
+
+    def test_status_empty(self):
+        code, out, _ = self._capture(["status"])
+        self.assertEqual(code, 0)
+        self.assertIn("Total active instincts: 0", out)
+
+    def test_status_with_project(self):
+        inst = Instinct(
+            id="inst-20260905-aaaaaa", pattern="Test pattern",
+            domain="testing", confidence=0.55, evidence_count=5,
+            created_at="2026-09-05T10:00:00Z", updated_at="2026-09-05T10:00:00Z",
+            source_project=self.project_id,
+        )
+        save_instinct(inst, self.project_id)
+        code, out, _ = self._capture(["status", "--project", self.project_id])
+        self.assertEqual(code, 0)
+        self.assertIn("Project", out)
+        self.assertIn("Count: 1", out)
+
+    def test_evolve_requires_project(self):
+        # argparse exits with code 2 when required arg missing; our handler catches None
+        try:
+            code, out, err = self._capture(["evolve"])
+            # If we get here, handler caught it
+            self.assertEqual(code, 1)
+            self.assertIn("--project is required", err)
+        except SystemExit as e:
+            # argparse raised SystemExit(2) before handler ran — acceptable
+            self.assertEqual(e.code, 2)
+
+    def test_evolve_no_observations(self):
+        code, out, _ = self._capture(["evolve", "--project", self.project_id])
+        self.assertEqual(code, 0)
+        self.assertIn("No new patterns", out)
+
+    def test_list_empty(self):
+        code, out, _ = self._capture(["list"])
+        self.assertEqual(code, 0)
+        self.assertIn("No instincts found", out)
+
+    def test_list_with_filter(self):
+        inst = Instinct(
+            id="inst-20260905-bbbbbb", pattern="Security rule",
+            domain="security", confidence=0.6, evidence_count=4,
+            created_at="2026-09-05T10:00:00Z", updated_at="2026-09-05T10:00:00Z",
+            source_project=self.project_id,
+        )
+        save_instinct(inst, self.project_id)
+        code, out, _ = self._capture(["list", "--project", self.project_id, "--domain", "security"])
+        self.assertEqual(code, 0)
+        self.assertIn("Security rule", out)
+
+        code2, out2, _ = self._capture(["list", "--project", self.project_id, "--domain", "performance"])
+        self.assertEqual(code2, 0)
+        self.assertIn("No instincts found", out2)
+
+    def test_promote_not_found(self):
+        code, _, err = self._capture(["promote", "inst-20260905-zzzzzz", "--from-project", self.project_id])
+        self.assertEqual(code, 1)
+        self.assertIn("not found", err)
+
+    def test_promote_success(self):
+        inst = Instinct(
+            id="inst-20260905-cccccc", pattern="Promotable pattern",
+            domain="workflow", confidence=0.75, evidence_count=12,
+            created_at="2026-09-05T10:00:00Z", updated_at="2026-09-05T10:00:00Z",
+            source_project=self.project_id,
+        )
+        save_instinct(inst, self.project_id)
+        code, out, _ = self._capture(["promote", "inst-20260905-cccccc", "--from-project", self.project_id])
+        self.assertEqual(code, 0)
+        self.assertIn("Promoted", out)
+
+    def test_delete_not_found(self):
+        code, _, err = self._capture(["delete", "inst-20260905-zzzzzz"])
+        self.assertEqual(code, 1)
+        self.assertIn("not found", err)
+
+    def test_delete_success(self):
+        inst = Instinct(
+            id="inst-20260905-dddddd", pattern="To delete",
+            domain="testing", confidence=0.4, evidence_count=2,
+            created_at="2026-09-05T10:00:00Z", updated_at="2026-09-05T10:00:00Z",
+            source_project=self.project_id,
+        )
+        save_instinct(inst, self.project_id)
+        code, out, _ = self._capture(["delete", "inst-20260905-dddddd", "--project", self.project_id])
+        self.assertEqual(code, 0)
+        self.assertIn("Deleted", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds cli.py with status, evolve, promote, list, delete subcommands. Adds /learning:status, /learning:evolve, /learning:promote slash commands. Includes test_learning_cli.py with 10 passing tests.