### PR TITLE
feat(learning): add Brain DB decisions sync for high-confidence instincts

### DIFF
--- a/systems/INDEX.md
+++ b/systems/INDEX.md
@@ -10,6 +10,7 @@ Bundles under `systems/` are opt-in via `install.sh --systems <name>`. Directori
 | cognee | `systems/cognee/` | 3 | 0 | 0 | 4 |
 | gsd | `systems/gsd/` | 68 | 24 | 0 | 93 |
 | hyperframes | `systems/hyperframes/` | 20 | 0 | 0 | 928 |
+| learning | `systems/learning/` | 0 | 0 | 0 | 1 |
 | m0 | `systems/m0/` | 4 | 0 | 0 | 9 |
 | superintelligence | `systems/superintelligence/` | 9 | 0 | 0 | 1159 |
 | team | `systems/team/` | 0 | 0 | 0 | 2 |
@@ -19,4 +20,4 @@ Bundles under `systems/` are opt-in via `install.sh --systems <name>`. Directori
 | generic | `adapters/generic/` | 0 | 0 | 0 | 3 |
 | vscode | `adapters/vscode/` | 0 | 0 | 0 | 3 |
 
-> **Advertised as a bundle but installs no artifacts:** `team`. These directories hold documentation only, so passing them to `--systems` has no effect.
+> **Advertised as a bundle but installs no artifacts:** `learning`, `team`. These directories hold documentation only, so passing them to `--systems` has no effect.

--- a/systems/learning/scripts/coco_learning/brain_sync.py
+++ b/systems/learning/scripts/coco_learning/brain_sync.py
@@ -1,0 +1,194 @@
+"""Coco Learning System — Brain DB decisions sync.
+
+Syncs high-confidence instincts to the Brain DB as decisions,
+creating a durable record of learned behaviors in the project knowledge graph.
+
+Brain DB schema reference: systems/brain/skills/brain/scripts/brain/schema.py
+Decision fields: id, title, content, status, created_at, tags
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from .models import Instinct
+from .storage import list_instincts
+
+
+# Default Brain DB path relative to project root
+DEFAULT_BRAIN_DB_REL = ".brain/brain.db"
+
+
+def _find_brain_db(project_root: Optional[str] = None) -> Optional[Path]:
+    """Locate the Brain DB SQLite file for a project."""
+    if project_root:
+        db_path = Path(project_root) / DEFAULT_BRAIN_DB_REL
+        if db_path.exists():
+            return db_path
+    
+    # Try current working directory
+    cwd_db = Path.cwd() / DEFAULT_BRAIN_DB_REL
+    if cwd_db.exists():
+        return cwd_db
+    
+    # Check environment override
+    env_db = os.environ.get("COCO_BRAIN_DB")
+    if env_db and Path(env_db).exists():
+        return Path(env_db)
+    
+    return None
+
+
+def instinct_to_decision(instinct: Instinct) -> dict:
+    """Convert an Instinct to a Brain DB decision record."""
+    return {
+        "title": f"[{instinct.domain}] {instinct.pattern}",
+        "content": (
+            f"Learned behavior from {instinct.evidence_count} observations.\n"
+            f"Confidence: {instinct.confidence:.2f} ({instinct.state})\n"
+            f"Source project: {instinct.source_project}\n"
+            f"Tags: {', '.join(instinct.tags)}"
+        ),
+        "status": "accepted" if instinct.confidence >= 0.7 else "proposed",
+        "tags": json.dumps(["coco-learning", instinct.domain] + instinct.tags),
+    }
+
+
+def sync_instincts_to_brain(
+    project_id: Optional[str] = None,
+    min_confidence: float = 0.5,
+    project_root: Optional[str] = None,
+    dry_run: bool = False,
+) -> dict:
+    """Sync eligible instincts to Brain DB as decisions.
+    
+    Args:
+        project_id: Project scope for instincts (None = global only)
+        min_confidence: Minimum confidence threshold for sync
+        project_root: Path to project root for Brain DB lookup
+        dry_run: If True, report what would be synced without writing
+        
+    Returns:
+        Dict with 'synced', 'skipped', 'errors', 'decisions' keys
+    """
+    result = {
+        "synced": 0,
+        "skipped": 0,
+        "errors": [],
+        "decisions": [],
+    }
+    
+    # Find Brain DB
+    db_path = _find_brain_db(project_root)
+    if db_path is None:
+        result["errors"].append("Brain DB not found; skipping sync")
+        return result
+    
+    # Load eligible instincts
+    instincts = list_instincts(project_id)
+    eligible = [i for i in instincts if i.confidence >= min_confidence and not i.superseded_by]
+    
+    if not eligible:
+        return result
+    
+    try:
+        conn = sqlite3.connect(str(db_path))
+        cursor = conn.cursor()
+        
+        # Ensure decisions table exists (idempotent)
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS decisions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                title TEXT NOT NULL,
+                content TEXT,
+                status TEXT DEFAULT 'proposed',
+                created_at TEXT,
+                tags TEXT
+            )
+        """)
+        
+        for instinct in eligible:
+            decision = instinct_to_decision(instinct)
+            
+            # Check if already synced (by title match)
+            cursor.execute(
+                "SELECT id FROM decisions WHERE title = ? AND tags LIKE '%coco-learning%'",
+                (decision["title"],)
+            )
+            existing = cursor.fetchone()
+            
+            if existing:
+                result["skipped"] += 1
+                continue
+            
+            if dry_run:
+                result["decisions"].append(decision)
+                result["synced"] += 1
+            else:
+                cursor.execute(
+                    "INSERT INTO decisions (title, content, status, created_at, tags) VALUES (?, ?, ?, ?, ?)",
+                    (
+                        decision["title"],
+                        decision["content"],
+                        decision["status"],
+                        datetime.now(timezone.utc).isoformat(),
+                        decision["tags"],
+                    )
+                )
+                result["synced"] += 1
+                result["decisions"].append(decision)
+        
+        conn.commit()
+        conn.close()
+        
+    except sqlite3.Error as e:
+        result["errors"].append(f"Database error: {e}")
+    
+    return result
+
+
+def get_sync_status(project_root: Optional[str] = None) -> dict:
+    """Get current sync status between instincts and Brain DB."""
+    result = {
+        "brain_db_found": False,
+        "total_decisions": 0,
+        "learning_decisions": 0,
+        "eligible_instincts": 0,
+    }
+    
+    db_path = _find_brain_db(project_root)
+    if db_path is None:
+        return result
+    
+    result["brain_db_found"] = True
+    
+    try:
+        conn = sqlite3.connect(str(db_path))
+        cursor = conn.cursor()
+        
+        # Check if decisions table exists
+        cursor.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='decisions'"
+        )
+        if not cursor.fetchone():
+            conn.close()
+            return result
+        
+        cursor.execute("SELECT COUNT(*) FROM decisions")
+        result["total_decisions"] = cursor.fetchone()[0]
+        
+        cursor.execute(
+            "SELECT COUNT(*) FROM decisions WHERE tags LIKE '%coco-learning%'"
+        )
+        result["learning_decisions"] = cursor.fetchone()[0]
+        
+        conn.close()
+    except sqlite3.Error:
+        pass
+    
+    return result

--- a/tests/test_learning_brain_sync.py
+++ b/tests/test_learning_brain_sync.py
@@ -1,0 +1,146 @@
+"""Tests for the Coco Learning System Brain DB sync."""
+
+import os
+import shutil
+import sqlite3
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "systems", "learning", "scripts"))
+
+from coco_learning.models import Instinct
+from coco_learning.storage import save_instinct, ensure_dirs
+from coco_learning.brain_sync import (
+    instinct_to_decision,
+    sync_instincts_to_brain,
+    get_sync_status,
+    _find_brain_db,
+)
+
+
+class TestBrainSync(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        os.environ["COCO_LEARNING_DIR"] = self.tmpdir
+        self.project_id = "brainproj123456789"
+        ensure_dirs(self.project_id)
+        
+        # Create a mock Brain DB
+        self.brain_dir = os.path.join(self.tmpdir, ".brain")
+        os.makedirs(self.brain_dir, exist_ok=True)
+        self.brain_db = os.path.join(self.brain_dir, "brain.db")
+        conn = sqlite3.connect(self.brain_db)
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS decisions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                title TEXT NOT NULL,
+                content TEXT,
+                status TEXT DEFAULT 'proposed',
+                created_at TEXT,
+                tags TEXT
+            )
+        """)
+        conn.commit()
+        conn.close()
+        
+        # Point brain_sync to our test DB
+        os.environ["COCO_BRAIN_DB"] = self.brain_db
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+        os.environ.pop("COCO_LEARNING_DIR", None)
+        os.environ.pop("COCO_BRAIN_DB", None)
+
+    def _make_instinct(self, confidence=0.7, domain="testing", pattern="Test pattern"):
+        inst = Instinct(
+            id=f"inst-20260905-{domain[:6]}",
+            pattern=pattern,
+            domain=domain,
+            confidence=confidence,
+            evidence_count=10,
+            created_at="2026-09-05T10:00:00Z",
+            updated_at="2026-09-05T10:00:00Z",
+            source_project=self.project_id,
+            tags=["test"],
+        )
+        save_instinct(inst, self.project_id)
+        return inst
+
+    def test_instinct_to_decision_format(self):
+        inst = self._make_instinct(confidence=0.75, domain="security", pattern="Check auth")
+        decision = instinct_to_decision(inst)
+        self.assertIn("[security]", decision["title"])
+        self.assertIn("Check auth", decision["title"])
+        self.assertEqual(decision["status"], "accepted")
+        self.assertIn("coco-learning", decision["tags"])
+
+    def test_instinct_to_decision_proposed_status(self):
+        inst = self._make_instinct(confidence=0.55)
+        decision = instinct_to_decision(inst)
+        self.assertEqual(decision["status"], "proposed")
+
+    def test_sync_no_brain_db(self):
+        os.environ.pop("COCO_BRAIN_DB", None)
+        result = sync_instincts_to_brain(project_root="/nonexistent/path")
+        self.assertGreater(len(result["errors"]), 0)
+        self.assertIn("not found", result["errors"][0])
+
+    def test_sync_no_eligible_instincts(self):
+        result = sync_instincts_to_brain(self.project_id, min_confidence=0.5)
+        self.assertEqual(result["synced"], 0)
+
+    def test_sync_creates_decisions(self):
+        self._make_instinct(confidence=0.7)
+        result = sync_instincts_to_brain(self.project_id, min_confidence=0.5)
+        self.assertEqual(result["synced"], 1)
+        self.assertEqual(len(result["decisions"]), 1)
+        
+        # Verify in DB
+        conn = sqlite3.connect(self.brain_db)
+        cursor = conn.cursor()
+        cursor.execute("SELECT COUNT(*) FROM decisions WHERE tags LIKE '%coco-learning%'")
+        count = cursor.fetchone()[0]
+        conn.close()
+        self.assertEqual(count, 1)
+
+    def test_sync_skips_already_synced(self):
+        self._make_instinct(confidence=0.7)
+        sync_instincts_to_brain(self.project_id, min_confidence=0.5)
+        result = sync_instincts_to_brain(self.project_id, min_confidence=0.5)
+        self.assertEqual(result["skipped"], 1)
+        self.assertEqual(result["synced"], 0)
+
+    def test_sync_respects_min_confidence(self):
+        self._make_instinct(confidence=0.4, pattern="Low confidence")
+        result = sync_instincts_to_brain(self.project_id, min_confidence=0.5)
+        self.assertEqual(result["synced"], 0)
+
+    def test_sync_dry_run(self):
+        self._make_instinct(confidence=0.7)
+        result = sync_instincts_to_brain(self.project_id, min_confidence=0.5, dry_run=True)
+        self.assertEqual(result["synced"], 1)
+        
+        # Verify NOT in DB
+        conn = sqlite3.connect(self.brain_db)
+        cursor = conn.cursor()
+        cursor.execute("SELECT COUNT(*) FROM decisions")
+        count = cursor.fetchone()[0]
+        conn.close()
+        self.assertEqual(count, 0)
+
+    def test_get_sync_status_no_db(self):
+        os.environ.pop("COCO_BRAIN_DB", None)
+        status = get_sync_status("/nonexistent")
+        self.assertFalse(status["brain_db_found"])
+
+    def test_get_sync_status_with_db(self):
+        self._make_instinct(confidence=0.7)
+        sync_instincts_to_brain(self.project_id, min_confidence=0.5)
+        status = get_sync_status()
+        self.assertTrue(status["brain_db_found"])
+        self.assertEqual(status["learning_decisions"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds brain_sync.py syncing eligible instincts to Brain DB as decision records with idempotency check, min_confidence filter, and dry_run support. Includes test_learning_brain_sync.py with 10 passing tests.