### PR TITLE
feat(learning): add team feedback to instincts bridge

### DIFF
--- a/systems/INDEX.md
+++ b/systems/INDEX.md
@@ -10,6 +10,7 @@ Bundles under `systems/` are opt-in via `install.sh --systems <name>`. Directori
 | cognee | `systems/cognee/` | 3 | 0 | 0 | 4 |
 | gsd | `systems/gsd/` | 68 | 24 | 0 | 93 |
 | hyperframes | `systems/hyperframes/` | 20 | 0 | 0 | 928 |
+| learning | `systems/learning/` | 0 | 0 | 0 | 1 |
 | m0 | `systems/m0/` | 4 | 0 | 0 | 9 |
 | superintelligence | `systems/superintelligence/` | 9 | 0 | 0 | 1159 |
 | team | `systems/team/` | 0 | 0 | 0 | 2 |
@@ -19,4 +20,4 @@ Bundles under `systems/` are opt-in via `install.sh --systems <name>`. Directori
 | generic | `adapters/generic/` | 0 | 0 | 0 | 3 |
 | vscode | `adapters/vscode/` | 0 | 0 | 0 | 3 |
 
-> **Advertised as a bundle but installs no artifacts:** `team`. These directories hold documentation only, so passing them to `--systems` has no effect.
+> **Advertised as a bundle but installs no artifacts:** `learning`, `team`. These directories hold documentation only, so passing them to `--systems` has no effect.

--- a/systems/learning/scripts/coco_learning/team_bridge.py
+++ b/systems/learning/scripts/coco_learning/team_bridge.py
@@ -1,0 +1,149 @@
+"""Coco Learning System — Team feedback to instincts bridge.
+
+Converts structured team review feedback into learning observations
+and triggers pattern detection for continuous improvement.
+
+Team roles (from commands/team/roles.md) produce feedback in standardized formats.
+This module parses that feedback and feeds it into the learning pipeline.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+from typing import Optional
+
+from .models import Observation
+from .storage import append_observation, ensure_dirs
+from .detector import run_detection_cycle
+
+
+# Mapping of team role names to learning domains
+ROLE_DOMAIN_MAP: dict[str, str] = {
+    "code-reviewer": "testing",
+    "test-guardian": "testing",
+    "security-reviewer": "security",
+    "refactoring-specialist": "architecture",
+    "database-architect": "architecture",
+    "ai-engineer": "performance",
+    "typescript-pro": "workflow",
+    "ui-ux-designer": "workflow",
+    "pm-advisor": "workflow",
+    "data-specialist": "debugging",
+    "mcp-specialist": "devops",
+}
+
+# Patterns in feedback text that indicate actionable learning opportunities
+FEEDBACK_PATTERNS: list[tuple[str, str, list[str]]] = [
+    # (regex, instinct_template, tags)
+    (r"(always|never|must|should)\s+(run|execute|check|verify)\s+tests?", 
+     "Always run tests after code changes", ["testing", "safety"]),
+    (r"(security|vulnerability|injection|xss|csrf)", 
+     "Review security implications before merging", ["security", "review"]),
+    (r"(performance|slow|latency|bottleneck|optimize)", 
+     "Profile before optimizing performance-critical paths", ["performance", "optimization"]),
+    (r"(documentation|docs?|comment|readme)", 
+     "Update documentation when changing public APIs", ["documentation", "maintenance"]),
+    (r"(error handling|try.?catch|exception|graceful)", 
+     "Add comprehensive error handling at boundaries", ["debugging", "reliability"]),
+    (r"(breaking change|migration|deprecat)", 
+     "Plan migration strategy for breaking changes", ["workflow", "compatibility"]),
+    (r"(test coverage|coverage.*low|untested)", 
+     "Maintain test coverage above 80% for modified code", ["testing", "quality"]),
+    (r"(n\+1|query.*efficien|index|database.*slow)", 
+     "Check for N+1 queries when modifying data access", ["performance", "database"]),
+]
+
+
+def parse_team_feedback(
+    role: str,
+    feedback_text: str,
+    project_id: str,
+    session_id: str = "team-review",
+) -> list[Observation]:
+    """Parse team review feedback into learning observations.
+    
+    Args:
+        role: Team role name (e.g., "code-reviewer", "test-guardian")
+        feedback_text: The review feedback content
+        project_id: Target project identifier
+        session_id: Session identifier for grouping
+        
+    Returns:
+        List of Observation objects ready for storage
+    """
+    observations: list[Observation] = []
+    timestamp = datetime.now(timezone.utc).isoformat()
+    domain = ROLE_DOMAIN_MAP.get(role, "workflow")
+    
+    # Check each feedback pattern
+    for pattern_re, template, tags in FEEDBACK_PATTERNS:
+        if re.search(pattern_re, feedback_text, re.IGNORECASE):
+            obs = Observation(
+                timestamp=timestamp,
+                event="TeamFeedback",
+                session=session_id,
+                tool=f"team:{role}",
+                input_summary=template,
+                output_summary=f"domain={domain},tags={','.join(tags)}",
+                project_id=project_id,
+                project_name="",
+            )
+            observations.append(obs)
+    
+    return observations
+
+
+def ingest_team_feedback(
+    role: str,
+    feedback_text: str,
+    project_id: str,
+    session_id: str = "team-review",
+    auto_evolve: bool = True,
+) -> dict:
+    """Full pipeline: parse feedback → store observations → optionally evolve.
+    
+    Args:
+        role: Team role name
+        feedback_text: Review feedback content  
+        project_id: Target project identifier
+        session_id: Session identifier
+        auto_evolve: Whether to run pattern detection after ingestion
+        
+    Returns:
+        Dict with 'observations_stored', 'instincts_detected', 'instincts' keys
+    """
+    ensure_dirs(project_id)
+    
+    # Parse and store observations
+    observations = parse_team_feedback(role, feedback_text, project_id, session_id)
+    for obs in observations:
+        append_observation(obs)
+    
+    result = {
+        "observations_stored": len(observations),
+        "instincts_detected": 0,
+        "instincts": [],
+    }
+    
+    # Optionally run evolution cycle
+    if auto_evolve and observations:
+        instincts = run_detection_cycle(project_id, auto_save=True)
+        result["instincts_detected"] = len(instincts)
+        result["instincts"] = [
+            {
+                "id": i.id,
+                "pattern": i.pattern,
+                "confidence": i.confidence,
+                "state": i.state,
+            }
+            for i in instincts
+        ]
+    
+    return result
+
+
+def get_role_domain(role: str) -> str:
+    """Get the learning domain for a team role."""
+    return ROLE_DOMAIN_MAP.get(role, "workflow")

--- a/tests/test_learning_team_bridge.py
+++ b/tests/test_learning_team_bridge.py
@@ -1,0 +1,114 @@
+"""Tests for the Coco Learning System team feedback bridge."""
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "systems", "learning", "scripts"))
+
+from coco_learning.models import Observation
+from coco_learning.storage import ensure_dirs, list_instincts
+from coco_learning.team_bridge import (
+    parse_team_feedback,
+    ingest_team_feedback,
+    get_role_domain,
+    ROLE_DOMAIN_MAP,
+)
+
+
+class TestTeamBridge(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        os.environ["COCO_LEARNING_DIR"] = self.tmpdir
+        self.project_id = "teamproj123456789"
+        ensure_dirs(self.project_id)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+        os.environ.pop("COCO_LEARNING_DIR", None)
+
+    def test_role_domain_mapping(self):
+        self.assertEqual(get_role_domain("code-reviewer"), "testing")
+        self.assertEqual(get_role_domain("security-reviewer"), "security")
+        self.assertEqual(get_role_domain("unknown-role"), "workflow")
+
+    def test_parse_empty_feedback(self):
+        obs = parse_team_feedback("code-reviewer", "", self.project_id)
+        self.assertEqual(obs, [])
+
+    def test_parse_testing_feedback(self):
+        feedback = "You should always run tests before committing changes."
+        obs = parse_team_feedback("test-guardian", feedback, self.project_id)
+        self.assertGreater(len(obs), 0)
+        self.assertEqual(obs[0].event, "TeamFeedback")
+        self.assertEqual(obs[0].tool, "team:test-guardian")
+        self.assertIn("test", obs[0].input_summary.lower())
+
+    def test_parse_security_feedback(self):
+        feedback = "This introduces a potential XSS vulnerability in the user input handler."
+        obs = parse_team_feedback("code-reviewer", feedback, self.project_id)
+        self.assertGreater(len(obs), 0)
+        found_security = any("security" in o.output_summary.lower() for o in obs)
+        self.assertTrue(found_security)
+
+    def test_parse_performance_feedback(self):
+        feedback = "The query performance is slow due to N+1 problem in the data loader."
+        obs = parse_team_feedback("database-architect", feedback, self.project_id)
+        self.assertGreater(len(obs), 0)
+
+    def test_parse_multiple_patterns(self):
+        feedback = """
+        Critical issues:
+        1. You must run tests after every schema change
+        2. There's a security vulnerability with SQL injection
+        3. Documentation needs updating for the new API
+        """
+        obs = parse_team_feedback("code-reviewer", feedback, self.project_id)
+        self.assertGreaterEqual(len(obs), 3)
+
+    def test_ingest_stores_observations(self):
+        feedback = "Always run tests before merging PRs."
+        result = ingest_team_feedback(
+            "test-guardian", feedback, self.project_id, auto_evolve=False
+        )
+        self.assertGreater(result["observations_stored"], 0)
+        self.assertEqual(result["instincts_detected"], 0)
+
+    def test_ingest_with_auto_evolve(self):
+        # Seed enough feedback to trigger pattern detection
+        feedbacks = [
+            "You should always run tests after code changes.",
+            "Must run tests before deploying.",
+            "Always run tests when modifying database schema.",
+        ]
+        total_obs = 0
+        for fb in feedbacks:
+            result = ingest_team_feedback(
+                "test-guardian", fb, self.project_id, auto_evolve=True
+            )
+            total_obs += result["observations_stored"]
+
+        self.assertGreater(total_obs, 0)
+        # After multiple feedback entries, instincts may or may not be detected
+        # depending on min_evidence threshold — just verify no crash
+        instincts = list_instincts(self.project_id)
+        self.assertIsInstance(instincts, list)
+
+    def test_observation_project_id_set(self):
+        feedback = "Should check error handling at API boundaries."
+        obs = parse_team_feedback("code-reviewer", feedback, self.project_id)
+        for o in obs:
+            self.assertEqual(o.project_id, self.project_id)
+
+    def test_all_mapped_roles_produce_valid_tool_names(self):
+        for role in ROLE_DOMAIN_MAP:
+            obs = parse_team_feedback(role, "should run tests always", self.project_id)
+            for o in obs:
+                self.assertTrue(o.tool.startswith("team:"))
+                self.assertIn(role, o.tool)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds team_bridge.py converting structured team review feedback into learning observations. Maps 10 team roles to learning domains with 8 regex-based feedback patterns. Includes test_learning_team_bridge.py with 10 passing tests.