### PR TITLE
fix(index): generate from git-tracked files, not the working tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,12 +152,15 @@ jobs:
 
       - name: Run the standalone test suites
         run: |
-          # These three suites pass locally but were invoked nowhere in CI, so nothing stopped
+          # These suites pass locally but were invoked nowhere in CI, so nothing stopped
           # them rotting. m0-smoke.sh and run_fixtures.sh had no CI coverage at all.
           bash tests/smoke.sh
           bash skills/arch-index/scripts/run_fixtures.sh
           bash systems/m0/tests/m0-smoke.sh
-          # tests/smoke.sh writes into the tree; fail loudly rather than leaving it dirty.
+          # The generated indexes must not depend on untracked files: a stale
+          # systems/<name>/ directory used to produce a phantom bundle row and show
+          # up as unexplained INDEX drift on twenty unrelated branches.
+          bash tests/check-index-tracks-git.sh
           if ! git diff --quiet; then
             echo "A test suite left the tree dirty:"
             git diff --stat

--- a/scripts/build-index.py
+++ b/scripts/build-index.py
@@ -26,12 +26,62 @@ against `find . -name 'SKILL.md' -not -path './.git/*' | wc -l`.
 """
 
 import os
+import subprocess
 import sys
 import pathlib
 import yaml
 from collections import defaultdict
 
 ROOT = pathlib.Path(__file__).parent.parent.resolve()
+
+
+def _tracked_paths():
+    """POSIX paths of every git-tracked file, or None when this is not a checkout.
+
+    Discovery walks the filesystem, which makes the generated indexes a function of
+    whatever happens to be in the working tree. An untracked leftover directory — a
+    stale `systems/<name>/` from an experiment, say — was then indexed as if it
+    shipped, and the next person to run the "Verify INDEX is up to date" gate saw
+    drift they had not caused and could not explain. Reading git's index instead
+    makes the output a function of the commit.
+
+    Returns None outside a git checkout (a tarball or npm install), where the
+    filesystem walk is the only thing available.
+    """
+    try:
+        proc = subprocess.run(['git', '-C', str(ROOT), 'ls-files', '-z'],
+                              capture_output=True, check=True)
+    except (OSError, subprocess.CalledProcessError):
+        print('WARNING: not a git checkout — falling back to a filesystem walk, so '
+              'untracked directories will be indexed.', file=sys.stderr)
+        return None
+    return {p for p in proc.stdout.decode('utf-8', 'replace').split('\0') if p}
+
+
+TRACKED = _tracked_paths()
+TRACKED_DIRS = set()
+if TRACKED is not None:
+    for _p in TRACKED:
+        _parts = _p.split('/')
+        for _i in range(1, len(_parts)):
+            TRACKED_DIRS.add('/'.join(_parts[:_i]))
+
+
+def _rel(path):
+    return path.relative_to(ROOT).as_posix()
+
+
+def _shipped(path):
+    """True when a file should count towards an index.
+
+    Outside git this is every file, which is the old behaviour.
+    """
+    return TRACKED is None or _rel(path) in TRACKED
+
+
+def _shipped_dir(path):
+    """True when a directory holds at least one tracked file."""
+    return TRACKED is None or _rel(path) in TRACKED_DIRS
 
 # (glob, index of the parent directory that names the bundle, or None for core skills)
 # Depths differ per shape, so the bundle index is declared alongside its glob rather
@@ -96,6 +146,8 @@ def collect_skills():
     seen = set()
     for glob, bundle_at in SKILL_SOURCES:
         for p in sorted(ROOT.glob(glob)):
+            if not _shipped(p):
+                continue
             if p in seen:
                 continue
             seen.add(p)
@@ -120,6 +172,8 @@ def collect_skills():
 def collect_commands():
     commands = []
     for p in sorted(ROOT.glob('commands/*/*.md')):
+        if not _shipped(p):
+            continue
         fm = parse_frontmatter(p) or {}
         ns = p.parent.name
         cname = p.stem
@@ -141,6 +195,8 @@ def _first_prose_line(path):
 def collect_agents():
     agents = []
     for p in sorted(ROOT.glob('agents/*.md')):
+        if not _shipped(p):
+            continue
         if p.name in ('README.md', 'INDEX.md'):
             continue
         agents.append({'name': p.stem, 'desc': _first_prose_line(p),
@@ -150,6 +206,8 @@ def collect_agents():
     # parents[1]. parents[2] here yields the literal string "systems", which produced
     # 24 links to a nonexistent systems/systems/agents/ directory.
     for p in sorted(ROOT.glob('systems/*/agents/*.md')):
+        if not _shipped(p):
+            continue
         if p.name in ('README.md', 'INDEX.md'):
             continue
         agents.append({'name': p.stem, 'desc': _first_prose_line(p),
@@ -289,16 +347,18 @@ def write_systems_index(skills, agents):
         base_dir = ROOT / base
         if not base_dir.is_dir():
             continue
-        for d in sorted(p for p in base_dir.iterdir() if p.is_dir()):
-            n_cmds = (len(list(d.glob('commands/*.md')))
-                      + len(list(d.glob('commands/*/*.md'))))
+        for d in sorted(p for p in base_dir.iterdir()
+                          if p.is_dir() and _shipped_dir(p)):
+            n_cmds = len([c for c in list(d.glob('commands/*.md'))
+                          + list(d.glob('commands/*/*.md')) if _shipped(c)])
             containers.append({
                 'base': base,
                 'name': d.name,
                 'skills': skills_by_bundle.get(d.name, 0),
                 'agents': agents_by_bundle.get(d.name, 0),
                 'commands': n_cmds,
-                'files': sum(1 for f in d.rglob('*') if f.is_file() and _ships(f)),
+                'files': sum(1 for f in d.rglob('*')
+                          if f.is_file() and _ships(f) and _shipped(f)),
             })
 
     lines = ['# System Bundles Index', '',

--- a/tests/check-index-tracks-git.sh
+++ b/tests/check-index-tracks-git.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# The generated indexes must be a function of the commit, not of the working tree.
+#
+# An untracked leftover directory used to be indexed as if it shipped: a stale
+# systems/<name>/ produced a phantom bundle row in systems/INDEX.md, which showed up
+# as "INDEX files are out of date" in CI on twenty separate branches whose authors
+# had not touched the index at all. This test pins that shut.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  echo "SKIP: not a git checkout, so there is nothing to compare against."
+  exit 0
+fi
+
+# Probe directories are named so they cannot collide with a real bundle or skill.
+PROBE_SYS="systems/zz-index-probe"
+PROBE_SKILL="skills/zz-index-probe"
+
+cleanup() {
+  rm -rf "$PROBE_SYS" "$PROBE_SKILL"
+  python3 scripts/build-index.py >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+python3 scripts/build-index.py >/dev/null
+
+before_systems="$(git hash-object systems/INDEX.md)"
+before_skills="$(git hash-object skills/INDEX.md)"
+
+mkdir -p "$PROBE_SYS" "$PROBE_SKILL"
+echo "Not part of the distributable." > "$PROBE_SYS/README.md"
+cat > "$PROBE_SKILL/SKILL.md" <<'EOF'
+---
+name: zz-index-probe
+description: "Use when this test runs. A probe that must never be indexed."
+---
+# Probe
+EOF
+
+python3 scripts/build-index.py >/dev/null
+
+after_systems="$(git hash-object systems/INDEX.md)"
+after_skills="$(git hash-object skills/INDEX.md)"
+
+fail=0
+if [ "$before_systems" != "$after_systems" ]; then
+  echo "FAIL: an untracked systems/ directory changed systems/INDEX.md"
+  git diff --stat systems/INDEX.md || true
+  fail=1
+fi
+if [ "$before_skills" != "$after_skills" ]; then
+  echo "FAIL: an untracked skills/ directory changed skills/INDEX.md"
+  git diff --stat skills/INDEX.md || true
+  fail=1
+fi
+if grep -q 'zz-index-probe' systems/INDEX.md skills/INDEX.md; then
+  echo "FAIL: the probe was indexed"
+  fail=1
+fi
+
+if [ "$fail" -eq 0 ]; then
+  echo "PASS: generated indexes ignore untracked files."
+fi
+exit "$fail"


### PR DESCRIPTION
## The bug

Every generated index was a function of the **working tree**, not of the commit. `build-index.py` enumerated with `Path.glob` / `iterdir` / `rglob`, so anything sitting on disk got indexed as if it shipped.

That is the root cause of the incident that cost twenty PRs. A stale, untracked `systems/<name>/` directory produced a phantom bundle row in `systems/INDEX.md`, and every branch carrying that regenerated index then failed the *Verify INDEX is up to date* gate with drift its author had not caused and could not explain. The same mechanism let an untracked `skills/<name>/` reach `skills/INDEX.md`.

## The fix

Discovery filters through `git ls-files`. Four call sites changed: the four `SKILL_SOURCES` globs, `commands/*/*.md`, both agent globs, and the `systems/` + `adapters/` container walk (including its file count, so an untracked directory cannot pad a bundle's totals either).

- **On a clean checkout the output is byte-identical** to the previous generator — verified by hashing all ten generated files before and after.
- **Outside a git checkout** (a tarball or npm install) it falls back to the filesystem walk and prints a warning on stderr, because there is nothing else to read.

## The test

`tests/check-index-tracks-git.sh` plants an untracked `systems/` and `skills/` probe, regenerates, and fails if either appears. Against the **previous** script it fails on all three assertions; against this one it passes. It runs in the standalone-suite step, and cleans up via a trap so that step's dirty-tree check still holds.

Proven both directions before committing:

```
# previous script
FAIL: an untracked systems/ directory changed systems/INDEX.md
FAIL: an untracked skills/ directory changed skills/INDEX.md
FAIL: the probe was indexed

# this one
PASS: generated indexes ignore untracked files.
```

## Why it matters beyond the incident

The index is the repo's published inventory of its own skills and agents. A generator that indexes whatever is on disk will eventually assert that a bundle exists when it does not — and the CI gate that compares generated output cannot tell the difference between "the index is stale" and "the tree is dirty". This removes that ambiguity: the index is now a pure function of the commit.
